### PR TITLE
make gitignore Visual Studio definitions more specific

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,9 +3,9 @@
 cmake-build-*/
 
 # Visual Studio 2022
-.vs/
-build/
-lib/
-out/
-CMakeSettings.json
+/.vs/
+/build/
+/lib/
+/out/
+/CMakeSettings.json
 /CMakeUserPresets.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,10 @@
 # CLion
-.idea/
-cmake-build-*/
+/.idea/
+/cmake-build-*/
 
 # Visual Studio 2022
 /.vs/
 /build/
-/lib/
 /out/
 /CMakeSettings.json
 /CMakeUserPresets.json


### PR DESCRIPTION
This change has gitignore only ignore files from the repo root directory.