### PR TITLE
remove UTIL and JA2 preprocessor definitions

### DIFF
--- a/Standard Gaming Platform/Button Sound Control.cpp
+++ b/Standard Gaming Platform/Button Sound Control.cpp
@@ -9,7 +9,6 @@ void SpecifyButtonSoundScheme( INT32 iButtonID, INT8 bSoundScheme )
 	ButtonList[ iButtonID ]->ubSoundSchemeID = (UINT8)bSoundScheme;
 	if( bSoundScheme == BUTTON_SOUND_SCHEME_GENERIC )
 	{
-		#ifdef JA2
 		switch( guiCurrentScreen )
 		{
 			case MAINMENU_SCREEN:
@@ -46,7 +45,6 @@ void SpecifyButtonSoundScheme( INT32 iButtonID, INT8 bSoundScheme )
 			//DEBUG_SCREEN,
 			//SEX_SCREEN,
 		}
-		#endif
 		if( bSoundScheme == BUTTON_SOUND_SCHEME_GENERIC )
 			bSoundScheme = BUTTON_SOUND_SCHEME_NONE;
 	}
@@ -65,7 +63,6 @@ void PlayButtonSound( INT32 iButtonID, INT32 iSoundType )
 		case BUTTON_SOUND_SCHEME_GENERIC:
 			break;
 
-#ifdef JA2
 
 		case BUTTON_SOUND_SCHEME_VERYSMALLSWITCH1:
 			switch( iSoundType )
@@ -180,7 +177,6 @@ void PlayButtonSound( INT32 iButtonID, INT32 iSoundType )
 			}
 			break;
 
-#endif
 
 	}	
 

--- a/Standard Gaming Platform/Button System.cpp
+++ b/Standard Gaming Platform/Button System.cpp
@@ -18,7 +18,6 @@
 	#include "Button System.h"
 	#include "line.h"
 	#include <stdarg.h>
-	#if defined( JA2 ) || defined( UTIL )
 		#include "WordWrap.h"
 		#include "video.h"
 		#include "Button Sound Control.h"
@@ -27,32 +26,11 @@
 			#include "Render Dirty.h"
 			#include "utilities.h"
 		#endif
-	#else
-		#include "video2.h"
-	#endif
 #include <vector>
 
 
 //ATE: Added to let Wiz default creating mouse regions with no cursor, JA2 default to a cursor ( first one )
-#ifdef JA2
 	#define		MSYS_STARTING_CURSORVAL		0
-#else
-	#define		MSYS_STARTING_CURSORVAL		MSYS_NO_CURSOR
-	// The following should be moved from here
-	#define GETPIXELDEPTH( )	( gbPixelDepth )		// From "utilities.h" in JA2
-	#define		COLOR_RED						162							// From "lighting.h" in JA2
-	#define		COLOR_BLUE					203
-	#define		COLOR_YELLOW				144
-	#define		COLOR_GREEN					184
-	#define		COLOR_LTGREY				134
-	#define		COLOR_BROWN					80
-	#define		COLOR_PURPLE				160
-	#define		COLOR_ORANGE				76
-	#define		COLOR_WHITE					208
-	#define		COLOR_BLACK					72
-	// this doesn't exactly belong here either... (From "Font Control.h" in JA2)
-	#define		FONT_MCOLOR_BLACK				0
-#endif
 #define		COLOR_DKGREY				136
 
 
@@ -72,11 +50,9 @@ CHAR8		str[128];
 //an already deleted button, or it's images, etc.	It will also ensure that you don't create
 //the same button that already exists.
 //TO REMOVE ALL DEBUG FUNCTIONALITY:	simply comment out BUTTONSYSTEM_DEBUGGING definition
-#ifdef JA2
 	#ifdef _DEBUG
 	#define BUTTONSYSTEM_DEBUGGING
 	#endif
-#endif
 
 #ifdef BUTTONSYSTEM_DEBUGGING
 BOOLEAN gfIgnoreShutdownAssertions; // symbol already declared globally in mousesystem.cpp (jonathanl)
@@ -2866,9 +2842,7 @@ void QuickButtonCallbackMButn( MOUSE_REGION *reg, INT32 reason )
 
 	if( StateBefore != StateAfter )
 	{
-#ifdef JA2
 		InvalidateRegion(b->Area.RegionTopLeftX, b->Area.RegionTopLeftY, b->Area.RegionBottomRightX, b->Area.RegionBottomRightY);
-#endif
 	}
 
 	if( gfPendingButtonDeletion )
@@ -2931,11 +2905,9 @@ void RenderButtons(void)
 				b->uiFlags &= (~BUTTON_DIRTY);
 				DrawButtonFromPtr(b);
 
-#ifdef JA2
 				InvalidateRegion(b->Area.RegionTopLeftX, b->Area.RegionTopLeftY, b->Area.RegionBottomRightX, b->Area.RegionBottomRightY);
 //#else
 //				InvalidateRegion(b->Area.RegionTopLeftX, b->Area.RegionTopLeftY, b->Area.RegionBottomRightX, b->Area.RegionBottomRightY, FALSE);
-#endif
 
 			}
 		}
@@ -3208,9 +3180,7 @@ void DrawDefaultOnButton( GUI_BUTTON *b )
 		//bottom (two thick)
 		LineDraw( TRUE, b->Area.RegionTopLeftX-1, b->Area.RegionBottomRightY, b->Area.RegionBottomRightX+1, b->Area.RegionBottomRightY, 0, pDestBuf );
 		LineDraw( TRUE, b->Area.RegionTopLeftX-1, b->Area.RegionBottomRightY+1, b->Area.RegionBottomRightX+1, b->Area.RegionBottomRightY+1, 0, pDestBuf );
-		#ifdef JA2
 		InvalidateRegion( b->Area.RegionTopLeftX-1, b->Area.RegionTopLeftY-1, b->Area.RegionBottomRightX+1, b->Area.RegionBottomRightY+1 );
-		#endif
 	}
 	if( b->bDefaultStatus == DEFAULT_STATUS_DOTTEDINTERIOR || b->bDefaultStatus == DEFAULT_STATUS_WINDOWS95 )
 	{ //Draw an internal dotted rectangle.
@@ -3553,7 +3523,6 @@ void DrawTextOnButton(GUI_BUTTON *b)
 			xp++;
 			yp++;
 		}
-#ifdef JA2
 		if( b->sWrappedWidth != -1 )
 		{
 			UINT8 bJustified=0;
@@ -3600,12 +3569,6 @@ void DrawTextOnButton(GUI_BUTTON *b)
 			xp+= b->bTextXSubOffSet;
 			mprintf(xp, yp, b->string);
 		}
-#else
-		if(b->fMultiColor)
-			gprintf(xp, yp, b->string);
-		else
-			mprintf(xp, yp, b->string);
-#endif
 		// Restore the old text printing settings
 	}
 }
@@ -3674,11 +3637,6 @@ void DrawGenericButton(GUI_BUTTON *b)
 // The 3x2 size was a bit limiting. JA2 should default to the original
 // size, unchanged
 
-#ifndef JA2
-	pTrav = &(BPic->pETRLEObject[0] );
-	iBorderHeight = (INT32)pTrav->usHeight;
-	iBorderWidth = (INT32)pTrav->usWidth;
-#endif
 
 	// Compute the number of button "chunks" needed to be blitted
 	width = b->Area.RegionBottomRightX - b->Area.RegionTopLeftX;
@@ -4198,9 +4156,7 @@ void BtnGenericMouseMoveButtonCallback(GUI_BUTTON *btn,INT32 reason)
 			}
 		}
 
-		#ifdef JA2
 		InvalidateRegion(btn->Area.RegionTopLeftX, btn->Area.RegionTopLeftY, btn->Area.RegionBottomRightX, btn->Area.RegionBottomRightY);
-		#endif
 	}
 	else if( reason & MSYS_CALLBACK_REASON_GAIN_MOUSE )
 	{
@@ -4210,9 +4166,7 @@ void BtnGenericMouseMoveButtonCallback(GUI_BUTTON *btn,INT32 reason)
 			PlayButtonSound( btn->IDNum, BUTTON_SOUND_CLICKED_ON );
 		}
 
-		#ifdef JA2
 		InvalidateRegion(btn->Area.RegionTopLeftX, btn->Area.RegionTopLeftY, btn->Area.RegionBottomRightX, btn->Area.RegionBottomRightY);
-		#endif
 	}
 }
 
@@ -4231,9 +4185,7 @@ void ReleaseAnchorMode()
 			gpAnchoredButton->uiFlags |= BUTTON_CLICKED_ON;
 		else
 			gpAnchoredButton->uiFlags &= ( ~BUTTON_CLICKED_ON );
-			#ifdef JA2
 			InvalidateRegion(gpAnchoredButton->Area.RegionTopLeftX, gpAnchoredButton->Area.RegionTopLeftY, gpAnchoredButton->Area.RegionBottomRightX, gpAnchoredButton->Area.RegionBottomRightY);
-			#endif
 	}
 	gpPrevAnchoredButton = gpAnchoredButton;
 	gpAnchoredButton = NULL;
@@ -4302,9 +4254,7 @@ void HideButton( INT32 iButtonNum )
 
 	b->Area.uiFlags &= (~MSYS_REGION_ENABLED);
 	b->uiFlags |= BUTTON_DIRTY;
-	#ifdef JA2
 		InvalidateRegion(b->Area.RegionTopLeftX, b->Area.RegionTopLeftY, b->Area.RegionBottomRightX, b->Area.RegionBottomRightY);
-	#endif
 }
 
 void ShowButton( INT32 iButtonNum )
@@ -4320,9 +4270,7 @@ void ShowButton( INT32 iButtonNum )
 
 	b->Area.uiFlags |= MSYS_REGION_ENABLED;
 	b->uiFlags |= BUTTON_DIRTY;
-	#ifdef JA2
 		InvalidateRegion(b->Area.RegionTopLeftX, b->Area.RegionTopLeftY, b->Area.RegionBottomRightX, b->Area.RegionBottomRightY);
-	#endif
 }
 
 void DisableButtonHelpTextRestore( void )

--- a/Standard Gaming Platform/Button System.h
+++ b/Standard Gaming Platform/Button System.h
@@ -15,17 +15,10 @@
 
 // Moved here from Button System.c by DB 99/01/07
 // Names of the default generic button image files.
-#ifdef JA2
 #define DEFAULT_GENERIC_BUTTON_OFF			"GENBUTN.STI"
 #define DEFAULT_GENERIC_BUTTON_ON				"GENBUTN2.STI"
 #define DEFAULT_GENERIC_BUTTON_OFF_HI		"GENBUTN3.STI"
 #define DEFAULT_GENERIC_BUTTON_ON_HI		"GENBUTN4.STI"
-#else
-#define DEFAULT_GENERIC_BUTTON_OFF			"Data\\Message Box\\GENBUTN.STI"
-#define DEFAULT_GENERIC_BUTTON_ON				"Data\\Message Box\\GENBUTN2.STI"
-#define DEFAULT_GENERIC_BUTTON_OFF_HI		"Data\\Message Box\\GENBUTN3.STI"
-#define DEFAULT_GENERIC_BUTTON_ON_HI		"Data\\Message Box\\GENBUTN4.STI"
-#endif
 
 #define BUTTON_TEXT_LEFT		-1
 #define BUTTON_TEXT_CENTER	0

--- a/Standard Gaming Platform/Cursor Control.cpp
+++ b/Standard Gaming Platform/Cursor Control.cpp
@@ -1,10 +1,6 @@
 	#include "Cursor Control.h"
 
-	#if defined( JA2 ) || defined( UTIL )
 	#include "video.h"
-	#else
-	#include "video2.h"
-	#endif
 
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
@@ -311,7 +307,6 @@ void	CursorDatabaseClear(void)
 
 BOOLEAN SetCurrentCursorFromDatabase( UINT32 uiCursorIndex	)
 {
-#ifdef JA2
 
 	BOOLEAN				ReturnValue = TRUE;
 	UINT16				usSubIndex;
@@ -398,11 +393,7 @@ BOOLEAN SetCurrentCursorFromDatabase( UINT32 uiCursorIndex	)
 				}
 
 
-	#ifdef JA2
 				SetMouseCursorProperties( (INT16)(usEffWidth/2), (INT16)(usEffHeight/2), (UINT16)(usEffHeight), (UINT16)(usEffWidth ) );
-	#else
-				SetMouseCursorProperties( sCenterValY, (INT16)( sCenterValY + gsGlobalCursorYOffset ), MAX_CURSOR_HEIGHT, MAX_CURSOR_WIDTH );
-	#endif
 				DirtyCursor( );
 
 			}
@@ -545,11 +536,7 @@ BOOLEAN SetCurrentCursorFromDatabase( UINT32 uiCursorIndex	)
 				sCenterValX = pCurData->sOffsetX;
 				sCenterValY = pCurData->sOffsetY;
 
-	#ifdef JA2
 				SetMouseCursorProperties( sCenterValX, (INT16)( sCenterValY + gsGlobalCursorYOffset ), 	pCurData->usHeight, 	pCurData->usWidth );
-	#else
-				SetMouseCursorProperties( sCenterValY, (INT16)( sCenterValY + gsGlobalCursorYOffset ), MAX_CURSOR_HEIGHT, MAX_CURSOR_WIDTH );
-	#endif
 				DirtyCursor( );
 			}
 		}
@@ -575,9 +562,6 @@ BOOLEAN SetCurrentCursorFromDatabase( UINT32 uiCursorIndex	)
 	}
 
 	return ( ReturnValue );
-#else
-	return(0);
-#endif
 
 }
 

--- a/Standard Gaming Platform/Cursor Control.h
+++ b/Standard Gaming Platform/Cursor Control.h
@@ -6,11 +6,7 @@
 #include "VObject.h"
 #include "VSurface.h"
 
-#if defined( JA2 ) || defined( UTIL )
 #include "Video.h"
-#else
-#include "video2.h"
-#endif	
 
 #ifdef __cplusplus
 extern "C" {

--- a/Standard Gaming Platform/DEBUG.H
+++ b/Standard Gaming Platform/DEBUG.H
@@ -200,12 +200,8 @@ extern	void	_DebugMessage(const char *pSourceFile, unsigned uiLineNum, const cha
 #define DbgTopicRegistration(a, b, c);			((void *)0)
 #define DbgMessage(a, b, c)						((void *)0)
 
-#if defined( JA2 ) || defined( UTIL )
 #define RegisterJA2DebugTopic(a, b)				((void *)0)
 #define DebugMsg(a, b, c)						((void *)0)
-#else
-#define DebugMsg(a)								((void *)0)
-#endif
 
 //*******************************************************************************************
 #endif

--- a/Standard Gaming Platform/DEBUG.cpp
+++ b/Standard Gaming Platform/DEBUG.cpp
@@ -31,13 +31,11 @@
 	#include "debug.h"
 
 	//Kris addition
-	#ifdef JA2
 		#include "screenids.h"
 		#include "Sys Globals.h"
 		#include "jascreens.h"
 		#include "gameloop.h"
 		#include "input.h"
-	#endif
 
 	// CJC added
 	#ifndef _NO_DEBUG_TXT

--- a/Standard Gaming Platform/Font.cpp
+++ b/Standard Gaming Platform/Font.cpp
@@ -13,11 +13,7 @@
 	#include "Font.h"
 	#include "Debug.h"
 
-	#if defined( JA2 ) || defined( UTIL )
 	#include "video.h"
-	#else
-	#include "video2.h"
-	#endif
 
 	#include "himage.h"
 	#include "vobject.h"
@@ -397,9 +393,7 @@ UINT32					LoadIndex;
 	if((LoadIndex=FindFreeFont())==(-1))
 	{
 		DbgMessage(TOPIC_FONT_HANDLER, DBG_LEVEL_0, String("Out of font slots (%s)", filename));
-#ifdef JA2
 			FatalError( "Cannot init FONT file %s", filename );
-#endif
 			return(-1);
 	}
 
@@ -409,9 +403,7 @@ UINT32					LoadIndex;
 	if((FontObjs[LoadIndex]=CreateVideoObject(&vo_desc))==NULL)
 	{
 		DbgMessage(TOPIC_FONT_HANDLER, DBG_LEVEL_0, String("Error creating VOBJECT (%s)", filename));
-#ifdef JA2
 			FatalError( "Cannot init FONT file %s", filename );
-#endif
 			return(-1);
 	}
 
@@ -1237,16 +1229,9 @@ UINT8				*pDestBuf;
 	// Unlock buffer
 	UnLockVideoSurface( FontDestBuffer );
 
-#if defined ( JA2 ) || defined( UTIL )
 	InvalidateRegion(x, y,
 										x + StringPixLength(string, FontDefault),
 										y + GetFontHeight(FontDefault));
-#else
-	InvalidateRegion(x, y,
-										x + StringPixLength(string, FontDefault),
-										y + GetFontHeight(FontDefault),
-										INVAL_SRC_TRANS);
-#endif
 
 	return(0);
 }
@@ -1621,12 +1606,6 @@ FontTranslationTable *CreateEnglishTransTable(	)
 	pTable = (FontTranslationTable *)MemAlloc(sizeof(FontTranslationTable));
 	memset(pTable, 0, sizeof(FontTranslationTable) );
 
-	//#ifdef JA2
-	//	// ha ha, we have more than Wizardry now (again)
-	//	pTable->usNumberOfSymbols = 255;
-	//#else
-	//	pTable->usNumberOfSymbols = 255;
-	//#endif
 
 	pTable->usNumberOfSymbols = 255;
 

--- a/Standard Gaming Platform/Font.h
+++ b/Standard Gaming Platform/Font.h
@@ -15,7 +15,6 @@
 #define		MILITARY_SHADOW			67
 #define		NO_SHADOW						0
 
-#ifdef JA2
 
 // these are bogus! No palette is set yet!
 // font foreground color symbols
@@ -39,36 +38,6 @@
 #define		FONT_BCOLOR_ORANGE		76
 #define		FONT_BCOLOR_PURPLE		160
 
-#else
-
-// font foreground color symbols
-#define		FONT_FCOLOR_WHITE			0x0000		
-#define		FONT_FCOLOR_RED				0x0000
-#define		FONT_FCOLOR_BLUE			0x0000
-#define		FONT_FCOLOR_GREEN			0x0000
-#define		FONT_FCOLOR_YELLOW		0x0000
-#define		FONT_FCOLOR_BROWN			0x0000
-#define		FONT_FCOLOR_ORANGE		0x0000
-#define		FONT_FCOLOR_PURPLE		0x0000
-
-// font background color symbols
-#define		FONT_BCOLOR_WHITE			0x0000
-#define		FONT_BCOLOR_RED				0x0000
-#define		FONT_BCOLOR_BLUE			0x0000
-#define		FONT_BCOLOR_GREEN			0x0000
-#define		FONT_BCOLOR_YELLOW		0x0000
-#define		FONT_BCOLOR_BROWN			0x0000
-#define		FONT_BCOLOR_ORANGE		0x0000
-#define		FONT_BCOLOR_PURPLE		0x0000
-
-// font glyphs for spell targeting types
-#define		FONT_GLYPH_TARGET_POINT		0xFFF0
-#define		FONT_GLYPH_TARGET_CONE		0xFFF1
-#define		FONT_GLYPH_TARGET_SINGLE	0xFFF2
-#define		FONT_GLYPH_TARGET_GROUP		0xFFF3
-#define		FONT_GLYPH_TARGET_NONE		0xFFF4
-
-#endif
 
 
 // typedefs

--- a/Standard Gaming Platform/LibraryDataBase.cpp
+++ b/Standard Gaming Platform/LibraryDataBase.cpp
@@ -7,22 +7,11 @@
 	#include "WCheck.h"
 	#include "Debug.h"
 
-	#if defined(JA2) || defined( UTIL )
 		#include "video.h"
-	#else
-		#include "video2.h"
-	#endif
 
 //NUMBER_OF_LIBRARIES
-#ifdef JA2
 	#include	"Ja2 Libs.h"
 	#include	"GameSettings.h"
-#elif defined(UTIL)
-	LibraryInitHeader gGameLibaries[ ] = { 0 };
-#else
-// We link it as an .obj file
-//	#include "WizLibs.c"
-#endif
 
 
 
@@ -59,11 +48,7 @@ BOOLEAN InitializeFileDatabase( )
 	UINT32		uiSize;
 	BOOLEAN		fLibraryInited = FALSE;
 
-#ifdef JA2
 	GetCDLocation( );
-#else
-	gzCdDirectory[ 0 ] = '.';
-#endif
 
 	//if all the libraries exist, set them up
 	gFileDataBase.usNumberOfLibraries = NUMBER_OF_LIBRARIES;

--- a/Standard Gaming Platform/LibraryDataBase.h
+++ b/Standard Gaming Platform/LibraryDataBase.h
@@ -40,14 +40,7 @@ typedef struct
 
 
 
-#ifdef JA2
 	#include "Ja2 Libs.h"
-#elif UTIL
-	#define NUMBER_OF_LIBRARIES 0
-	typedef	FILETIME				SGP_FILETIME;
-#else	//wizardry
-	#include "WizLibs.h"
-#endif
 
 extern LibraryInitHeader gGameLibaries[];
 extern	CHAR8	gzCdDirectory[ SGPFILENAME_LEN ];

--- a/Standard Gaming Platform/MemMan.cpp
+++ b/Standard Gaming Platform/MemMan.cpp
@@ -42,7 +42,6 @@
 //
 //**************************************************************************
 
-#ifdef JA2
 #include "MessageBoxScreen.h"
 STR16 gzJA2ScreenNames[] =
 {
@@ -76,7 +75,6 @@ STR16 gzJA2ScreenNames[] =
 	L"QUEST_DEBUG_SCREEN",
 #endif
 };
-#endif
 
 #ifdef EXTREME_MEMORY_DEBUGGING
 	typedef struct MEMORY_NODE

--- a/Standard Gaming Platform/STCI.cpp
+++ b/Standard Gaming Platform/STCI.cpp
@@ -147,12 +147,7 @@ BOOLEAN STCILoadRGB( HIMAGE hImage, UINT16 fContents, HWFILE hFile, STCIHeader *
 			}
 		}
 	}
-#ifdef JA2
 	return( TRUE );
-#else
-// Anything else is an ERROR! --DB
-	return(FALSE);
-#endif
 }
 
 

--- a/Standard Gaming Platform/Types.h
+++ b/Standard Gaming Platform/Types.h
@@ -4,7 +4,6 @@
 #ifndef _SIRTECH_TYPES_
 #define _SIRTECH_TYPES_
 
-#ifdef	JA2
 	#ifdef	RELEASE_WITH_DEBUG_INFO
 
 		//For JA2 Release with debug info build, disable these warnigs messages
@@ -13,7 +12,6 @@
 	#endif
 
 
-#endif 
 
 
 // build defines header....
@@ -31,16 +29,11 @@
 
 // HEY WIZARDRY DUDES, JA2 ISN'T THE ONLY PROGRAM WE COMPILE! :-)
 
-#if defined( JA2 ) || defined( UTILS )
 typedef unsigned int	UINT32;
 typedef signed __int64		 INT64;		// WANNE - BMP: Used for Big Maps
 typedef signed int	 INT32;
 typedef unsigned __int64	UINT64;
 //typedef unsigned long long	UINT128;  //Madd:  Doing away with this redundant type
-#else
-typedef unsigned int	UINT32;
-typedef int					INT32;
-#endif
 
 // integers
 typedef unsigned char	UINT8;

--- a/Standard Gaming Platform/english.h
+++ b/Standard Gaming Platform/english.h
@@ -71,12 +71,7 @@
 #define INSERT				245
 #define DEL				 246
 
-#ifndef JA2
-// Stupid definition causes problems with headers that use the keyword END -- DB
-	#define KEY_END			247
-#else
 	#define END								247
-#endif
 
 #define DNARROW			 248
 #define PGDN				249

--- a/Standard Gaming Platform/himage.cpp
+++ b/Standard Gaming Platform/himage.cpp
@@ -201,10 +201,8 @@ HIMAGE CreateImage( SGPFILENAME ImageFile, UINT16 fContents, ImageFileType::Test
 	if ( !FileExists( ImageFile ) )
 	{
 		//If in debig, make fatal!
-#ifdef JA2
 #ifdef _DEBUG
 		//FatalError( "Resource file %s does not exist.", ImageFile );
-#endif
 #endif
 		DbgMessage( TOPIC_HIMAGE, DBG_LEVEL_2, String("Resource file %s does not exist.", ImageFile) );
 
@@ -216,10 +214,8 @@ HIMAGE CreateImage( SGPFILENAME ImageFile, UINT16 fContents, ImageFileType::Test
 	if ( iFileLoader == UNKNOWN_FILE_READER )
 	{
 		//If in debug, make fatal!
-#ifdef JA2
 #ifdef _DEBUG
 		//FatalError( "Resource file %s does not exist.", ImageFile );
-#endif
 #endif
 		DbgMessage( TOPIC_HIMAGE, DBG_LEVEL_2, String("Resource file %s does not exist.", ImageFile) );
 

--- a/Standard Gaming Platform/impTGA.cpp
+++ b/Standard Gaming Platform/impTGA.cpp
@@ -23,11 +23,7 @@
 	#include "himage.h"
 	#include "string.h"
 	#include "debug.h"
-	#if defined( JA2 ) || defined( UTIL )
 		#include "video.h"
-	#else
-		#include "video2.h"
-	#endif
 	#include "impTGA.h"
 
 //**************************************************************************

--- a/Standard Gaming Platform/input.cpp
+++ b/Standard Gaming Platform/input.cpp
@@ -15,11 +15,7 @@
 	#include "input.h"
 	#include "memman.h"
 	#include "english.h"
-	#if defined( JA2 ) || defined( UTIL )
 		#include "video.h"
-	#else
-		#include "video2.h"
-	#endif
 	#include "local.h"
 
 
@@ -30,12 +26,6 @@ extern UINT16 gsKeyTranslationTable[1024];
 
 extern BOOLEAN gfApplicationActive;
 
-#ifndef JA2
-
-#undef GetCursorPos
-#define GetCursorPos SGPMouseGetPos
-
-#endif
 
 // The gfKeyState table is used to track which of the keys is up or down at any one time. This is used while polling
 // the interface.
@@ -1095,11 +1085,9 @@ void KeyUp(UINT32 usParam, UINT32 uiParam)
 				{
 					// DB this used to be keyed to SCRL_LOCK
 					// which I believe Luis gave the wrong value
-//#ifndef JA2
 					if (_KeyDown(CTRL))
 						VideoCaptureToggle();
 					else
-//#endif
 						PrintScreen();
 				}
 				else
@@ -1388,12 +1376,7 @@ void	RedirectToString(UINT16 usInputCharacter)
 			gpCurrentStringDescriptor->usStringOffset = 0 ;
 			gpCurrentStringDescriptor->usLastCharacter = usInputCharacter;
 			break;
-#ifndef JA2
-		// Stupid definition causes problems with headers that use the keyword END -- DB
-		case KEY_END
-#else
 		case END
-#endif
 		: // Go to the end of the input string
 			gpCurrentStringDescriptor->usStringOffset = gpCurrentStringDescriptor->usCurrentStringLength;
 			gpCurrentStringDescriptor->usLastCharacter = usInputCharacter;

--- a/Standard Gaming Platform/mousesystem.cpp
+++ b/Standard Gaming Platform/mousesystem.cpp
@@ -19,13 +19,8 @@
 	#include "input.h"
 	#include "memman.h"
 	#include "line.h"
-	#if (defined( JA2 ) || defined( UTIL ))
 		#include "video.h"
 		#define BASE_REGION_FLAGS		(MSYS_REGION_ENABLED | MSYS_SET_CURSOR)
-	#else
-		#include "video2.h"
-		#define BASE_REGION_FLAGS		MSYS_REGION_ENABLED				// Wiz doesn't ever want MSYS_SET_CURSOR to be on...
-	#endif
 	#ifdef _JA2_RENDER_DIRTY
 		#include "render dirty.h"
 		#include "Font Control.h"
@@ -117,13 +112,11 @@ BOOLEAN					gfRefreshUpdate = FALSE;
 //an already deleted region.	It will also ensure that you don't create an identical region
 //that already exists.
 //TO REMOVE ALL DEBUG FUNCTIONALITY:	simply comment out MOUSESYSTEM_DEBUGGING definition
-#ifdef JA2
 	#ifdef _DEBUG
 	#ifndef BOUNDS_CHECKER
 	#define MOUSESYSTEM_DEBUGGING
 	#endif
 	#endif
-#endif
 
 #ifdef MOUSESYSTEM_DEBUGGING
 extern BOOLEAN gfIgnoreShutdownAssertions;
@@ -283,9 +276,7 @@ void MSYS_SGP_Mouse_Handler_Hook(UINT16 Type,UINT16 Xcoord, UINT16 Ycoord, BOOLE
 				//you release inside of the button, the action is selected -- but later in the code.
 				//NOTE:	It has to be here, because the mouse can be released anywhere regardless of
 				//regions, buttons, etc.
-				#ifdef JA2
 					ReleaseAnchorMode();
-				#endif
 			}
 			else if(Type == RIGHT_BUTTON_DOWN)
 			{
@@ -708,17 +699,12 @@ void MSYS_UpdateMouseRegion(void)
 				MSYS_PrevRegion->uiFlags &= (~MSYS_GOT_BACKGROUND);
 				MSYS_PrevRegion->uiFlags &= (~MSYS_FASTHELP_RESET);
 
-				#ifndef UTIL 
 					// dirty buttons, need a re-render
 //DEF: Nov 30 98
 //				PausedMarkButtonsDirty( );
-				#endif
 
 				//if( region->uiFlags & MSYS_REGION_ENABLED )
 				//	region->uiFlags |= BUTTON_DIRTY;
-#ifndef JA2			
-							VideoRemoveToolTip();
-#endif
 			}
 
 			if (MSYS_CurrRegion)
@@ -751,9 +737,6 @@ void MSYS_UpdateMouseRegion(void)
 					MSYS_CurrRegion->uiFlags &= (~MSYS_GOT_BACKGROUND);
 					MSYS_CurrRegion->uiFlags |= MSYS_FASTHELP_RESET;
 
-#ifndef JA2			
-							VideoRemoveToolTip();
-#endif
 
 					//if( b->uiFlags & BUTTON_ENABLED )
 					//	b->uiFlags |= BUTTON_DIRTY;
@@ -882,9 +865,6 @@ void MSYS_UpdateMouseRegion(void)
 
 							//if( b->uiFlags & BUTTON_ENABLED )
 							//	b->uiFlags |= BUTTON_DIRTY;
-#ifndef JA2
-							VideoRemoveToolTip();
-#endif
 						}
 
 						//Kris: Nov 31, 1999 -- Added support for double click events.
@@ -1109,10 +1089,6 @@ void MSYS_RemoveRegion(MOUSE_REGION *region)
 	// Get rid of the FastHelp text (if applicable)
 	if( region->FastHelpText )
 	{
-#ifndef JA2
-		if(region->uiFlags & MSYS_FASTHELP)
-			VideoRemoveToolTip();
-#endif
 		MemFree( region->FastHelpText );
 	}
 	region->FastHelpText = NULL;
@@ -1369,10 +1345,8 @@ void SetRegionFastHelpText( MOUSE_REGION *region, const STR16 szText )
 	// ATE: We could be replacing already existing, active text
 	// so let's remove the region so it be rebuilt...
 
-	#ifdef JA2
 	if ( guiCurrentScreen != MAP_SCREEN )
 	{
-	#endif
 
 	#ifdef _JA2_RENDER_DIRTY
 	if( region->uiFlags & MSYS_GOT_BACKGROUND )
@@ -1382,9 +1356,7 @@ void SetRegionFastHelpText( MOUSE_REGION *region, const STR16 szText )
 	region->uiFlags &= (~MSYS_GOT_BACKGROUND);
 	region->uiFlags &= (~MSYS_FASTHELP_RESET);
 
-	#ifdef JA2
 	}
-	#endif
 
 	//region->FastHelpTimer = gsFastHelpDelay;
 }

--- a/Standard Gaming Platform/mousesystem.h
+++ b/Standard Gaming Platform/mousesystem.h
@@ -27,9 +27,7 @@
 //
 // *****************************************************************************
 
-#ifdef JA2
 #define _JA2_RENDER_DIRTY		// Undef this if not using the JA2 Dirty Rectangle System.
-#endif
 
 typedef void (*MOUSE_CALLBACK)(struct _MOUSE_REGION *,INT32);	// Define MOUSE_CALLBACK type as pointer to void 
 typedef void (*MOUSE_HELPTEXT_DONE_CALLBACK)( ); // the help is done callback

--- a/Standard Gaming Platform/sgp.cpp
+++ b/Standard Gaming Platform/sgp.cpp
@@ -15,13 +15,8 @@
 	#include "Random.h"
 	#include "gameloop.h"
 	#include "soundman.h"
-	#ifdef JA2
 		#include "JA2 Splash.h"
 		#include "Timer Control.h"
-	#endif
-	#if !defined( JA2 ) && !defined( UTIL )
-		#include "GameData.h"				// for MoveTimer() [Wizardry specific]
-	#endif
 	#include "LibraryDataBase.h"
 	#include "utilities.h"
 
@@ -56,10 +51,8 @@
 #include "connect.h"
 #include "english.h"
 
-#ifdef JA2
 	#include "BuildDefines.h"
 	#include "Intro.h"
-#endif
 
 #ifndef WIN32_LEAN_AND_MEAN
 	#define WIN32_LEAN_AND_MEAN
@@ -125,11 +118,9 @@ void SHOWEXCEPTION(vfs::Exception& ex)
 
 
 extern UINT32		MemDebugCounter;
-#ifdef JA2
 	extern BOOLEAN	gfPauseDueToPlayerGamePause;
 	extern int		iScreenMode;
 	extern BOOL		bScreenModeCmdLine;
-#endif
 
 extern	BOOLEAN		CheckIfGameCdromIsInCDromDrive();
 extern	void		QueueEvent(UINT16 ubInputEvent, UINT32 usParam, UINT32 uiParam);
@@ -155,17 +146,6 @@ int PASCAL HandledWinMain(HINSTANCE hInstance,	HINSTANCE hPrevInstance, LPSTR pC
 Console g_Console("", "", "Lua Console", "no");
 #endif
 
-#if !defined(JA2) && !defined(UTILS)
-void				ProcessCommandLine(CHAR8 *pCommandLine);
-BOOLEAN				RunSetup(void);
-
-// Should the game immediately load the quick save at startup?
-BOOLEAN				gfLoadAtStartup=FALSE;
-BOOLEAN				gfUsingBoundsChecker=FALSE;
-CHAR8				*gzStringDataOverride=NULL;
-BOOLEAN				gfCapturingVideo = FALSE;
-
-#endif
 
 #ifdef USE_VFS
 static void PopulateSectionFromCommandLine(vfs::PropertyContainer &oProps, vfs::String const& sSection);
@@ -174,9 +154,7 @@ static void PopulateSectionFromCommandLine(vfs::PropertyContainer &oProps, vfs::
 HINSTANCE			ghInstance;
 
 
-#ifdef JA2
 	void ProcessJa2CommandLineBeforeInitialization(CHAR8 *pCommandLine);
-#endif
 
 // Global Variable Declarations
 RECT				rcWindow;
@@ -259,7 +237,6 @@ INT32 FAR PASCAL WindowProcedure(HWND hWindow, UINT16 Message, WPARAM wParam, LP
 //				break;
 //			}
 */		
-#ifdef JA2
 	case WM_MOVE:
 		// if( 1==iScreenMode )
 		{
@@ -298,160 +275,6 @@ INT32 FAR PASCAL WindowProcedure(HWND hWindow, UINT16 Message, WPARAM wParam, LP
 			mmi->ptMinTrackSize = mmi->ptMaxSize;
 			break;
 		}
-#else
-	case WM_MOUSEMOVE:
-		break;
-
-	case WM_SIZING:
-		{
-			LPRECT		lpWindow;
-			INT32		iWidth, iHeight, iX, iY;
-			BOOLEAN		fWidthByHeight=FALSE, fHoldRight=FALSE;
-
-			lpWindow	= (LPRECT) lParam;
-
-			iWidth		= lpWindow->right-lpWindow->left;
-			iHeight		= lpWindow->bottom-lpWindow->top;
-			iX			= (lpWindow->left + lpWindow->right)/2;
-			iY			= (lpWindow->top + lpWindow->bottom)/2;
-
-			switch(wParam)
-			{
-				case WMSZ_BOTTOMLEFT:
-					fHoldRight=TRUE;
-				case WMSZ_BOTTOM:
-				case WMSZ_BOTTOMRIGHT:
-					if(iHeight < SCREEN_HEIGHT)
-					{
-						lpWindow->bottom=lpWindow->top+SCREEN_HEIGHT;
-						iHeight=SCREEN_HEIGHT;
-					}
-					fWidthByHeight=TRUE;
-				break;
-
-				case WMSZ_TOPLEFT:
-					fHoldRight=TRUE;
-				case WMSZ_TOP:
-				case WMSZ_TOPRIGHT:
-					if(iHeight < SCREEN_HEIGHT)
-					{
-						lpWindow->top=lpWindow->bottom-SCREEN_HEIGHT;
-						iHeight=SCREEN_HEIGHT;
-					}
-					fWidthByHeight=TRUE;
-					break;
-
-				case WMSZ_LEFT:
-					if(iWidth < SCREEN_WIDTH)
-					{
-						lpWindow->left=lpWindow->right-SCREEN_WIDTH;
-						iWidth = SCREEN_WIDTH;
-					}
-					break;
-
-				case WMSZ_RIGHT:
-					if(iWidth < SCREEN_WIDTH)
-					{
-						lpWindow->right=lpWindow->left+SCREEN_WIDTH;
-						iWidth = SCREEN_WIDTH;
-					}
-			}
-
-			// Calculate width as a factor of height
-			if(fWidthByHeight)
-			{
-				iWidth = iHeight * SCREEN_WIDTH / SCREEN_HEIGHT;
-//				lpWindow->left = iX - iWidth/2;
-//				lpWindow->right = iX + iWidth / 2;
-				if(fHoldRight)
-					lpWindow->left = lpWindow->right - iWidth;
-				else
-					lpWindow->right = lpWindow->left + iWidth;
-			}
-			else // Calculate height as a factor of width
-			{
-				iHeight = iWidth * SCREEN_HEIGHT / SCREEN_WIDTH;
-//				lpWindow->top = iY - iHeight/2;
-//				lpWindow->bottom = iY + iHeight/2;
-				lpWindow->bottom = lpWindow->top + iHeight;
-			}
-	
-/*
-			switch(wParam)
-			{
-				case WMSZ_BOTTOM:
-				case WMSZ_BOTTOMLEFT:
-				case WMSZ_BOTTOMRIGHT:
-					if(iHeight < SCREEN_HEIGHT)
-					{
-						lpWindow->bottom=lpWindow->top+SCREEN_HEIGHT;
-					}
-			}
-
-			switch(wParam)
-			{
-				case WMSZ_TOP:
-				case WMSZ_TOPLEFT:
-				case WMSZ_TOPRIGHT:
-					if(iHeight < SCREEN_HEIGHT)
-					{
-						lpWindow->top=lpWindow->bottom-SCREEN_HEIGHT;
-					}
-			}
-
-			switch(wParam)
-			{
-				case WMSZ_BOTTOMLEFT:
-				case WMSZ_LEFT:
-				case WMSZ_TOPLEFT:
-					if(iWidth < SCREEN_WIDTH)
-					{
-						lpWindow->left=lpWindow->right-SCREEN_WIDTH;
-					}
-			}
-
-			switch(wParam)
-			{
-				case WMSZ_BOTTOMRIGHT:
-				case WMSZ_RIGHT:
-				case WMSZ_TOPRIGHT:
-					if(iWidth < SCREEN_WIDTH)
-					{
-						lpWindow->right=lpWindow->left+SCREEN_WIDTH;
-					}
-			}
-*/
-		}
-		break;
-
-	case WM_SIZE:
-		{
-			UINT16 nWidth = LOWORD(lParam);	// width of client area 
-			UINT16 nHeight = HIWORD(lParam); // height of client area 
-
-			if(nWidth && nHeight)
-			{
-				switch(wParam)
-				{
-					case SIZE_MAXIMIZED:
-						VideoFullScreen(TRUE);
-						break;
-
-					case SIZE_RESTORED:
-						VideoResizeWindow();
-						break;
-				}
-			}
-		}
-		break;
-
-	case WM_MOVE:
-		{
-			INT32 xPos = (INT32)LOWORD(lParam);	// horizontal position
-			INT32 yPos = (INT32)HIWORD(lParam);	// vertical position
-		}
-		break;
-#endif
 	case WM_SETCURSOR:
 		SetCursor( NULL);
 		return TRUE;
@@ -472,7 +295,6 @@ INT32 FAR PASCAL WindowProcedure(HWND hWindow, UINT16 Message, WPARAM wParam, LP
 		case TRUE: // We are restarting DirectDraw
 			if (fRestore == TRUE)
 			{
-#ifdef JA2
 				RestoreVideoManager();
 				RestoreVideoSurfaces();	// Restore any video surfaces
 
@@ -481,39 +303,18 @@ INT32 FAR PASCAL WindowProcedure(HWND hWindow, UINT16 Message, WPARAM wParam, LP
 				{
 					PauseTime( FALSE );
 				}
-#else
-				if(!VideoInspectorIsEnabled())
-				{
-					RestoreVideoManager();
-					RestoreVideoSurfaces();	// Restore any video surfaces
-				}
-
-				MoveTimer(TIMER_RESUME);
-#endif
 				gfApplicationActive = TRUE;
 			}
 			break;
 		case FALSE: // We are suspending direct draw
 			if (iScreenMode == 0)
 			{
-#ifdef JA2
 				// pause the JA2 Global clock
 				//PauseTime( TRUE );
 				SuspendVideoManager();
-#else
-#ifndef UTIL 
-				if(!VideoInspectorIsEnabled())
-				{
-					SuspendVideoManager();
-				}
-#endif
-#endif
 				// suspend movement timer, to prevent timer crash if delay becomes long
 				// * it doesn't matter whether the 3-D engine is actually running or not, or if it's even been initialized
 				// * restore is automatic, no need to do anything on reactivation
-#if !defined( JA2 ) && !defined( UTIL )
-				MoveTimer(TIMER_SUSPEND);
-#endif
 				// gfApplicationActive = FALSE;
 				fRestore = TRUE;
 			}
@@ -535,36 +336,18 @@ INT32 FAR PASCAL WindowProcedure(HWND hWindow, UINT16 Message, WPARAM wParam, LP
 	case WM_SETFOCUS:
 		//if (iScreenMode == 0)
 		{
-#if !defined( JA2 ) && !defined( UTIL )
-			if(!VideoInspectorIsEnabled())
-			{
-				RestoreVideoManager();
-			}
-			gfApplicationActive=TRUE;
-//			RestrictMouseToXYXY(0, 0, SCREEN_WIDTH, SCREEN_HEIGHT);
-#else
 			RestoreCursorClipRect( );
-#endif
 		}
 		break;
 
 	case WM_KILLFOCUS:
 		if (iScreenMode == 0)
 		{
-#if !defined( JA2 ) && !defined( UTIL )
-			if(!VideoInspectorIsEnabled())
-			{
-				SuspendVideoManager();
-			}
-			gfApplicationActive=FALSE;
-			FreeMouseCursor( FALSE );
-#endif
 			// Set a flag to restore surfaces once a WM_ACTIVEATEAPP is received
 			fRestore = TRUE;
 		}
 		break;
 
-#if defined( JA2 )
 	case	WM_DEVICECHANGE:
 		{
 			//DEV_BROADCAST_HDR	*pHeader = (DEV_BROADCAST_HDR	*)lParam;
@@ -583,7 +366,6 @@ INT32 FAR PASCAL WindowProcedure(HWND hWindow, UINT16 Message, WPARAM wParam, LP
 			//}
 		}
 		break;
-#endif
 
 	case WM_SYSKEYUP:
 	case WM_KEYUP:
@@ -658,9 +440,6 @@ BOOLEAN InitializeStandardGamingPlatform(HINSTANCE hInstance, int sCommandShow)
 	InitializeRegistryKeys( "Wizardry8", "Wizardry8key" );
 
 	// For rendering DLLs etc.
-#ifndef JA2
-	AddSubdirectoryToPath("DLL");
-#endif
 
 	// Second, read in settings
 	GetRuntimeSettings( );
@@ -823,9 +602,7 @@ BOOLEAN InitializeStandardGamingPlatform(HINSTANCE hInstance, int sCommandShow)
 		Loc::ImportStrings();
 	}
 
-//#ifdef JA2
 	InitJA2SplashScreen();
-//#endif
 
 	// Make sure we start up our local clock (in milliseconds)
 	// We don't need to check for a return value here since so far its always TRUE
@@ -851,14 +628,12 @@ BOOLEAN InitializeStandardGamingPlatform(HINSTANCE hInstance, int sCommandShow)
 
 	FastDebugMsg("Initializing Sound Manager");
 	// Initialize the Sound Manager (DirectSound)
-#ifndef UTIL
 	if (InitializeSoundManager() == FALSE)
 	{
 		// We were unable to initialize the sound manager
 		FastDebugMsg("FAILED : Initializing Sound Manager");
 		return FALSE;
 	}
-#endif
 
 	FastDebugMsg("Initializing Game Manager");
 	// Initialize the Game
@@ -899,22 +674,6 @@ void CreateStandardGamingPlatform(HWND hWindow)
 
 void ShutdownStandardGamingPlatform(void)
 {
-#ifndef JA2
-	static BOOLEAN Reenter = FALSE;
-
-	//
-	// Prevent multiple reentry into this function
-	//
-
-	if (Reenter == FALSE)
-	{
-		Reenter = TRUE;
-	}
-	else
-	{
-		return;
-	}
-#endif
 
 	//
 	// Shut down the different components of the SGP
@@ -933,9 +692,7 @@ void ShutdownStandardGamingPlatform(void)
 	ShutdownButtonSystem();
 	MSYS_Shutdown();
 
-#ifndef UTIL
 	ShutdownSoundManager();
-#endif
 
 	DestroyEnglishTransTable( );	// has to go before ShutdownFontManager()
 	ShutdownFontManager();
@@ -1155,29 +912,17 @@ int PASCAL HandledWinMain(HINSTANCE hInstance,	HINSTANCE hPrevInstance, LPSTR pC
 	ghInstance = hInstance;
 
 	// Copy commandline!
-#ifdef JA2
 	strncpy( gzCommandLine, pCommandLine, 100);
 	gzCommandLine[99]='\0';
 
 	//Process the command line BEFORE initialization
 	ProcessJa2CommandLineBeforeInitialization( pCommandLine );
-#else
-	ProcessCommandLine(pCommandLine);
-#endif
 
-#ifdef JA2
 	// Handle Check for CD
 	if ( !HandleJA2CDCheck( ) )
 	{
 		return( 0 );
 	}
-#else
-
-	if(!RunSetup())
-	{
-		return(0);
-	}
-#endif
 
 //	ShowCursor(FALSE);
 
@@ -1212,7 +957,6 @@ int PASCAL HandledWinMain(HINSTANCE hInstance,	HINSTANCE hPrevInstance, LPSTR pC
 	}
 #endif
 
-#ifdef JA2
 #	ifdef ENGLISH
 	try
 	{
@@ -1220,7 +964,6 @@ int PASCAL HandledWinMain(HINSTANCE hInstance,	HINSTANCE hPrevInstance, LPSTR pC
 	}
 	HANDLE_FATAL_ERROR;
 #	endif
-#endif
 
 	gfApplicationActive = TRUE;
 	gfProgramIsRunning = TRUE;
@@ -1326,19 +1069,6 @@ void SGPExit(void)
 	gfProgramIsRunning = FALSE;
 
 // Wizardry only
-#if !defined( JA2 ) && !defined( UTIL )
-	if (gfGameInitialized)
-	{
-		// ARM: if in DEBUG mode & we've ShutdownWithErrorBox, don't unload screens and release data structs to permit easier debugging
-#ifdef _DEBUG
-		if (gfIgnoreMessages)
-		{
-			fUnloadScreens = FALSE;
-		}
-#endif
-		GameloopExit(fUnloadScreens);
-	}
-#endif
 
 	ShutdownStandardGamingPlatform();
 //	ShowCursor(TRUE);
@@ -1347,9 +1077,6 @@ void SGPExit(void)
 		MessageBox(NULL, gzErrorMsg, "Error", MB_OK | MB_ICONERROR	);
 	}
 
-#ifndef JA2
-	VideoDumpMemoryLeaks();
-#endif
 
 }
 
@@ -1722,81 +1449,6 @@ void ShutdownWithErrorBox(CHAR8 *pcMessage)
 	exit(0);
 }
 
-#if !defined(JA2) && !defined(UTILS)
-
-void ProcessCommandLine(CHAR8 *pCommandLine)
-{
-	CHAR8 cSeparators[] = "\t =";
-	CHAR8 *pCopy=NULL, *pToken;
-
-	pCopy = (CHAR8 *)MemAlloc(strlen(pCommandLine) + 1);
-
-	Assert(pCopy);
-	if(!pCopy)
-	{
-		return;
-	}
-	memcpy(pCopy, pCommandLine, strlen(pCommandLine)+1);
-
-	pToken=strtok(pCopy, cSeparators);
-	while(pToken)
-	{
-		if(!_strnicmp(pToken, "/NOSOUND", 8))
-		{
-			SoundEnableSound(FALSE);
-		}
-		else if(!_strnicmp(pToken, "/INSPECTOR", 10))
-		{
-			VideoInspectorEnable();
-		}
-		else if(!_strnicmp(pToken, "/VIDEOCFG", 9))
-		{
-			pToken=strtok(NULL, cSeparators);
-			VideoSetConfigFile(pToken);
-		}
-		else if(!_strnicmp(pToken, "/LOAD", 5))
-		{
-			gfLoadAtStartup=TRUE;
-		}
-		else if(!_strnicmp(pToken, "/WINDOW", 7))
-		{
-			VideoFullScreen(FALSE);
-		}
-		else if(!_strnicmp(pToken, "/BC", 7))
-		{
-			gfUsingBoundsChecker = TRUE;
-		}
-		else if(!_strnicmp(pToken, "/CAPTURE", 7))
-		{
-			gfCapturingVideo = TRUE;
-		}
-		else if(!_strnicmp(pToken, "/NOOCT", 6))
-		{
-			NoOct();
-		}
-		else if(!_strnicmp(pToken, "/STRINGDATA", 11))
-		{
-			pToken=strtok(NULL, cSeparators);
-			gzStringDataOverride = (CHAR8 *)MemAlloc(strlen(pToken) + 1);
-			strcpy(gzStringDataOverride, pToken);
-		}
-
-		pToken=strtok(NULL, cSeparators);
-	}
-
-	MemFree(pCopy);
-}
-
-BOOLEAN RunSetup(void)
-{
-	if(!FileExists(VideoGetConfigFile()))
-	{
-		_spawnl(_P_WAIT, "3DSetup.EXE", "3DSetup.EXE", VideoGetConfigFile(), NULL);
-	}
-	return(FileExists(VideoGetConfigFile()));
-}
-
-#endif
 
 
 

--- a/Standard Gaming Platform/sgp.h
+++ b/Standard Gaming Platform/sgp.h
@@ -6,26 +6,8 @@
 #include "timer.h"
 #include "debug.h"
 
-#if defined( JA2 ) || defined( UTIL )
 #include "video.h"
-#else
-#include "video2.h"
-#endif
 
-#ifndef JA2
-#include "input.h"
-#include "memman.h"
-#include "fileman.h"
-#include "soundman.h"
-#include "pcx.h"
-#include "line.h"
-#include "gameloop.h"
-#include "font.h"
-#include "english.h"
-#include "vobject.h"
-#include "Random.h"
-#include "shading.h"
-#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -36,13 +18,6 @@ extern CHAR8			gzCommandLine[100];	// Command line given
 extern UINT8			gbPixelDepth;				// GLOBAL RUN-TIME SETTINGS
 extern BOOLEAN		gfDontUseDDBlits;		// GLOBAL FOR USE OF DD BLITTING
 
-#if !defined(JA2) && !defined(UTILS)
-extern BOOLEAN		gfLoadAtStartup;
-extern CHAR8		*gzStringDataOverride;
-extern BOOLEAN		gfUsingBoundsChecker;
-extern BOOLEAN		gfCapturingVideo;
-
-#endif
 
 // function prototypes
 void SGPExit(void);

--- a/Standard Gaming Platform/sgp_auto_memory.h
+++ b/Standard Gaming Platform/sgp_auto_memory.h
@@ -84,7 +84,6 @@ namespace sgp
 
 } // namespace sgp
 
-#ifdef JA2
 
 #include "MemMan.h"
 
@@ -108,6 +107,5 @@ namespace sgp
 	};
 }
 
-#endif
 
 #endif // _SGP_AUTO_MEMORY_H_

--- a/Standard Gaming Platform/shading.cpp
+++ b/Standard Gaming Platform/shading.cpp
@@ -1,11 +1,7 @@
 	#include "DirectDraw Calls.h"
 	#include <stdio.h>
 	#include "debug.h"
-	#if defined( JA2 ) || defined( UTIL )
 		#include "video.h"
-	#else
-		#include "video2.h"
-	#endif
 	#include "himage.h"
 	#include "vobject.h"
 	#include "vobject_blitters.h"
@@ -281,7 +277,6 @@ void SetShadeTablePercent( FLOAT uiShadePercent )
 }
 
 
-#ifdef JA2	// Jul. 23 '97 - ALEX - because Wizardry isn't using it & no longer has a version of Set8BPPPalette() available
 void Init8BitTables(void)
 {
 SGPPaletteEntry Pal[256];
@@ -308,4 +303,4 @@ BOOLEAN Set8BitModePalette(SGPPaletteEntry *pPal)
 	Set8BPPPalette(pPal);
 	return(TRUE);
 }
-#endif
+

--- a/Standard Gaming Platform/shading.h
+++ b/Standard Gaming Platform/shading.h
@@ -16,10 +16,8 @@ void BuildShadeTable(void);
 void BuildIntensityTable(void);
 void SetShadeTablePercent( FLOAT uiShadePercent );
 
-#ifdef JA2	// Jul. 23 '97 - ALEX - because Wizardry isn't using it & no longer has a version of Set8BPPPalette() available
 void Init8BitTables(void);
 BOOLEAN Set8BitModePalette(SGPPaletteEntry *pPal);
-#endif
 
 extern SGPPaletteEntry Shaded8BPPPalettes[HVOBJECT_SHADE_TABLES+3][256];
 extern UINT8 ubColorTables[HVOBJECT_SHADE_TABLES+3][256];

--- a/Standard Gaming Platform/timer.cpp
+++ b/Standard Gaming Platform/timer.cpp
@@ -1,10 +1,6 @@
 	#include "types.h"
 	#include <windows.h>
-	#if defined( JA2 ) || defined( UTIL )
 		#include "video.h"
-	#else
-		#include "video2.h"
-	#endif
 	#include "timer.h"
 
 #ifndef WIN32_LEAN_AND_MEAN

--- a/Standard Gaming Platform/vobject.cpp
+++ b/Standard Gaming Platform/vobject.cpp
@@ -1,11 +1,7 @@
 	#include "DirectDraw Calls.h"
 	#include <stdio.h>
 	#include "debug.h"
-	#if defined( JA2 ) || defined( UTIL )
 		#include "video.h"
-	#else
-		#include "video2.h"
-	#endif
 	#include "himage.h"
 	#include "vobject.h"
 	#include "wcheck.h"
@@ -968,17 +964,6 @@ BOOLEAN BltVideoObjectToBuffer( UINT16 *pBuffer, UINT32 uiDestPitchBYTES, HVOBJE
 				{
 					if(gbPixelDepth==16)
 					{
-#ifndef JA2
-						if ( fBltFlags & VO_BLT_MIRROR_Y)
-						{
-							if(!BltIsClipped(hSrcVObject, iDestX, iDestY, usIndex, &ClippingRect))
-								Blt8BPPDataTo16BPPBufferTransMirror( pBuffer, uiDestPitchBYTES, hSrcVObject, iDestX, iDestY, usIndex );
-// CLipping version not done -- DB
-//								Blt8BPPDataTo16BPPBufferTransMirrorClip( pBuffer, uiDestPitchBYTES, hSrcVObject, iDestX, iDestY, usIndex, &ClippingRect);
-							break;
-						}
-						else
-#endif
 						if ( fBltFlags & VO_BLT_SRCTRANSPARENCY	)
 						{
 							if(BltIsClipped(hSrcVObject, iDestX, iDestY, usIndex, &ClippingRect))

--- a/Standard Gaming Platform/vobject_blitters.cpp
+++ b/Standard Gaming Platform/vobject_blitters.cpp
@@ -1,11 +1,7 @@
 	#include "DirectDraw Calls.h"
 	#include <stdio.h>
 	#include "debug.h"
-	#if defined( JA2 ) || defined( UTIL )
 		#include "video.h"													// JA2
-	#else
-		#include "video2.h"				// Wiz8
-	#endif
 	#include "himage.h"
 	#include "vobject.h"
 	#include "wcheck.h"

--- a/Standard Gaming Platform/vsurface.cpp
+++ b/Standard Gaming Platform/vsurface.cpp
@@ -2,11 +2,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include "debug.h"
-#if defined( JA2 ) || defined( UTIL )
 #include "video.h"
-#else
-#include "video2.h"
-#endif
 #include "himage.h"
 #include "vsurface.h"
 #include "vsurface_private.h"
@@ -453,7 +449,6 @@ BYTE *LockVideoSurface( UINT32 uiVSurface, UINT32 *puiPitch )
 	//
 	// Check if given backbuffer or primary buffer
 	//
-#ifdef JA2
 	if ( uiVSurface == PRIMARY_SURFACE )
 	{
 		return SurfaceData::SetSurfaceData(uiVSurface, (BYTE *)LockPrimarySurface( puiPitch ));
@@ -463,7 +458,6 @@ BYTE *LockVideoSurface( UINT32 uiVSurface, UINT32 *puiPitch )
 	{
 		return SurfaceData::SetSurfaceData(uiVSurface, (BYTE *)LockBackBuffer( puiPitch ));
 	}
-#endif
 
 	if ( uiVSurface == FRAME_BUFFER )
 	{
@@ -509,7 +503,6 @@ void UnLockVideoSurface( UINT32 uiVSurface )
 	//
 	// Check if given backbuffer or primary buffer
 	//
-#ifdef JA2
 	if ( uiVSurface == PRIMARY_SURFACE )
 	{
 		UnlockPrimarySurface();
@@ -521,7 +514,6 @@ void UnLockVideoSurface( UINT32 uiVSurface )
 		UnlockBackBuffer();
 		return;
 	}
-#endif
 
 	if ( uiVSurface == FRAME_BUFFER )
 	{
@@ -680,7 +672,6 @@ BOOLEAN SetPrimaryVideoSurfaces( )
 	//
 	// Get Primary surface
 	//
-#ifdef JA2
 	pSurface = GetPrimarySurfaceObject();
 	CHECKF( pSurface != NULL );
 
@@ -709,7 +700,6 @@ BOOLEAN SetPrimaryVideoSurfaces( )
 	CHECKF( ghMouseBuffer != NULL );
 	SurfaceData::RegisterSurface(MOUSE_BUFFER,ghMouseBuffer);
 
-#endif
 
 	//
 	// Get frame buffer surface
@@ -990,11 +980,9 @@ HVSURFACE CreateVideoSurface( VSURFACE_DESC *VSurfaceDesc )
 	UINT8								ubBitDepth;
 	UINT32							fMemUsage;
 
-	//#ifdef JA2
 	UINT32							uiRBitMask;
 	UINT32							uiGBitMask;
 	UINT32							uiBBitMask;
-	//#endif
 
 	//Clear the memory
 	memset( &SurfaceDescription, 0, sizeof( DDSURFACEDESC ) );
@@ -1008,11 +996,7 @@ HVSURFACE CreateVideoSurface( VSURFACE_DESC *VSurfaceDesc )
 	//
 	// The description structure contains memory usage flag
 	//
-#ifdef JA2
 	fMemUsage = VSurfaceDesc->fCreateFlags;
-#else
-	fMemUsage = VSURFACE_SYSTEM_MEM_USAGE;
-#endif
 
 	//
 	// Check creation options
@@ -1110,16 +1094,10 @@ HVSURFACE CreateVideoSurface( VSURFACE_DESC *VSurfaceDesc )
 
 		// We're using pixel formats too -- DB/Wiz
 
-		//#ifdef JA2
 		CHECKF( GetPrimaryRGBDistributionMasks( &uiRBitMask, &uiGBitMask, &uiBBitMask ) );
 		PixelFormat.dwRBitMask = uiRBitMask;
 		PixelFormat.dwGBitMask = uiGBitMask;
 		PixelFormat.dwBBitMask = uiBBitMask;
-		//#else
-		//			PixelFormat.dwRBitMask = 0xf800;
-		//			PixelFormat.dwGBitMask = 0x7e0;
-		//			PixelFormat.dwBBitMask = 0x1f;
-		//#endif
 		break;
 
 	default:
@@ -1392,10 +1370,6 @@ BYTE *LockVideoSurfaceBuffer( HVSURFACE hVSurface, UINT32 *pPitch )
 	Assert( hVSurface != NULL );
 	Assert( pPitch != NULL );
 
-#ifndef JA2
-	if(hVSurface==ghFrameBuffer)
-		return(LockFrameBuffer(pPitch));
-#endif
 
 	DDLockSurface( (LPDIRECTDRAWSURFACE2)hVSurface->pSurfaceData, NULL, &SurfaceDescription, 0, NULL);
 
@@ -1408,13 +1382,6 @@ void UnLockVideoSurfaceBuffer( HVSURFACE hVSurface )
 {
 	Assert( hVSurface != NULL );
 
-#ifndef JA2
-	if(hVSurface==ghFrameBuffer)
-	{
-		UnlockFrameBuffer();
-		return;
-	}
-#endif
 
 	DDUnlockSurface( (LPDIRECTDRAWSURFACE2)hVSurface->pSurfaceData, NULL );
 
@@ -2088,28 +2055,6 @@ BOOLEAN BltVideoSurfaceToVideoSurface( HVSURFACE hDestVSurface, HVSURFACE hSrcVS
 			return(TRUE);
 		}
 		// For testing with non-DDraw blitting, uncomment to test -- DB
-#ifndef JA2
-		else
-		{
-			if((pSrcSurface16=(UINT16 *)LockVideoSurfaceBuffer(hSrcVSurface, &uiSrcPitch))==NULL)
-			{
-				DbgMessage(TOPIC_VIDEOSURFACE, DBG_LEVEL_2, String( "Failed on lock of 16BPP surface for blitting" ));
-				return(FALSE);
-			}
-
-			if((pDestSurface16=(UINT16 *)LockVideoSurfaceBuffer(hDestVSurface, &uiDestPitch))==NULL)
-			{
-				UnLockVideoSurfaceBuffer(hSrcVSurface);
-				DbgMessage(TOPIC_VIDEOSURFACE, DBG_LEVEL_2, String( "Failed on lock of 16BPP dest surface for blitting" ));
-				return(FALSE);
-			}
-
-			Blt16BPPTo16BPP(pDestSurface16, uiDestPitch, pSrcSurface16, uiSrcPitch, iDestX, iDestY, SrcRect.left, SrcRect.top, uiWidth, uiHeight);
-			UnLockVideoSurfaceBuffer(hSrcVSurface);
-			UnLockVideoSurfaceBuffer(hDestVSurface);
-			return(TRUE);
-		}
-#endif
 
 		CHECKF( BltVSurfaceUsingDD( hDestVSurface, hSrcVSurface, fBltFlags, iDestX, iDestY, &SrcRect ) );
 

--- a/Utils/Cinematics.cpp
+++ b/Utils/Cinematics.cpp
@@ -32,11 +32,7 @@
 #include <vfs/Core/vfs.h>
 #include <vfs/Core/vfs_file_raii.h>
 
-#ifdef JA2
 	#include "video.h"
-#else
-	#include "video2.h"
-#endif
 
 #include "vsurface_private.h"
 


### PR DESCRIPTION
UTIL is never used, and JA2 is always used. assumption being we'll never make 1.13 for Wizardry 8.

video2.h doesn't exist, which prevented me from deleting it.