### PR TITLE
[Fix] Incorrect displaying info and tooltips in Advances Properties Tab

### DIFF
--- a/Tactical/DisplayCover.cpp
+++ b/Tactical/DisplayCover.cpp
@@ -1823,8 +1823,8 @@ void CalculateWeapondata()
 			pObjUsed = pObjPlatform;
 		}
 
-		gunrange = GunRange( pObjUsed, pSoldier ) / 10;
-		laserrange = GetBestLaserRange( pObjPlatform ) / 10;
+		gunrange = GunRange( pObjUsed, pSoldier ) / CELL_X_SIZE;
+		laserrange = GetBestLaserRange( pObjPlatform ) / CELL_X_SIZE;
 
 		if ( Item[pObjUsed->usItem].usItemClass & IC_LAUNCHER )
 		{

--- a/Tactical/Interface Enhanced.cpp
+++ b/Tactical/Interface Enhanced.cpp
@@ -1621,8 +1621,8 @@ void InternalInitEDBTooltipRegion( OBJECTTYPE * gpItemDescObject, UINT32 guiCurr
 
 			/////////////////// PROJECTION FACTOR / NCTH BEST LASER RANGE
 			// with the reworked NCTH code and the laser performance factor we will display BestLaserRange instead of ProjectionFactor but we still need the mouse region
-			if (UsingNewCTHSystem() && ( GetProjectionFactor( gpItemDescObject ) > 1.0 || GetBestLaserRange( gpItemDescObject ) > 0
-				&& (gGameCTHConstants.LASER_PERFORMANCE_BONUS_HIP + gGameCTHConstants.LASER_PERFORMANCE_BONUS_IRON + gGameCTHConstants.LASER_PERFORMANCE_BONUS_SCOPE != 0) ) )
+			if (UsingNewCTHSystem() && ( GetProjectionFactor( gpItemDescObject ) > 1.0 || (GetBestLaserRange(gpItemDescObject) / CELL_X_SIZE > 0
+				&& (gGameCTHConstants.LASER_PERFORMANCE_BONUS_HIP + gGameCTHConstants.LASER_PERFORMANCE_BONUS_IRON + gGameCTHConstants.LASER_PERFORMANCE_BONUS_SCOPE != 0)) ) )
 			{
 				ubRegionOffset = 6;
 				MSYS_EnableRegion( &gUDBFasthelpRegions[ iFirstDataRegion + ubRegionOffset ] );
@@ -1637,7 +1637,7 @@ void InternalInitEDBTooltipRegion( OBJECTTYPE * gpItemDescObject, UINT32 guiCurr
 			}
 
 			/////////////////// OCTH BEST LASER RANGE
-			if (!UsingNewCTHSystem() && (Item[gpItemDescObject->usItem].bestlaserrange > 0 || GetAverageBestLaserRange( gpItemDescObject ) > 0 ) )
+			if ( UsingNewCTHSystem() == false && (GetAverageBestLaserRange(gpItemDescObject) / CELL_X_SIZE) > 0 )
 			{
 				ubRegionOffset = 7;
 				MSYS_EnableRegion( &gUDBFasthelpRegions[ iFirstDataRegion + ubRegionOffset ] );
@@ -2874,10 +2874,10 @@ void InternalInitEDBTooltipRegion( OBJECTTYPE * gpItemDescObject, UINT32 guiCurr
 		///////////////////// ACCURACY MODIFIER
 		if (GetAccuracyModifier( gpItemDescObject ) != 0 )
 		{
-			if (cnt >= sFirstLine && cnt < sLastLine)
+			if (UsingNewCTHSystem() == true)
 			{
-			if( UsingNewCTHSystem() == true )
-			{
+				if (cnt >= sFirstLine && cnt < sLastLine)
+				{
 					if (Item[ gpItemDescObject->usItem ].usItemClass & (IC_WEAPON|IC_PUNCH))
 					{
 						swprintf( pStr, L"%s%s", szUDBAdvStatsTooltipText[ 0 ], szUDBAdvStatsExplanationsTooltipTextForWeapons[ 0 ]);
@@ -3255,9 +3255,9 @@ void InternalInitEDBTooltipRegion( OBJECTTYPE * gpItemDescObject, UINT32 guiCurr
 
 		///////////////////// PROJECTION FACTOR / BEST LASER RANGE
 		// with the reworked NCTH code and the laser performance factor we will display BestLaserRange instead of ProjectionFactor
-		if ( ( UsingNewCTHSystem() && GetBestLaserRange( gpItemDescObject ) > 0
+		if ( ( UsingNewCTHSystem() && (GetBestLaserRange(gpItemDescObject) / CELL_X_SIZE) > 0
 			&& (gGameCTHConstants.LASER_PERFORMANCE_BONUS_HIP + gGameCTHConstants.LASER_PERFORMANCE_BONUS_IRON + gGameCTHConstants.LASER_PERFORMANCE_BONUS_SCOPE != 0) )
-			|| ( !UsingNewCTHSystem() && GetBestLaserRange( gpItemDescObject ) > 0 ) )
+			|| ( !UsingNewCTHSystem() && (GetBestLaserRange(gpItemDescObject) / CELL_X_SIZE) > 0 ) )
 		{
 			if (cnt >= sFirstLine && cnt < sLastLine)
 			{
@@ -4434,10 +4434,12 @@ void DrawWeaponStats( OBJECTTYPE * gpItemDescObject )
 
 		//////////////////// PROJECTION FACTOR / NCTH BEST LASER RANGE
 		// with the reworked NCTH code and the laser performance factor we will display BestLaserRange instead of ProjectionFactor but we use the same icon
-		if ( (UsingNewCTHSystem() && ( GetProjectionFactor( gpItemDescObject ) > 1.0 ||	( GetBestLaserRange( gpItemDescObject ) > 0
+		INT16 itemLaserRangeTiles = GetBestLaserRange(gpItemDescObject) / CELL_X_SIZE;
+		INT16 comparedLaserRangeTiles = fComparisonMode ? GetBestLaserRange(gpComparedItemDescObject) / CELL_X_SIZE : 0;
+		if ( (UsingNewCTHSystem() && ( GetProjectionFactor( gpItemDescObject ) > 1.0 ||	( itemLaserRangeTiles > 0
 			&& (gGameCTHConstants.LASER_PERFORMANCE_BONUS_HIP + gGameCTHConstants.LASER_PERFORMANCE_BONUS_IRON + gGameCTHConstants.LASER_PERFORMANCE_BONUS_SCOPE != 0) ) ) ) ||
 			( fComparisonMode && UsingNewCTHSystem() && ( (GetProjectionFactor( gpItemDescObject ) > 1.0 || GetProjectionFactor( gpComparedItemDescObject ) > 1.0) ||
-			( GetBestLaserRange( gpComparedItemDescObject ) > 0
+			( comparedLaserRangeTiles > 0
 			&& (gGameCTHConstants.LASER_PERFORMANCE_BONUS_HIP + gGameCTHConstants.LASER_PERFORMANCE_BONUS_IRON + gGameCTHConstants.LASER_PERFORMANCE_BONUS_SCOPE != 0) ) ) ) )
 		{
 			ubNumLine = 6;
@@ -4455,8 +4457,8 @@ void DrawWeaponStats( OBJECTTYPE * gpItemDescObject )
 		}
 
 		//////////////////// OCTH BEST LASER RANGE
-		if ( !UsingNewCTHSystem() && ( GetBestLaserRange( gpItemDescObject ) ||
-			( fComparisonMode && GetBestLaserRange( gpComparedItemDescObject ) ) ) )
+		if ( UsingNewCTHSystem() == false &&
+			(itemLaserRangeTiles != 0 || (fComparisonMode && comparedLaserRangeTiles != 0)) )
 		{
 			ubNumLine = 7;
 			BltVideoObjectFromIndex( guiSAVEBUFFER, guiItemInfoWeaponIcon, 14, gItemDescGenRegions[ubNumLine][0].sLeft+sOffsetX, gItemDescGenRegions[ubNumLine][0].sTop+sOffsetY, VO_BLT_SRCTRANSPARENCY, NULL );
@@ -5347,11 +5349,13 @@ void DrawAdvancedStats( OBJECTTYPE * gpItemDescObject )
 
 	///////////////////// PROJECTION FACTOR / BEST LASER RANGE
 	// with the reworked NCTH code and the laser performance factor we will display BestLaserRange instead of ProjectionFactor but we use the same icon
-	if ( ( UsingNewCTHSystem() && ( GetProjectionFactor( gpItemDescObject ) > 1.0 || ( GetBestLaserRange( gpItemDescObject ) > 0
+	INT16 itemLaserRangeTiles = GetBestLaserRange(gpItemDescObject) / CELL_X_SIZE;
+	INT16 comparedLaserRangeTiles = fComparisonMode ? GetBestLaserRange(gpComparedItemDescObject) / CELL_X_SIZE : 0;
+	if ( ( UsingNewCTHSystem() && ( GetProjectionFactor( gpItemDescObject ) > 1.0 || ( itemLaserRangeTiles > 0
 		&& (gGameCTHConstants.LASER_PERFORMANCE_BONUS_HIP + gGameCTHConstants.LASER_PERFORMANCE_BONUS_IRON + gGameCTHConstants.LASER_PERFORMANCE_BONUS_SCOPE != 0) ) ) ||
-		( fComparisonMode && ( GetProjectionFactor( gpComparedItemDescObject ) > 1.0 || ( GetBestLaserRange( gpComparedItemDescObject ) > 0
+		( fComparisonMode && ( GetProjectionFactor( gpComparedItemDescObject ) > 1.0 || ( comparedLaserRangeTiles > 0
 		&& (gGameCTHConstants.LASER_PERFORMANCE_BONUS_HIP + gGameCTHConstants.LASER_PERFORMANCE_BONUS_IRON + gGameCTHConstants.LASER_PERFORMANCE_BONUS_SCOPE != 0) ) ) ) ) ||
-		( !UsingNewCTHSystem() && ( GetBestLaserRange( gpItemDescObject ) > 0 || ( fComparisonMode && GetBestLaserRange( gpComparedItemDescObject ) > 0 ) ) ) )
+		( !UsingNewCTHSystem() && ( itemLaserRangeTiles > 0 || ( fComparisonMode && comparedLaserRangeTiles > 0 ) ) ) )
 	{
 		if (cnt >= sFirstLine && cnt < sLastLine)
 		{
@@ -7532,9 +7536,11 @@ void DrawWeaponValues( OBJECTTYPE * gpItemDescObject )
 
 		///////////////// (LASER) PROJECTION FACTOR
 		// with the reworked NCTH code and the laser performance factor we will display BestLaserRange instead of ProjectionFactor
+		INT16 itemLaserRangeTiles = GetBestLaserRange(gpItemDescObject) / CELL_X_SIZE;
+		INT16 comparedLaserRangeTiles = fComparisonMode ? GetBestLaserRange(gpComparedItemDescObject) / CELL_X_SIZE : 0;
 		if (UsingNewCTHSystem() == true && 
 			( (Item[gpItemDescObject->usItem].projectionfactor > 1.0 || GetProjectionFactor( gpItemDescObject ) > 1.0) ||
-			( GetBestLaserRange( gpItemDescObject ) > 0
+			( itemLaserRangeTiles > 0
 			&& (gGameCTHConstants.LASER_PERFORMANCE_BONUS_HIP + gGameCTHConstants.LASER_PERFORMANCE_BONUS_IRON + gGameCTHConstants.LASER_PERFORMANCE_BONUS_SCOPE != 0) ) ) )
 		{
 			// Set line to draw into
@@ -7545,13 +7551,13 @@ void DrawWeaponValues( OBJECTTYPE * gpItemDescObject )
 			FLOAT iFinalProjectionValue = 0;
 			BOOLEAN bNewCode = FALSE;
 
-			if ( GetBestLaserRange( gpItemDescObject ) > 0
-				&& (gGameCTHConstants.LASER_PERFORMANCE_BONUS_HIP + gGameCTHConstants.LASER_PERFORMANCE_BONUS_IRON + gGameCTHConstants.LASER_PERFORMANCE_BONUS_SCOPE != 0) )
+			if ( itemLaserRangeTiles > 0 &&
+				(gGameCTHConstants.LASER_PERFORMANCE_BONUS_HIP + gGameCTHConstants.LASER_PERFORMANCE_BONUS_IRON + gGameCTHConstants.LASER_PERFORMANCE_BONUS_SCOPE != 0) )
 			{
 				// Get base laser range
 				iProjectionValue = __max(0, Item[ gpItemDescObject->usItem ].bestlaserrange * gItemSettings.fBestLaserRangeModifier / CELL_X_SIZE);
 				// Get best laser range
-				iProjectionModifier = ((FLOAT)GetBestLaserRange( gpItemDescObject ) / CELL_X_SIZE);
+				iProjectionModifier = (FLOAT)itemLaserRangeTiles;
 				// Get final laser range
 				iFinalProjectionValue = __max( iProjectionValue, iProjectionModifier );
 				bNewCode = TRUE;
@@ -7609,7 +7615,7 @@ void DrawWeaponValues( OBJECTTYPE * gpItemDescObject )
 					// Get base laser range
 					iComparedProjectionValue = __max(0, Item[ gpComparedItemDescObject->usItem ].bestlaserrange * gItemSettings.fBestLaserRangeModifier / CELL_X_SIZE);
 					// Get best laser range
-					iComparedProjectionModifier = ((FLOAT)GetBestLaserRange( gpComparedItemDescObject ) / CELL_X_SIZE);
+					iComparedProjectionModifier = (FLOAT)comparedLaserRangeTiles;
 					// Get final laser range
 					iComparedFinalProjectionValue = __max( iComparedProjectionValue, iComparedProjectionModifier );
 				}
@@ -7632,7 +7638,7 @@ void DrawWeaponValues( OBJECTTYPE * gpItemDescObject )
 		}
 		else if( fComparisonMode && UsingNewCTHSystem() == true && 
 				( (Item[gpComparedItemDescObject->usItem].projectionfactor > 1.0 || GetProjectionFactor( gpComparedItemDescObject ) > 1.0) ||
-				( GetBestLaserRange( gpItemDescObject ) > 0
+				( itemLaserRangeTiles > 0
 				&& (gGameCTHConstants.LASER_PERFORMANCE_BONUS_HIP + gGameCTHConstants.LASER_PERFORMANCE_BONUS_IRON + gGameCTHConstants.LASER_PERFORMANCE_BONUS_SCOPE != 0) ) ) )
 		{
 			ubNumLine = 6;
@@ -7642,13 +7648,13 @@ void DrawWeaponValues( OBJECTTYPE * gpItemDescObject )
 			FLOAT iFinalProjectionValue = 0;
 			BOOLEAN bNewCode = FALSE;
 
-			if ( GetBestLaserRange( gpComparedItemDescObject ) > 0
+			if ( comparedLaserRangeTiles > 0
 				&& (gGameCTHConstants.LASER_PERFORMANCE_BONUS_HIP + gGameCTHConstants.LASER_PERFORMANCE_BONUS_IRON + gGameCTHConstants.LASER_PERFORMANCE_BONUS_SCOPE != 0) )
 			{
 				// Get base laser range
 				iProjectionValue = __max(0, Item[ gpComparedItemDescObject->usItem ].bestlaserrange * gItemSettings.fBestLaserRangeModifier / CELL_X_SIZE);
 				// Get best laser range
-				iProjectionModifier = ((FLOAT)GetBestLaserRange( gpComparedItemDescObject ) / CELL_X_SIZE);
+				iProjectionModifier = (FLOAT)comparedLaserRangeTiles;
 				// Get final laser range
 				iFinalProjectionValue = __max( iProjectionValue, iProjectionModifier );
 				bNewCode = TRUE;
@@ -7752,7 +7758,7 @@ void DrawWeaponValues( OBJECTTYPE * gpItemDescObject )
 		}
 
 		///////////////// OCTH BEST LASER RANGE
-		if ( !UsingNewCTHSystem() && GetBestLaserRange( gpItemDescObject ) > 0 )
+		if ( !UsingNewCTHSystem() && itemLaserRangeTiles > 0 )
 		{
 			// Set line to draw into
 			ubNumLine = 7;
@@ -7789,7 +7795,7 @@ void DrawWeaponValues( OBJECTTYPE * gpItemDescObject )
 				DrawPropertyValueInColour( iComparedFinalBestLaserRangeValue - iFinalBestLaserRangeValue, ubNumLine, 3, fComparisonMode, FALSE, TRUE );
 			}
 		}
-		else if( !UsingNewCTHSystem() && ( fComparisonMode && GetBestLaserRange( gpComparedItemDescObject ) > 0 ) )
+		else if( !UsingNewCTHSystem() && ( fComparisonMode && comparedLaserRangeTiles > 0 ) )
 		{
 			// Set line to draw into
 			ubNumLine = 7;
@@ -11366,14 +11372,16 @@ void DrawAdvancedValues( OBJECTTYPE *gpItemDescObject )
 		cnt++;
 	}
 
-	BOOLEAN bNewCode = FALSE;
 	///////////////////// PROJECTION FACTOR / BEST LASER RANGE
 	// with the reworked NCTH code and the laser performance factor we will display BestLaserRange instead of ProjectionFactor
-	if ( ( UsingNewCTHSystem() && ( GetBestLaserRange( gpItemDescObject ) > 0 || ( fComparisonMode && GetBestLaserRange( gpComparedItemDescObject ) > 0
+	BOOLEAN bNewCode = FALSE;
+	INT16 itemLaserRangeTiles = GetBestLaserRange(gpItemDescObject) / CELL_X_SIZE;
+	INT16 comparedLaserRangeTiles = fComparisonMode ? GetBestLaserRange(gpComparedItemDescObject) / CELL_X_SIZE : 0;
+	if ( ( UsingNewCTHSystem() && (itemLaserRangeTiles > 0 || ( fComparisonMode && comparedLaserRangeTiles > 0
 		&& (gGameCTHConstants.LASER_PERFORMANCE_BONUS_HIP + gGameCTHConstants.LASER_PERFORMANCE_BONUS_IRON + gGameCTHConstants.LASER_PERFORMANCE_BONUS_SCOPE != 0) ) ) )
-		|| ( !UsingNewCTHSystem() && ( GetBestLaserRange( gpItemDescObject ) > 0 || ( fComparisonMode && GetBestLaserRange( gpComparedItemDescObject ) > 0 ) ) ) )
+		|| ( !UsingNewCTHSystem() && (itemLaserRangeTiles > 0 || ( fComparisonMode && comparedLaserRangeTiles > 0 ) ) ) )
 	{
-		iFloatModifier[0] = ((FLOAT)GetBestLaserRange( gpItemDescObject ) / CELL_X_SIZE);
+		iFloatModifier[0] = (FLOAT)itemLaserRangeTiles;
 		bNewCode = TRUE;
 	}
 	else
@@ -11384,7 +11392,7 @@ void DrawAdvancedValues( OBJECTTYPE *gpItemDescObject )
 	if( fComparisonMode )
 	{
 		if ( bNewCode )
-			iComparedFloatModifier[0] = ((FLOAT)GetBestLaserRange( gpComparedItemDescObject ) / CELL_X_SIZE);
+			iComparedFloatModifier[0] = (FLOAT)comparedLaserRangeTiles;
 		else
 			iComparedFloatModifier[0] = GetProjectionFactor( gpComparedItemDescObject );
 		iComparedFloatModifier[1] = iComparedFloatModifier[0];

--- a/Tactical/Items.cpp
+++ b/Tactical/Items.cpp
@@ -14078,29 +14078,29 @@ INT16 GetFlatToHitBonus( OBJECTTYPE * pObj )
 // HEADROCK: Function to get average of all "best laser range" attributes from weapon and attachments
 INT16 GetAverageBestLaserRange( OBJECTTYPE * pObj )
 {
-	INT16 bonus=0;
+	FLOAT bonus = 0.0;
 	INT16 numModifiers=0;
 
 	if (Item[pObj->usItem].bestlaserrange > 0)
 	{
 		numModifiers++;
-		bonus += Item[pObj->usItem].bestlaserrange;
+		bonus += (FLOAT) Item[pObj->usItem].bestlaserrange;
 	}
 	for (attachmentList::iterator iter = (*pObj)[0]->attachments.begin(); iter != (*pObj)[0]->attachments.end(); ++iter)
 	{
 		if (Item[iter->usItem].bestlaserrange > 0 && iter->exists())
 		{
 			numModifiers++;
-			bonus += Item[iter->usItem].bestlaserrange;
+			bonus += (FLOAT) Item[iter->usItem].bestlaserrange;
 		}
 	}
 
-	if (numModifiers>0)
+	if (numModifiers > 1)
 	{
 		bonus = bonus / numModifiers;
 	}
 
-	return( bonus * gItemSettings.fBestLaserRangeModifier );
+	return (INT16)(bonus * gItemSettings.fBestLaserRangeModifier);
 }
 
 // get the best laser range from the weapon and attachments
@@ -14120,7 +14120,7 @@ INT16 GetBestLaserRange( OBJECTTYPE * pObj )
 		}
 	}
 
-	return( range * gItemSettings.fBestLaserRangeModifier );
+	return (INT16) ((FLOAT)range * gItemSettings.fBestLaserRangeModifier);
 }
 
 // HEADROCK: This function determines the bipod bonii of the gun or its attachments
@@ -15642,14 +15642,9 @@ BOOLEAN GetItemFromRandomItem( UINT16 usRandomItem, UINT16* pusNewItem )
 		// as it is also possible to reference to other random items, we also have to check for them
 
 		// clear the random item arrays and reset the counters
-		for ( int i = 0; i < RANDOM_ITEM_MAX_NUMBER; ++i)
-			randomitemarray[i] = 0;
-
-		for ( int i = 0; i < RANDOM_TABOO_MAX; ++i)
-		{
-			randomitemtabooarray[i] = 0;
-			randomitemclasstabooarray[i] = 0;
-		}
+		memset(randomitemarray, 0, sizeof(randomitemarray));
+		memset(randomitemtabooarray, 0, sizeof(randomitemtabooarray));
+		memset(randomitemclasstabooarray, 0, sizeof(randomitemclasstabooarray));
 
 		itemcnt = 0;
 		rdtaboocnt = 0;


### PR DESCRIPTION
* Tooltips were shifted by one position due to wrong handling "Accuracy modifier".

* DrawAdvancedValues(): if ( iFloatModifier[0] > 1.0 || ( fComparisonMode && iComparedFloatModifier[0] > 1.0 ) ) it checks number of laser range tiles  (iFloatModifier[0] > 1.0, "meters" / CELL_X_SIZE) right before actual drawing a line with values. So if someone put 1..9 into XML (<BestLaserRange>) it will not print that value. But number of "meters" was checked (like x > 0) everywhere prior to this code. so all the code before decided to draw line with icon for laser range, but the guilty code line didn't I suppose not to draw laser info at all if a modder screwed up <BestLaserRange> putting a 1..9 value so all values 0..9 basically mean 0 tiles, i.e. there is no laser ability.