### PR TITLE
Update simultaneous combat check for group arrivals

### DIFF
--- a/Strategic/Strategic Movement.cpp
+++ b/Strategic/Strategic Movement.cpp
@@ -1895,8 +1895,9 @@ void GroupArrivedAtSector( UINT8 ubGroupID, BOOLEAN fCheckForBattle, BOOLEAN fNe
 
 	// if this group arrival would cause a simultaneous combat, then delay it!
 	// we can't have more that one battle at a time.
-	if( fExceptionQueue || (fCheckForBattle && (gTacticalStatus.fEnemyInSector || HostileCiviliansPresent() || HostileBloodcatsPresent())) // if there is an active battle
-		&& (pGroup->ubNextX != gWorldSectorX || pGroup->ubNextY != gWorldSectorY || gbWorldSectorZ > 0 ) // and the group is arriving at a sector
+	if( fExceptionQueue
+		|| ((fCheckForBattle && (gTacticalStatus.fEnemyInSector || HostileCiviliansPresent() || HostileBloodcatsPresent())) // if there is an active battle
+		&& (pGroup->ubNextX != gWorldSectorX || pGroup->ubNextY != gWorldSectorY || gbWorldSectorZ > 0)) // and the group is arriving at a different sector
 #ifndef JA2UB
 		|| AreInMeanwhile()
 #endif

--- a/Strategic/Strategic Movement.cpp
+++ b/Strategic/Strategic Movement.cpp
@@ -1892,47 +1892,47 @@ void GroupArrivedAtSector( UINT8 ubGroupID, BOOLEAN fCheckForBattle, BOOLEAN fNe
 			fExceptionQueue = TRUE;
 		}
 	}
-	//First check if the group arriving is going to queue another battle. //KM : Aug 11, 1999 -- Patch fix:	Added additional checks to prevent a 2nd battle in the case			
-	//NOTE:	We can't have more than one battle ongoing at a time.         //where the player is involved in a potential battle with bloodcats/civilians
-	if( fExceptionQueue || (fCheckForBattle && (gTacticalStatus.fEnemyInSector || HostileCiviliansPresent() || HostileBloodcatsPresent()) &&
-			FindMovementGroupInSector( (UINT8)gWorldSectorX, (UINT8)gWorldSectorY, OUR_TEAM ) &&
-		(pGroup->ubNextX != gWorldSectorX || pGroup->ubNextY != gWorldSectorY || gbWorldSectorZ > 0 ) && NumHostilesInSector(pGroup->ubNextX, pGroup->ubNextY, pGroup->ubSectorZ) > 0)
-		#ifdef JA2UB
-			//Ja25: NO meanwhiles		
-		#else
+
+	// if this group arrival would cause a simultaneous combat, then delay it!
+	// we can't have more that one battle at a time.
+	if( fExceptionQueue || (fCheckForBattle && (gTacticalStatus.fEnemyInSector || HostileCiviliansPresent() || HostileBloodcatsPresent())) // if there is an active battle
+		&& (pGroup->ubNextX != gWorldSectorX || pGroup->ubNextY != gWorldSectorY || gbWorldSectorZ > 0 ) // and the group is arriving at a sector
+#ifndef JA2UB
 		|| AreInMeanwhile()
-		#endif
+#endif
 		)
 	{
-		//QUEUE BATTLE!
-		//Delay arrival by a random value ranging from 3-5 minutes, so it doesn't get the player
-		//too suspicious after it happens to him a few times, which, by the way, is a rare occurrence.
-#ifdef JA2UB
-/*Ja25: No meanwhiles*/
-#else
-		if( AreInMeanwhile() )
+		if (((pGroup->usGroupTeam == OUR_TEAM || pGroup->usGroupTeam == MILITIA_TEAM) && NumHostilesInSector(pGroup->ubNextX, pGroup->ubNextY, pGroup->ubSectorZ) > 0) // if a friendly movement group will arrive at an enemy sector
+		|| (pGroup->usGroupTeam == ENEMY_TEAM && (NumPlayerTeamMembersInSector(pGroup->ubNextX, pGroup->ubNextY, pGroup->ubSectorZ) + NumNonPlayerTeamMembersInSector(pGroup->ubNextX, pGroup->ubNextY, MILITIA_TEAM) > 0))) // or an enemy movement group will arrive at a friendly sector
 		{
-			pGroup->uiArrivalTime ++; //tack on only 1 minute if we are in a meanwhile scene. This effectively
-									//prevents any battle from occurring while inside a meanwhile scene.
-		}
-		else
-#endif
-		{
-			pGroup->uiArrivalTime += Random(3) + 3;
-		}
-
-		if( !AddStrategicEvent( EVENT_GROUP_ARRIVAL, pGroup->uiArrivalTime, pGroup->ubGroupID ) )
-			AssertMsg( 0, "Failed to add movement event." );
-
-		if ( pGroup->usGroupTeam == OUR_TEAM )
-		{
-			if( pGroup->uiArrivalTime - ABOUT_TO_ARRIVE_DELAY > GetWorldTotalMin( ) )
+			//QUEUE BATTLE!
+			//Delay arrival by a random value ranging from 3-5 minutes, so it doesn't get the player
+			//too suspicious after it happens to him a few times, which, by the way, is a rare occurrence.
+#ifndef JA2UB
+			if( AreInMeanwhile() )
 			{
-				AddStrategicEvent( EVENT_GROUP_ABOUT_TO_ARRIVE, pGroup->uiArrivalTime - ABOUT_TO_ARRIVE_DELAY, pGroup->ubGroupID );
+				pGroup->uiArrivalTime ++; //tack on only 1 minute if we are in a meanwhile scene. This effectively
+										//prevents any battle from occurring while inside a meanwhile scene.
 			}
-		}
+			else
+#endif
+			{
+				pGroup->uiArrivalTime += Random(3) + 3;
+			}
 
-		return;
+			if( !AddStrategicEvent( EVENT_GROUP_ARRIVAL, pGroup->uiArrivalTime, pGroup->ubGroupID ) )
+				AssertMsg( 0, "Failed to add movement event." );
+
+			if ( pGroup->usGroupTeam == OUR_TEAM )
+			{
+				if( pGroup->uiArrivalTime - ABOUT_TO_ARRIVE_DELAY > GetWorldTotalMin( ) )
+				{
+					AddStrategicEvent( EVENT_GROUP_ABOUT_TO_ARRIVE, pGroup->uiArrivalTime - ABOUT_TO_ARRIVE_DELAY, pGroup->ubGroupID );
+				}
+			}
+
+			return;
+		}
 	}
 	
 	//Update the position of the group


### PR DESCRIPTION
The previous check didn't take group team into account, so it was possible for a simultaneous battle to be triggered by an enemy group moving into a friendly sector