### PR TITLE
Fix MapEditor target for VS2017

### DIFF
--- a/ja2_VS2017.vcxproj
+++ b/ja2_VS2017.vcxproj
@@ -204,7 +204,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalLibraryDirectories>Multiplayer\raknet;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>Winmm.lib;RakNetLibStatic.lib;ws2_32.lib;DbgHelp.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Winmm.lib;RakNetLibStatic.lib;ws2_32.lib;DbgHelp.lib;legacy_stdio_definitions.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)\MapEditor_EN_Release.exe</OutputFile>
       <RandomizedBaseAddress>false</RandomizedBaseAddress>
       <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>


### PR DESCRIPTION
Based on what I read [here](https://stackoverflow.com/questions/31053670/unresolved-external-symbol-vsnprintf-in-dxerr-lib/34230122) and [this answer](https://stackoverflow.com/a/34230122) I added `legacy_stdio_definitions.lib` to the Additional Dependencies linker step.  

Hoping that someone could test this branch in their environment to be sure that this still builds properly in other environments.

The error I was receiving before no longer occurrs during build:
```
"J:\1dot13.git\ja2_VS2017.sln" (default target) (1) ->
"J:\1dot13.git\ja2_VS2017.vcxproj.metaproj" (default target) (8) ->
"J:\1dot13.git\ja2_VS2017.vcxproj" (default target) (20) ->
(Link target) ->
  RakNetLibStatic.lib(LogCommandParser.obj) : error LNK2019: unresolved external symbol __vsnprintf referenced in function "public: void _
cdecl LogCommandParser::WriteLog(char const *,char const *,...)" (?WriteLog@LogCommandParser@@QAAXPBD0ZZ) [J:\1dot13.git\ja2_VS2017.vcxpro
]
  RakNetLibStatic.lib(RakNetTransport.obj) : error LNK2001: unresolved external symbol __vsnprintf [J:\1dot13.git\ja2_VS2017.vcxproj]
  RakNetLibStatic.lib(TelnetTransport.obj) : error LNK2001: unresolved external symbol __vsnprintf [J:\1dot13.git\ja2_VS2017.vcxproj]
  RakNetLibStatic.lib(RakString.obj) : error LNK2001: unresolved external symbol __vsnprintf [J:\1dot13.git\ja2_VS2017.vcxproj]
  J:\1dot13.git\\lib\VS2010\JA2_EN\MapEditor\\MapEditor_EN_Release.exe : fatal error LNK1120: 1 unresolved externals [J:\1dot13.git\ja2_VS
017.vcxproj]

    859 Warning(s)
    5 Error(s)
```