### PR TITLE
r9404: Prevent illegal array access

### DIFF
--- a/GameVersion.cpp
+++ b/GameVersion.cpp
@@ -55,8 +55,8 @@
 
 #endif
 										
-CHAR8		czVersionNumber[16]	= { "Build 10.10.22" };		//YY.MM.DD
+CHAR8		czVersionNumber[16]	= { "Build 22.11.04" };		//YY.MM.DD
 CHAR16		zTrackingNumber[16]	= { L"Z" };
-CHAR16		zRevisionNumber[16] = { L"Revision 9403" };
+CHAR16		zRevisionNumber[16] = { L"Revision 9404" };
 	
 // SAVE_GAME_VERSION is defined in header, change it there

--- a/Tactical/Soldier Control.cpp
+++ b/Tactical/Soldier Control.cpp
@@ -6603,12 +6603,18 @@ void SOLDIERTYPE::EVENT_SoldierGotHit( UINT16 usWeaponIndex, INT16 sDamage, INT1
 		if ( Item[usWeaponIndex].usItemClass & IC_GUN )
 		{
 			PossiblyStartEnemyTaunt( this, TAUNT_GOT_HIT_GUNFIRE, ubAttackerID );
-			PossiblyStartEnemyTaunt( MercPtrs[ubAttackerID], TAUNT_HIT_GUNFIRE, this->ubID );
+			if (ubAttackerID != NOBODY)
+			{
+				PossiblyStartEnemyTaunt( MercPtrs[ubAttackerID], TAUNT_HIT_GUNFIRE, this->ubID );
+			}
 		}
 		else
 		{
 			PossiblyStartEnemyTaunt( this, TAUNT_GOT_HIT_THROWING_KNIFE, ubAttackerID );
-			PossiblyStartEnemyTaunt( MercPtrs[ubAttackerID], TAUNT_HIT_THROWING_KNIFE, this->ubID );
+			if (ubAttackerID != NOBODY)
+			{
+				PossiblyStartEnemyTaunt(MercPtrs[ubAttackerID], TAUNT_HIT_THROWING_KNIFE, this->ubID);
+			}
 		}
 	}
 	if ( Item[usWeaponIndex].usItemClass & IC_BLADE )


### PR DESCRIPTION
Using kill all enemies cheat via ALT + o caused reading MercPtrs from index 254 when its last element is at 253