### PR TITLE
Remove redefinition of symbols in jascreens.cpp

### DIFF
--- a/jascreens.cpp
+++ b/jascreens.cpp
@@ -1043,40 +1043,6 @@ UINT32 DemoExitScreenShutdown(void)
 	return( TRUE );
 }
 
-#ifndef JA2EDITOR
-
-UINT32 LoadSaveScreenInit()
-{
-	return TRUE;
-}
-
-UINT32 LoadSaveScreenHandle()
-{
-	return TRUE;
-}
-
-UINT32 LoadSaveScreenShutdown()
-{
-	return TRUE;
-}
-
-UINT32 EditScreenInit()
-{
-	return TRUE;
-}
-
-UINT32 EditScreenHandle()
-{
-	return TRUE;
-}
-
-UINT32 EditScreenShutdown()
-{
-	return TRUE;
-}
-
-
-#endif
 void PrintExceptionList()
 {
 	UINT8*		pDestBuf;


### PR DESCRIPTION
No idea why VS doesn't complain about this.
All these symbols are defined in Editor/LoadScreen.cpp when JA2EDITOR is defined and when it isn't.