### PR TITLE
Add support for AddressSanitizer instrumentation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,12 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+option(ADDRESS_SANITIZER OFF)
+if(ADDRESS_SANITIZER)
+	message(STATUS "AddressSanitizer ENABLED for non-Release builds")
+	add_compile_options($<IF:$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>,-fsanitize=address,>)
+endif()
+
 # whether we are using MSBuild as a generator
 set(usingMsBuild $<STREQUAL:${CMAKE_VS_PLATFORM_NAME},Win32>)
 


### PR DESCRIPTION
To use, just set `ADDRESS_SANITIZER` to `ON` on the command-line or your CMakeUserPresets.json file