### PR TITLE
 Aiming related deadlock fixes

### DIFF
--- a/Tactical/Handle Items.cpp
+++ b/Tactical/Handle Items.cpp
@@ -279,7 +279,8 @@ INT32 HandleItem( SOLDIERTYPE *pSoldier, INT32 sGridNo, INT8 bLevel, UINT16 usHa
 	{
 		pTargetSoldier = MercPtrs[ usSoldierIndex ];
 
-		if ( fFromUI )
+		// anv: don't try to heal interactive spots
+		if (fFromUI && Item[usHandItem].usItemClass != IC_MEDKIT)
 		{
 			INT32 sInteractiveGridNo;
 
@@ -325,6 +326,13 @@ INT32 HandleItem( SOLDIERTYPE *pSoldier, INT32 sGridNo, INT8 bLevel, UINT16 usHa
 	{
 		if (pTargetSoldier->bTeam == gbPlayerNum || pTargetSoldier->aiData.bNeutral)
 		{
+			// anv: don't try to attack yourself, it will only cause deadlock
+			if (pSoldier == pTargetSoldier)
+			{
+				TacticalCharacterDialogue(pSoldier, QUOTE_REFUSING_ORDER);
+				return(ITEM_HANDLE_REFUSAL);
+			}
+
 			// nice mercs won't shoot other nice guys or neutral civilians
 			if ((gMercProfiles[pSoldier->ubProfile].ubMiscFlags3 & PROFILE_MISC_FLAG3_GOODGUY) &&
 				((pTargetSoldier->ubProfile == NO_PROFILE && pTargetSoldier->aiData.bNeutral && pTargetSoldier->ubBodyType != CROW) ||


### PR DESCRIPTION
Self-healing when near doors can cause either deadlocks or random movement orders due to interactive spots taking priority over soldiers but not being viable heal targets.
Self-attacking was also possible leading to deadlock.

Deadlock on self-heal in this position
![deadlock](https://github.com/1dot13/source/assets/13915300/f34251a3-3cc2-4d17-a845-84399c5643aa)
Unexpected movement instead of self-heal in this position
![movement](https://github.com/1dot13/source/assets/13915300/b7bd9182-ebf9-4212-9157-1ff82fa50cdb)
Deadlock on self-attack
![deadlock_selfattack](https://github.com/1dot13/source/assets/13915300/3110c558-ee09-45c3-b6c4-61e1be555ccb)

Related to https://github.com/1dot13/source/commit/0ccecc472c060acd12e4f491f6958b29445c6a4