### PR TITLE
Add on option to start at maximum aiming level

### DIFF
--- a/GameSettings.cpp
+++ b/GameSettings.cpp
@@ -284,7 +284,7 @@ BOOLEAN LoadGameSettings()
 		gGameSettings.fOptions[TOPTION_RTCONFIRM]                       = iniReader.ReadBoolean("JA2 Game Settings","TOPTION_RTCONFIRM"                        ,  FALSE );
 		gGameSettings.fOptions[TOPTION_SLEEPWAKE_NOTIFICATION]          = iniReader.ReadBoolean("JA2 Game Settings","TOPTION_SLEEPWAKE_NOTIFICATION"           ,  TRUE  );
 		gGameSettings.fOptions[TOPTION_USE_METRIC_SYSTEM]               = iniReader.ReadBoolean("JA2 Game Settings","TOPTION_USE_METRIC_SYSTEM"                ,  TRUE );
-		gGameSettings.fOptions[TOPTION_MERC_CASTS_LIGHT] = iniReader.ReadBoolean("JA2 Game Settings", "TOPTION_MERC_CASTS_LIGHT", FALSE);
+		gGameSettings.fOptions[TOPTION_MERC_CASTS_LIGHT]				= iniReader.ReadBoolean("JA2 Game Settings", "TOPTION_MERC_CASTS_LIGHT"				   , FALSE);
 		gGameSettings.fOptions[TOPTION_SMART_CURSOR]                    = iniReader.ReadBoolean("JA2 Game Settings","TOPTION_SMART_CURSOR"                     ,  FALSE );
 		gGameSettings.fOptions[TOPTION_SNAP_CURSOR_TO_DOOR]             = iniReader.ReadBoolean("JA2 Game Settings","TOPTION_SNAP_CURSOR_TO_DOOR"              ,  TRUE  );
 		gGameSettings.fOptions[TOPTION_GLOW_ITEMS]                      = iniReader.ReadBoolean("JA2 Game Settings","TOPTION_GLOW_ITEMS"                       ,  TRUE  );
@@ -332,6 +332,7 @@ BOOLEAN LoadGameSettings()
 		else
 			gGameSettings.fOptions[TOPTION_TOGGLE_TURN_MODE]			= FALSE;
 
+		gGameSettings.fOptions[TOPTION_ALT_START_AIM]					= iniReader.ReadBoolean("JA2 Game Settings", "TOPTION_ALT_START_AIM"				   , FALSE); // Start at max aiming level instead of default no aiming
 		gGameSettings.fOptions[TOPTION_MERCENARY_FORMATIONS]            = iniReader.ReadBoolean("JA2 Game Settings","TOPTION_MERCENARY_FORMATIONS"             ,  TRUE ); // Flugente: mercenary formations
 		gGameSettings.fOptions[TOPTION_SHOW_ENEMY_LOCATION]				= iniReader.ReadBoolean("JA2 Game Settings","TOPTION_SHOW_ENEMY_LOCATION"			   ,  FALSE); // sevenfm: show locations of known enemies
 		gGameSettings.fOptions[TOPTION_REPORT_MISS_MARGIN]				= iniReader.ReadBoolean("JA2 Game Settings","TOPTION_REPORT_MISS_MARGIN"			   ,  FALSE ); // HEADROCK HAM 4: Shot offset report
@@ -607,12 +608,13 @@ BOOLEAN	SaveGameSettings()
 		settings << "TOPTION_AUTO_FAST_FORWARD_MODE           = " << (gGameSettings.fOptions[TOPTION_AUTO_FAST_FORWARD_MODE]			?    "TRUE" : "FALSE" ) << endl;
 		settings << "TOPTION_SHOW_LAST_ENEMY				  = " << (gGameSettings.fOptions[TOPTION_SHOW_LAST_ENEMY]					?	 "TRUE"	: "FALSE" ) << endl;
 		settings << "TOPTION_SHOW_LBE_CONTENT				  = " << (gGameSettings.fOptions[TOPTION_SHOW_LBE_CONTENT]					?	 "TRUE"	: "FALSE" ) << endl;
-		settings << "TOPTION_INVERT_WHEEL				  = " << (gGameSettings.fOptions[TOPTION_INVERT_WHEEL]						?	 "TRUE"	: "FALSE" ) << endl;
+		settings << "TOPTION_INVERT_WHEEL					  = " << (gGameSettings.fOptions[TOPTION_INVERT_WHEEL]						?	 "TRUE"	: "FALSE" ) << endl;
 
 		settings << "TOPTION_ZOMBIES						  = " << (gGameSettings.fOptions[TOPTION_ZOMBIES]							?    "TRUE" : "FALSE" ) << endl;
 		settings << "TOPTION_ENABLE_INVENTORY_POPUPS          = " << (gGameSettings.fOptions[TOPTION_ENABLE_INVENTORY_POPUPS]			?    "TRUE" : "FALSE" ) << endl; // the_bob : enable popups for picking items from sector inv
 		settings << "TOPTION_MERCENARY_FORMATIONS			  = " << (gGameSettings.fOptions[TOPTION_MERCENARY_FORMATIONS]				?    "TRUE" : "FALSE" ) << endl;
 		settings << "TOPTION_SHOW_ENEMY_LOCATION			  = " << (gGameSettings.fOptions[TOPTION_SHOW_ENEMY_LOCATION]				?	 "TRUE" : "FALSE" ) << endl;
+		settings << "TOPTION_ALT_START_AIM					  = " << (gGameSettings.fOptions[TOPTION_ALT_START_AIM]						? "TRUE" : "FALSE") << endl;
 
 		settings << "TOPTION_CHEAT_MODE_OPTIONS_HEADER        = " << (gGameSettings.fOptions[TOPTION_CHEAT_MODE_OPTIONS_HEADER]			?    "TRUE" : "FALSE" ) << endl;
 		settings << "TOPTION_FORCE_BOBBY_RAY_SHIPMENTS        = " << (gGameSettings.fOptions[TOPTION_FORCE_BOBBY_RAY_SHIPMENTS]			?    "TRUE" : "FALSE" ) << endl;
@@ -839,7 +841,8 @@ void InitGameSettings()
 	gGameSettings.fOptions[TOPTION_INVERT_WHEEL]						= FALSE;
 	
 	gGameSettings.fOptions[ TOPTION_MERCENARY_FORMATIONS ]				= FALSE;	// Flugente: mercenary formations
-	gGameSettings.fOptions[ TOPTION_SHOW_ENEMY_LOCATION ]				= FALSE;	// sevenfm: show locations of known enemies
+	gGameSettings.fOptions[TOPTION_SHOW_ENEMY_LOCATION]					= FALSE;	// sevenfm: show locations of known enemies
+	gGameSettings.fOptions[TOPTION_ALT_START_AIM]						= FALSE;
 
 	// arynn: Cheat/Debug Menu
 	gGameSettings.fOptions[ TOPTION_CHEAT_MODE_OPTIONS_HEADER ]			= FALSE;	

--- a/GameSettings.h
+++ b/GameSettings.h
@@ -103,6 +103,7 @@ enum
 
 	// sevenfm: new settings
 	TOPTION_SHOW_ENEMY_LOCATION,
+	TOPTION_ALT_START_AIM,
 
 	// arynn: Debug/Cheat
 	TOPTION_CHEAT_MODE_OPTIONS_HEADER,

--- a/Tactical/UI Cursors.cpp
+++ b/Tactical/UI Cursors.cpp
@@ -136,13 +136,13 @@ BOOLEAN GetMouseRecalcAndShowAPFlags( UINT32 *puiCursorFlags, BOOLEAN *pfShowAPs
 // FUNCTIONS FOR CURSOR DETERMINATION!
 UINT8	GetProperItemCursor( UINT8 ubSoldierID, UINT16 ubItemIndex, INT32 usMapPos, BOOLEAN fActivated )
 {
-	SOLDIERTYPE				*pSoldier;
-	UINT32						uiCursorFlags;
-	BOOLEAN						fShowAPs = FALSE;
-	BOOLEAN						fRecalc = FALSE;
+	SOLDIERTYPE *pSoldier;
+	UINT32 uiCursorFlags;
+	BOOLEAN fShowAPs = FALSE;
+	BOOLEAN fRecalc = FALSE;
 	INT32 sTargetGridNo = usMapPos;
-	UINT8							ubCursorID=0;
-	UINT8							ubItemCursor;
+	UINT8 ubCursorID=0;
+	UINT8 ubItemCursor = 0;
 
 	pSoldier = MercPtrs[ ubSoldierID ];
 
@@ -350,6 +350,7 @@ UINT8 HandleActivatedTargetCursor( SOLDIERTYPE *pSoldier, INT32 usMapPos, BOOLEA
 	UINT16							usCursor=0;
 	BOOLEAN							fMaxPointLimitHit = FALSE;
 	UINT16							usInHand;
+	extern UINT32					guiNewUICursor;
 
 	UINT16	reverse = 0;
 
@@ -455,6 +456,24 @@ UINT8 HandleActivatedTargetCursor( SOLDIERTYPE *pSoldier, INT32 usMapPos, BOOLEA
 			{
 				pSoldier->bDoAutofire--;
 				gsCurrentActionPoints = CalcTotalAPsToAttack( pSoldier, usMapPos, TRUE, (INT8)(pSoldier->aiData.bShownAimTime ) );
+			}
+
+			// Start at maximum aiming levels if the option is toggled
+			if (gGameSettings.fOptions[TOPTION_ALT_START_AIM] && (guiNewUICursor == ACTION_FLASH_SHOOT_UICURSOR || guiNewUICursor == ACTION_FLASH_BURST_UICURSOR))
+			{
+				pSoldier->aiData.bShownAimTime = maxAimLevels;
+				sAPCosts = CalcTotalAPsToAttack(pSoldier, usMapPos, TRUE, pSoldier->aiData.bShownAimTime);
+				// Determine if we can afford!
+				while (!EnoughPoints(pSoldier, sAPCosts, 0, FALSE))
+				{
+					pSoldier->aiData.bShownAimTime -= 1;
+					if (pSoldier->aiData.bShownAimTime < 0)
+					{
+						pSoldier->aiData.bShownAimTime = REFINE_AIM_1;
+						break;
+					}
+					sAPCosts = CalcTotalAPsToAttack(pSoldier, usMapPos, TRUE, pSoldier->aiData.bShownAimTime);
+				}
 			}
 
 			// If we don't have any points and we are at the first refine, do nothing but warn!

--- a/Tactical/UI Cursors.cpp
+++ b/Tactical/UI Cursors.cpp
@@ -458,8 +458,13 @@ UINT8 HandleActivatedTargetCursor( SOLDIERTYPE *pSoldier, INT32 usMapPos, BOOLEA
 				gsCurrentActionPoints = CalcTotalAPsToAttack( pSoldier, usMapPos, TRUE, (INT8)(pSoldier->aiData.bShownAimTime ) );
 			}
 
-			// Start at maximum aiming levels if the option is toggled
-			if (gGameSettings.fOptions[TOPTION_ALT_START_AIM] && (guiNewUICursor == ACTION_FLASH_SHOOT_UICURSOR || guiNewUICursor == ACTION_FLASH_BURST_UICURSOR))
+			const bool isCursorOnTarget = (
+				guiNewUICursor == ACTION_SHOOT_UICURSOR || guiNewUICursor == ACTION_TARGETBURST_UICURSOR ||
+				guiNewUICursor == ACTION_FLASH_SHOOT_UICURSOR || guiNewUICursor == ACTION_FLASH_BURST_UICURSOR ||
+				guiNewUICursor == ACTION_NOCHANCE_SHOOT_UICURSOR || guiNewUICursor == ACTION_NOCHANCE_BURST_UICURSOR
+			);
+				// Start at maximum aiming levels if the option is toggled
+			if (gGameSettings.fOptions[TOPTION_ALT_START_AIM] && isCursorOnTarget)
 			{
 				pSoldier->aiData.bShownAimTime = maxAimLevels;
 				sAPCosts = CalcTotalAPsToAttack(pSoldier, usMapPos, TRUE, pSoldier->aiData.bShownAimTime);
@@ -474,6 +479,7 @@ UINT8 HandleActivatedTargetCursor( SOLDIERTYPE *pSoldier, INT32 usMapPos, BOOLEA
 					}
 					sAPCosts = CalcTotalAPsToAttack(pSoldier, usMapPos, TRUE, pSoldier->aiData.bShownAimTime);
 				}
+				gsCurrentActionPoints = sAPCosts;
 			}
 
 			// If we don't have any points and we are at the first refine, do nothing but warn!

--- a/Utils/_ChineseText.cpp
+++ b/Utils/_ChineseText.cpp
@@ -6574,6 +6574,7 @@ STR16		zOptionsToggleText[] =
 	L"反转鼠标滚轮",                 //L"Invert mouse wheel",
 	L"保持佣兵间距",				// when multiple mercs are selected, they will try to keep their relative distances
 	L"显示已知敌人位置",			//L"Show enemy location", show locator on last known enemy location
+	L"Start at maximum aim",
 	L"--作弊模式选项--",				// TOPTION_CHEAT_MODE_OPTIONS_HEADER,
 	L"强制 Bobby Ray 送货",				// force all pending Bobby Ray shipments
 	L"-----------------",				// TOPTION_CHEAT_MODE_OPTIONS_END
@@ -6693,6 +6694,7 @@ STR16	zOptionsScreenHelpText[] =
 	L"打开时，反转鼠标滚轮方向。",
 	L"打开时，当选择多个佣兵，在前进时会保持彼此的间距。|C|t|r|l+|A|l|t+|G \n（按|S|h|i|f|t+点击人物头像可以加入或移出队伍）", //L"When ON and multiple mercs are selected, they will try to keep their relative distances while moving.\n(press |C|t|r|l+|A|l|t+|G to toggle mode or |S|h|i|f|t + click to move in formation)", TODO.Translate
 	L"打开时，会显示已知敌人最后移动的位置。",	//L"When ON, shows last known enemy location.",    
+	L"When ON, aiming at enemy will start at maximum aiming instead of default no aim",
 	L"(text not rendered)TOPTION_CHEAT_MODE_OPTIONS_HEADER",
 	L"强制 Bobby Ray 出货",
 	L"(text not rendered)TOPTION_CHEAT_MODE_OPTIONS_END",

--- a/Utils/_DutchText.cpp
+++ b/Utils/_DutchText.cpp
@@ -6576,6 +6576,7 @@ STR16		zOptionsToggleText[] =
 	L"Invert mouse wheel",			// TODO.Translate
 	L"Formation Movement",					// when multiple mercs are selected, they will try to keep their relative distances	// TODO.Translate
 	L"Show enemy location",					// show locator on last known enemy location
+	L"Start at maximum aim",
 	L"--Cheat Mode Options--",				// TOPTION_CHEAT_MODE_OPTIONS_HEADER,
 	L"Force Bobby Ray shipments",			// force all pending Bobby Ray shipments
 	L"-----------------",					// TOPTION_CHEAT_MODE_OPTIONS_END
@@ -6695,6 +6696,7 @@ STR16	zOptionsScreenHelpText[] =
 	L"When ON, inverts mouse wheel directions.",		// TODO.Translate
 	L"When ON and multiple mercs are selected, they will try to keep their relative distances while moving.\n(press |C|t|r|l+|A|l|t+|G to toggle mode or |S|h|i|f|t + click to move in formation)", //TODO.Translate
 	L"When ON, shows last known enemy location.",	//TODO.Translate
+	L"When ON, aiming at enemy will start at maximum aiming instead of default no aim",
 	L"(text not rendered)TOPTION_CHEAT_MODE_OPTIONS_HEADER",
 	L"Force all pending Bobby Ray shipments",
 	L"(text not rendered)TOPTION_CHEAT_MODE_OPTIONS_END",

--- a/Utils/_EnglishText.cpp
+++ b/Utils/_EnglishText.cpp
@@ -6574,6 +6574,7 @@ STR16		zOptionsToggleText[] =
 	L"Invert Mouse Wheel",
 	L"Formation Movement",					// when multiple mercs are selected, they will try to keep their relative distances
 	L"Show enemy location",					// show locator on last known enemy location
+	L"Start at maximum aim",
 	L"--Cheat Mode Options--",				// TOPTION_CHEAT_MODE_OPTIONS_HEADER,
 	L"Force Bobby Ray Shipments",			// force all pending Bobby Ray shipments
 	L"-----------------",					// TOPTION_CHEAT_MODE_OPTIONS_END
@@ -6693,6 +6694,7 @@ STR16	zOptionsScreenHelpText[] =
 	L"When ON, inverts mouse wheel directions.",
 	L"When ON and multiple mercs are selected, they will try to keep their relative distances while moving.\n(press |C|t|r|l+|A|l|t+|G to toggle mode or |S|h|i|f|t + click to move in formation)",
 	L"When ON, shows last known enemy location.",
+	L"When ON, aiming at enemy will start at maximum aiming instead of default no aim",
 	L"(text not rendered)TOPTION_CHEAT_MODE_OPTIONS_HEADER",
 	L"Force all pending Bobby Ray shipments",
 	L"(text not rendered)TOPTION_CHEAT_MODE_OPTIONS_END",

--- a/Utils/_FrenchText.cpp
+++ b/Utils/_FrenchText.cpp
@@ -6581,6 +6581,7 @@ STR16		zOptionsToggleText[] =
 	L"Inverser molette/souris",
 	L"Déplacement tactique",				// when multiple mercs are selected, they will try to keep their relative distances
 	L"Show enemy location",					// show locator on last known enemy location
+	L"Start at maximum aim",
 	L"--Options mode triche--",				// TOPTION_CHEAT_MODE_OPTIONS_HEADER,
 	L"Forcer envois Bobby Ray",				// force all pending Bobby Ray shipments
 	L"-----------------",					// TOPTION_CHEAT_MODE_OPTIONS_END
@@ -6699,6 +6700,7 @@ STR16	zOptionsScreenHelpText[] =
 	L"Si activé, inverse le sens de la molette de la souris.",
 	L"When ON and multiple mercs are selected, they will try to keep their relative distances while moving.\n(press |C|t|r|l+|A|l|t+|G to toggle mode or |S|h|i|f|t + click to move in formation)", //TODO.Translate
 	L"When ON, shows last known enemy location.",	//TODO.Translate
+	L"When ON, aiming at enemy will start at maximum aiming instead of default no aim",
 	L"(text not rendered)TOPTION_CHEAT_MODE_OPTIONS_HEADER",
 	L"Forcer tous les envois en attente de Bobby Ray",
 	L"(text not rendered)TOPTION_CHEAT_MODE_OPTIONS_END",

--- a/Utils/_GermanText.cpp
+++ b/Utils/_GermanText.cpp
@@ -6447,6 +6447,7 @@ STR16 zOptionsToggleText[] =
 	L"Mausradrichtung umkehren",
 	L"Bewegung in Formation",				// when multiple mercs are selected, they will try to keep their relative distances
 	L"Show enemy location",					// show locator on last known enemy location
+	L"Start at maximum aim",
 	L"--Cheat Mode Options--",				// TOPTION_CHEAT_MODE_OPTIONS_HEADER,
 	L"Erzwinge BR Lieferung",				// force all pending Bobby Ray shipments
 	L"-----------------",					// TOPTION_CHEAT_MODE_OPTIONS_END
@@ -6566,6 +6567,7 @@ STR16	zOptionsScreenHelpText[] =
 	L"Wenn diese Funktion aktiviert ist, wird die Mausradrichtung umgekehrt",
 	L"When ON and multiple mercs are selected, they will try to keep their relative distances while moving.\n(press |C|t|r|l+|A|l|t+|G to toggle mode or |S|h|i|f|t + click to move in formation)", //TODO.Translate
 	L"When ON, shows last known enemy location.",	//TODO.Translate
+	L"When ON, aiming at enemy will start at maximum aiming instead of default no aim",
 	L"(text not rendered)TOPTION_CHEAT_MODE_OPTIONS_HEADER",
 	L"Force all pending Bobby Ray shipments",
 	L"(text not rendered)TOPTION_CHEAT_MODE_OPTIONS_END",

--- a/Utils/_ItalianText.cpp
+++ b/Utils/_ItalianText.cpp
@@ -6559,6 +6559,7 @@ STR16		zOptionsToggleText[] =
 	L"Invert mouse wheel",			// TODO.Translate
 	L"Formation Movement",					// when multiple mercs are selected, they will try to keep their relative distances	// TODO.Translate
 	L"Show enemy location",					// show locator on last known enemy location
+	L"Start at maximum aim",
 	L"--Cheat Mode Options--",				// TOPTION_CHEAT_MODE_OPTIONS_HEADER,
 	L"Force Bobby Ray shipments",			// force all pending Bobby Ray shipments
 	L"-----------------",					// TOPTION_CHEAT_MODE_OPTIONS_END
@@ -6678,6 +6679,7 @@ STR16	zOptionsScreenHelpText[] =
 	L"When ON, inverts mouse wheel directions.",		// TODO.Translate
 	L"When ON and multiple mercs are selected, they will try to keep their relative distances while moving.\n(press |C|t|r|l+|A|l|t+|G to toggle mode or |S|h|i|f|t + click to move in formation)", //TODO.Translate
 	L"When ON, shows last known enemy location.",	//TODO.Translate
+	L"When ON, aiming at enemy will start at maximum aiming instead of default no aim",
 	L"(text not rendered)TOPTION_CHEAT_MODE_OPTIONS_HEADER",
 	L"Force all pending Bobby Ray shipments",
 	L"(text not rendered)TOPTION_CHEAT_MODE_OPTIONS_END",

--- a/Utils/_PolishText.cpp
+++ b/Utils/_PolishText.cpp
@@ -6578,6 +6578,7 @@ STR16		zOptionsToggleText[] =
 	L"Invert mouse wheel",			// TODO.Translate
 	L"Formation Movement",					// when multiple mercs are selected, they will try to keep their relative distances	// TODO.Translate
 	L"Show enemy location",					// show locator on last known enemy location
+	L"Start at maximum aim",
 	L"--Cheat Mode Options--",				// TOPTION_CHEAT_MODE_OPTIONS_HEADER,
 	L"Force Bobby Ray shipments",			// force all pending Bobby Ray shipments
 	L"-----------------",					// TOPTION_CHEAT_MODE_OPTIONS_END
@@ -6697,6 +6698,7 @@ STR16	zOptionsScreenHelpText[] =
 	L"When ON, inverts mouse wheel directions.",		// TODO.Translate
 	L"When ON and multiple mercs are selected, they will try to keep their relative distances while moving.\n(press |C|t|r|l+|A|l|t+|G to toggle mode or |S|h|i|f|t + click to move in formation)", //TODO.Translate
 	L"When ON, shows last known enemy location.",	//TODO.Translate
+	L"When ON, aiming at enemy will start at maximum aiming instead of default no aim",
 	L"(text not rendered)TOPTION_CHEAT_MODE_OPTIONS_HEADER",
 	L"Wymuś wszystkie oczekiwane dostawy od Bobby Ray's.",
 	L"(text not rendered)TOPTION_CHEAT_MODE_OPTIONS_END",

--- a/Utils/_RussianText.cpp
+++ b/Utils/_RussianText.cpp
@@ -6570,6 +6570,7 @@ STR16		zOptionsToggleText[] =
 	L"Инвертировать колесо мыши",
 	L"Боевой порядок",						// when multiple mercs are selected, they will try to keep their relative distances
 	L"Показывать расположение",				// show locator on last known enemy location
+	L"Start at maximum aim",
 	L"--Читерские настройки--",				// TOPTION_CHEAT_MODE_OPTIONS_HEADER,
 	L"Ускорить доставку Бобби Рэя",			// force all pending Bobby Ray shipments
 	L"-----------------",					// TOPTION_CHEAT_MODE_OPTIONS_END
@@ -6689,6 +6690,7 @@ STR16	zOptionsScreenHelpText[] =
 	L"Если включено, инвертирует направление\nпрокрутки колеса мыши.",
 	L"Если выбрано несколько наёмников,\nони будут пытаться сохранять взаимное расположение\nи дистанцию при движении\n(нажмите |C|t|r|l+|A|l|t+|G для переключения или |S|h|i|f|t + клик для движения).",
 	L"Если включено, показывает известное расположение противника\n(нажмите |S|h|i|f|t, чтобы показать источник шума).",
+	L"When ON, aiming at enemy will start at maximum aiming instead of default no aim",
 	L"(text not rendered)TOPTION_CHEAT_MODE_OPTIONS_HEADER",
 	L"Выберите этот пункт,\nчтобы груз Бобби Рэя прибыл немедленно.",
 	L"(text not rendered)TOPTION_CHEAT_MODE_OPTIONS_END",


### PR DESCRIPTION
When hovering mouse on an enemy, aiming level is started at maximum instead of no aiming when this option is toggled. Can be toggled on/off from options screen ingame at any point.

Closes #109 