### PR TITLE
Fix illegal array access

### DIFF
--- a/Laptop/IMP Skill Trait.cpp
+++ b/Laptop/IMP Skill Trait.cpp
@@ -146,7 +146,7 @@ void		HandleLastSelectedTraits( INT8 bNewTrait );
 INT8		GetLastSelectedSkill( void );
 BOOLEAN		CameBackToSpecialtiesPageButNotFinished();
 
-MOUSE_REGION	gMR_SkillTraitHelpTextRegions[IMP_SKILL_TRAITS_NEW_NUMBER_MAJOR_SKILLS];
+MOUSE_REGION	gMR_SkillTraitHelpTextRegions[IMP_SKILL_TRAITS__NUMBER_SKILLS];
 //ppp
 
 //*******************************************************************


### PR DESCRIPTION
Closes #51 
Array length was too small when using old skill trait system, which caused us to write over global variable responsible for setting imp voice set.