### PR TITLE
Prevent illegal array access

### DIFF
--- a/FeaturesScreen.cpp
+++ b/FeaturesScreen.cpp
@@ -1517,7 +1517,7 @@ void HandleHighLightedText(BOOLEAN fHighLight)
 		bLastRegion = -1;
 	}
 
-	if (bHighLight != -1)
+	if (bHighLight != -1 && toggle_box_array[bHighLight] != -1)
 	{
 		if (bHighLight < OPT_FIRST_COLUMN_TOGGLE_CUT_OFF)
 		{


### PR DESCRIPTION
When using mousewheel to switch between pages in features screen, the HandleHighLightedText() function sometimes would retain valid bHighlight index, but toggle_box_array[bHighlight] == -1, which is used to access z113FeaturesToggleText[] and would later trigger Assertion in gprintfdirty() with pFontString == NULL