### PR TITLE
Fix bug if vehicle holds more soldiers than can fit in a squad (by Seven)

### DIFF
--- a/Strategic/PreBattle Interface.cpp
+++ b/Strategic/PreBattle Interface.cpp
@@ -2141,6 +2141,13 @@ void PutNonSquadMercsInPlayerGroupOnSquads( GROUP *pGroup, BOOLEAN fExitVehicles
 						// because if this is a simultaneous group attack, the mercs could be coming from different sides, and the
 						// placement screen can't handle mercs on the same squad arriving from difference edges!
 						fSuccess = AddCharacterToSquad( pSoldier, bUniqueVehicleSquad );
+						{
+							bUniqueVehicleSquad = GetFirstEmptySquad();
+							if (bUniqueVehicleSquad != -1)
+							{
+								fSuccess = AddCharacterToSquad(pSoldier, bUniqueVehicleSquad);
+							}
+						}
 					}
 					//CHRISL: So what's supposed to happen in the merc is assigned to a vehicle but fExitVehicles is FALSE?
 					else

--- a/Strategic/PreBattle Interface.cpp
+++ b/Strategic/PreBattle Interface.cpp
@@ -2141,6 +2141,8 @@ void PutNonSquadMercsInPlayerGroupOnSquads( GROUP *pGroup, BOOLEAN fExitVehicles
 						// because if this is a simultaneous group attack, the mercs could be coming from different sides, and the
 						// placement screen can't handle mercs on the same squad arriving from difference edges!
 						fSuccess = AddCharacterToSquad( pSoldier, bUniqueVehicleSquad );
+						// if we failed, create another squad
+						if (!fSuccess)
 						{
 							bUniqueVehicleSquad = GetFirstEmptySquad();
 							if (bUniqueVehicleSquad != -1)


### PR DESCRIPTION
Fixed my own mistake in copy pasting code.

We would fail Assert(fSuccess) as all passengers would not fit in one squad, and the code wouldn't allow creating a new squad where they could be placed.