### PR TITLE
Vehicle group fixes

### DIFF
--- a/Strategic/Map Screen Interface.cpp
+++ b/Strategic/Map Screen Interface.cpp
@@ -4582,6 +4582,28 @@ void HandleSettingTheSelectedListOfMercs( void )
 		INT8 pbErrorNumber = -1;
 		pSoldier = MercPtrs[gCharactersList[GetSelectedDestChar()].usSolID];
 		INT8 bSquadValue = pSoldier->bAssignment;
+		if (bSquadValue == VEHICLE)
+		{
+			for (INT8 bCounter = 0; bCounter < NUMBER_OF_SQUADS; ++bCounter)
+			{
+				if (Squad[bCounter][0] != NULL && IsVehicle(Squad[bCounter][0]) &&
+					Squad[bCounter][0]->bVehicleID == pSoldier->iVehicleId)
+				{
+					bSquadValue = bCounter;
+					break;
+				}
+			}
+		}
+		if (bSquadValue >= NUMBER_OF_SQUADS)
+		{
+			if (pbErrorNumber != -1)
+			{
+				ReportMapScreenMovementError(pbErrorNumber);
+			}
+			SetSelectedDestChar(-1);
+			giDestHighLine = -1;
+			return;
+		}
 
 		// find number of characters in particular squad.
 		for (INT8 bCounter = 0; bCounter < NUMBER_OF_SOLDIERS_PER_SQUAD; ++bCounter)
@@ -4693,17 +4715,21 @@ INT8 FindSquadThatSoldierCanJoin( SOLDIERTYPE *pSoldier )
 	// run through the list of squads
 	for( bCounter = 0; bCounter < NUMBER_OF_SQUADS; bCounter++ )
 	{
-		// is this squad in this sector
-		if( IsThisSquadInThisSector( pSoldier->sSectorX, pSoldier->sSectorY, pSoldier->bSectorZ, bCounter ) )
+		// anv: don't automatically put people in vehicle squads
+		if (Squad[bCounter][0] == NULL || !IsVehicle(Squad[bCounter][0]))
 		{
-			// does it have room?
-			if( IsThisSquadFull( bCounter ) == FALSE )
+			// is this squad in this sector
+			if (IsThisSquadInThisSector(pSoldier->sSectorX, pSoldier->sSectorY, pSoldier->bSectorZ, bCounter))
 			{
-				// is it doing the same thing as the soldier is (staying or going) ?
-				if( IsSquadSelectedForMovement( bCounter ) == IsSoldierSelectedForMovement( pSoldier ) )
+				// does it have room?
+				if (IsThisSquadFull(bCounter) == FALSE)
 				{
-					// go ourselves a match, then
-					return( bCounter );
+					// is it doing the same thing as the soldier is (staying or going) ?
+					if (IsSquadSelectedForMovement(bCounter) == IsSoldierSelectedForMovement(pSoldier))
+					{
+						// go ourselves a match, then
+						return(bCounter);
+					}
 				}
 			}
 		}

--- a/Tactical/Squads.cpp
+++ b/Tactical/Squads.cpp
@@ -1700,7 +1700,20 @@ void CheckSquadMovementGroups( void )
 		for (INT8 iSoldier = 0; iSoldier < NUMBER_OF_SOLDIERS_PER_SQUAD; iSoldier++) {
 			if (Squad[iSquad][iSoldier] != NULL)
 			{
-				Squad[iSquad][iSoldier]->ubGroupID = pGroup->ubGroupID;
+				if (IsVehicle(Squad[iSquad][iSoldier]))
+				{
+					INT32 iCounter = 0;
+					for (iCounter = 0; iCounter < ubNumberOfVehicles; iCounter++)
+					{
+						if (pVehicleList[iCounter].ubProfileID == Squad[iSquad][iSoldier]->ubProfile)
+							break;
+					}
+					Squad[iSquad][iSoldier]->ubGroupID = pVehicleList[iCounter].ubMovementGroup;
+				}
+				else
+				{
+					Squad[iSquad][iSoldier]->ubGroupID = pGroup->ubGroupID;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
CheckSquadMovementGroups called after load was forcing vehicles to use ubGroupID from Squad instead of correct ubMovementGroup from pVehicleList. 
Issue: https://github.com/1dot13/source/issues/91

There was another semi-related error with using VEHICLE assignment directly as a squad index causing out of range issue when plotting vehicle movement on the map screen.
It was also possible to duplicate squad assignments when unassigning mercs from a vehicle by unselecting them before movement in the movement plot flow due to automatic squad assignments putting them in the same squad they were supposed to be removed from.