### PR TITLE
Don't push v1.13 tag but fake it

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,20 +96,14 @@ jobs:
           then
             # if we build for a specific tag, use that as the game version
             # examples:
-            # - v1.3.3
-            # - v1.3.2-rc2
+            # - v1.13.1
+            # - v1.13.2-rc2
             GAME_VERSION="$GITHUB_REF_NAME"
           else
-            # tag the very first commit as v1.13, fixes git describe if no tags are around
-            if ! git rev-list v1.13 2>/dev/null
-            then
-              git tag v1.13 $(git rev-list --max-parents=0 HEAD) && git push origin v1.13
-            fi
-          
-            # uses `git describe`, which tries to find a tag in the commit hierarchy
+            # uses `git describe`, which tries to find a tag in the commit hierarchy. or fall back to a v1.13 version
             # example five (5) commits after v1.13:
             # - v1.13-5-7g7ffa
-            GAME_VERSION="$(git describe --tags --match='v[0-9]*' $GITHUB_SHA)"
+            GAME_VERSION="$(git describe --tags --match='v[0-9]*' $GITHUB_SHA || echo v0-$(git rev-list --skip 1 --count $GITHUB_SHA)-g${GITHUB_SHA:0:8})"
           fi
           # max 15 CHAR8
           GAME_VERSION="${GAME_VERSION:0:15}"

--- a/.github/workflows/build_language.yml
+++ b/.github/workflows/build_language.yml
@@ -187,7 +187,8 @@ jobs:
           set -eux
           
           # "-" separates words, "_" combines words, see double-click behavior
-          DIST_NAME="JA2-${GAME_VERSION}-G${GAMEDIR_COMMIT_SHA:0:4}L${GAMEDIR_LANGUAGES_COMMIT_SHA:0:4}-${{ inputs.language }}"
+          DIST_PREFIX='JA2_113'
+          DIST_NAME="${DIST_PREFIX}-${GAME_VERSION}-G${GAMEDIR_COMMIT_SHA:0:4}L${GAMEDIR_LANGUAGES_COMMIT_SHA:0:4}-${{ inputs.language }}"
           echo "DIST_NAME=$DIST_NAME" >> $GITHUB_ENV
           
           echo "If you encounter problems during gameplay, please provide the following version information:
@@ -204,8 +205,8 @@ jobs:
           Gamedir Languages Repository: $GAMEDIR_LANGUAGES_REPOSITORY
           Gamedir Languages Commit SHA: $GAMEDIR_LANGUAGES_COMMIT_SHA
           Gamedir Languages Commit Date: $GAMEDIR_LANGUAGES_COMMIT_DATETIME
-          " > gamedir/ja2_1.13_version.txt
-          cat gamedir/ja2_1.13_version.txt
+          " > "gamedir/${DIST_PREFIX}-Version.txt"
+          cat "gamedir/${DIST_PREFIX}-Version.txt"
 
       - name: Create release archive
         shell: bash

--- a/GameVersion.cpp
+++ b/GameVersion.cpp
@@ -1,52 +1,40 @@
 	#include "Types.h"
 	#include "GameVersion.h"
- 
+
 //
 //	Keeps track of the game version
 //
- 
-// ------------------------------
-// MAP EDITOR (Release and Debug) BUILD VERSION
-// ------------------------------
-#ifdef JA2EDITOR
+
+#ifdef JA2EDITOR // map editor
 	
 	#ifdef JA2UB
-		CHAR16 zProductLabel[64]		= { L"Unfinished Business - Map Editor v1.13" };
+		CHAR16 zProductLabel[64]		= { L"JA2 1.13 Unfinished Business - Map Editor" };
 	#else
-		CHAR16 zProductLabel[64]		= { L"Map Editor v1.13" };
+		CHAR16 zProductLabel[64]		= { L"JA2 1.13 - Map Editor" };
 	#endif
 
-// ------------------------------
-// DEBUG BUILD VERSIONS
-// ------------------------------
-#elif defined JA2BETAVERSION
+#elif defined JA2BETAVERSION // debug
 
-	//DEBUG BUILD VERSION	
 	#ifdef JA2UB
-		CHAR16 zProductLabel[64]		= { L"Debug: Unfinished Business - v1.13" };
+		CHAR16 zProductLabel[64]		= { L"Debug: JA2 1.13 Unfinished Business" };
 	#elif defined (JA113DEMO)
-		CHAR16 zProductLabel[64]		= { L"Debug: JA2 Demo - v1.13" };
+		CHAR16 zProductLabel[64]		= { L"Debug: JA2 1.13 Demo" };
 	#else
-		CHAR16 zProductLabel[64]		= { L"Debug: v1.13" };
+		CHAR16 zProductLabel[64]		= { L"Debug: JA2 1.13" };
 	#endif
 
 #elif defined CRIPPLED_VERSION
 
-	//RELEASE BUILD VERSION s
-	CHAR16 zProductLabel[64]		= { L"Beta v. 0.98" };
+	CHAR16 zProductLabel[64]		= { L"JA2 113 Beta-0.98" };
 
-// ------------------------------
-// RELEASE BUILD VERSIONS
-// ------------------------------
-#else
+#else // release
 
-	//RELEASE BUILD VERSION	
 	#ifdef JA2UB
-		CHAR16		zProductLabel[64]		= { L"Unfinished Business - v1.13" };
+		CHAR16		zProductLabel[64]		= { L"JA2 1.13 Unfinished Business" };
 	#elif defined (JA113DEMO)
-		CHAR16		zProductLabel[64]		= { L"JA2 Demo - v1.13" };
+		CHAR16		zProductLabel[64]		= { L"JA2 1.13 Demo" };
 	#else
-		CHAR16		zProductLabel[64]		= { L"v1.13" };
+		CHAR16		zProductLabel[64]		= { L"JA2 1.13" };
 	#endif
 
 #endif


### PR DESCRIPTION
- dont push v1.13
- normalized product titles and removed prepended v from 1.13 as to avoid confusing with git tags and make it work with the main menu logo