### PR TITLE
Fix button glitches in widescreen UI

### DIFF
--- a/Strategic/Map Screen Interface Bottom.cpp
+++ b/Strategic/Map Screen Interface Bottom.cpp
@@ -1292,7 +1292,7 @@ void EnableDisableBottomButtonsAndRegions( void )
 		{
 			DisableButton( giMapInvDoneButton );
 		}
-		else
+		else if (!isWidescreenUI())
 		{
 			EnableButton( giMapInvDoneButton );
 		}

--- a/Strategic/mapscreen.cpp
+++ b/Strategic/mapscreen.cpp
@@ -5708,7 +5708,7 @@ UINT32 MapScreenHandle(void)
 		HandleCharBarRender( );
 	}
 
-	if( fShowInventoryFlag || fDisableDueToBattleRoster )
+	if( (fShowInventoryFlag && !isWidescreenUI()) || fDisableDueToBattleRoster )
 	{
 		for( iCounter = 0; iCounter < MAX_SORT_METHODS; iCounter++ )
 		{


### PR DESCRIPTION
Closes #123 
In widescreen strategic UI, team panel sort buttons would be hidden when transferring items to and fro merc inventory via CTRL + left click Exit inventory panel button should always be disabled in widescreen UI