### PR TITLE
Remove redefinition of symbols in jascreens.cpp

### DIFF
--- a/jascreens.cpp
+++ b/jascreens.cpp
@@ -1041,40 +1041,6 @@ UINT32 DemoExitScreenShutdown(void)
 	return( TRUE );
 }
 
-#ifndef JA2EDITOR
-
-UINT32 LoadSaveScreenInit()
-{
-	return TRUE;
-}
-
-UINT32 LoadSaveScreenHandle()
-{
-	return TRUE;
-}
-
-UINT32 LoadSaveScreenShutdown()
-{
-	return TRUE;
-}
-
-UINT32 EditScreenInit()
-{
-	return TRUE;
-}
-
-UINT32 EditScreenHandle()
-{
-	return TRUE;
-}
-
-UINT32 EditScreenShutdown()
-{
-	return TRUE;
-}
-
-
-#endif
 void PrintExceptionList()
 {
 	UINT8*		pDestBuf;


### PR DESCRIPTION
Had closed this in #67 because I thought there was another way to fix this, but I was wrong.

So, the way the MSVC builds this means the function definitions we want are in Editor/LoadScreen.cpp since Editor is a dependency of ja2 there, and is built first.