### PR TITLE
Fix message box text drawing in 720p when map inventory is up

### DIFF
--- a/Strategic/Map Screen Interface Bottom.cpp
+++ b/Strategic/Map Screen Interface Bottom.cpp
@@ -340,7 +340,7 @@ void RenderMapScreenInterfaceBottom( BOOLEAN fForceMapscreenFullRender )
 	// HEADROCK HAM 3.6: OK, let's always render this panel, as long as the team inventory screen isn't open.
 	// sevenfm: improved r8524 fix to work with 1280x720 resolution
 	//if (fMapScreenBottomDirty || ((!fShowInventoryFlag || iResolution > _1024x600) && fForceMapscreenFullRender))
-	if ((!fShowInventoryFlag || iResolution > _1280x720) && (fMapScreenBottomDirty || fForceMapscreenFullRender))
+	if ( (!fShowInventoryFlag || iResolution > _1024x600) && (fMapScreenBottomDirty || fForceMapscreenFullRender))
 	{
 		// get and blt panel
 		GetVideoObject(&hHandle, guiMAPBOTTOMPANEL );


### PR DESCRIPTION
Fixes #163 

Old 720p resolution had character inventory drawn over the message box so messages were hidden when inventory is up. New widescreen UI is similar to all the other higher resolutions where this is not the case anymore.