### PR TITLE
avoid static initialization order fiasco in soundman.cpp

### DIFF
--- a/Standard Gaming Platform/soundman.cpp
+++ b/Standard Gaming Platform/soundman.cpp
@@ -1852,16 +1852,6 @@ UINT32 uiCount;
 	return(FALSE);
 }
 
-// Lesh modifications
-// Sound debug
-static struct SoundLog {
-	sgp::Logger_ID id;
-	SoundLog() {
-		id = sgp::Logger::instance().createLogger();
-		sgp::Logger::instance().connectFile(id, SndDebugFileName, true, sgp::Logger::FLUSH_ON_DELETE);
-	}
-} s_SoundLog;
-
 //*****************************************************************************************
 // SoundLog
 //	Writes string into log file
@@ -1872,6 +1862,13 @@ static struct SoundLog {
 //*****************************************************************************************
 void SoundLog(CHAR8 *strMessage)
 {
+	static struct SoundLog {
+		sgp::Logger_ID id;
+		SoundLog() {
+			id = sgp::Logger::instance().createLogger();
+			sgp::Logger::instance().connectFile(id, SndDebugFileName, true, sgp::Logger::FLUSH_ON_DELETE);
+		}
+	} s_SoundLog;
 #ifndef USE_VFS
 	if ((SndDebug = fopen(SndDebugFileName, "a+t")) != NULL)
 	{


### PR DESCRIPTION
When running the CMake Debug build instead of `ja2_vs2019.sln`, `s_SoundLog` is undefined inside `SoundLog(CHAR8*)`. The most likely reason for that is that static objects in global scope have unspecified initialization order. The problem is fixed if the static SoundLog object is created inside the SoundLog(CHAR8*) function instead so that `s_SoundLog`'s lifetime becomes defined.

Also removed the comment whose meaning apparently has been lost to the sands of time.