### PR TITLE
don't build ja2 export tool by default

### DIFF
--- a/ext/export/src/CMakeLists.txt
+++ b/ext/export/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-option(BUILD_JA2EXPORT "Build the Ja2Export tool." ON)
+option(BUILD_JA2EXPORT "Build the Ja2Export tool." OFF)
 
 if(BUILD_JA2EXPORT)
 	message(STATUS "Configuring Ja2Export")


### PR DESCRIPTION
most users don't need this, better if whoever needs it just set BUILD_JA2EXPORT=ON on their end