### PR TITLE
Vehicles cancelled movement fuel fix

### DIFF
--- a/Strategic/Strategic Movement.cpp
+++ b/Strategic/Strategic Movement.cpp
@@ -1951,33 +1951,33 @@ void GroupArrivedAtSector( UINT8 ubGroupID, BOOLEAN fCheckForBattle, BOOLEAN fNe
 			SectorInfo[SECTOR( pGroup->ubSectorX, pGroup->ubSectorY )].bLastKnownEnemies = NumNonPlayerTeamMembersInSector( pGroup->ubSectorX, pGroup->ubSectorY, ENEMY_TEAM );
 		}
 
-		// award life 'experience' for travelling, based on travel time!
-		if ( !pGroup->fVehicle )
+		// Flugente: do not award experience gain if we never left
+		if (!fNeverLeft)
 		{
-			// Flugente: do not award experience gain if we never left
-			if ( !fNeverLeft )
+			// award life 'experience' for travelling, based on travel time!
+			if (!pGroup->fVehicle)
 			{
 				// gotta be walking to get tougher
-				AwardExperienceForTravelling( pGroup );
+				AwardExperienceForTravelling(pGroup);
 			}
-		}
-		else if( !IsGroupTheHelicopterGroup( pGroup ) )
-		{
-			SOLDIERTYPE *pSoldier;
-			INT32 iVehicleID;
-			iVehicleID = GivenMvtGroupIdFindVehicleId( pGroup->ubGroupID );
-			AssertMsg( iVehicleID != -1, "GroupArrival for vehicle group. Invalid iVehicleID. " );
-
-			pSoldier = GetSoldierStructureForVehicle( iVehicleID );
-			AssertMsg( pSoldier, "GroupArrival for vehicle group. Invalid soldier pointer." );
-
-			SpendVehicleFuel( pSoldier, (INT16)(pGroup->uiTraverseTime*6) );
-
-			if( !VehicleFuelRemaining( pSoldier ) )
+			else if (!IsGroupTheHelicopterGroup(pGroup))
 			{
-				ReportVehicleOutOfGas( iVehicleID, pGroup->ubSectorX, pGroup->ubSectorY );
-				//Nuke the group's path, so they don't continue moving.
-				ClearMercPathsAndWaypointsForAllInGroup( pGroup );
+				SOLDIERTYPE* pSoldier;
+				INT32 iVehicleID;
+				iVehicleID = GivenMvtGroupIdFindVehicleId(pGroup->ubGroupID);
+				AssertMsg(iVehicleID != -1, "GroupArrival for vehicle group. Invalid iVehicleID. ");
+
+				pSoldier = GetSoldierStructureForVehicle(iVehicleID);
+				AssertMsg(pSoldier, "GroupArrival for vehicle group. Invalid soldier pointer.");
+
+				SpendVehicleFuel(pSoldier, (INT16)(pGroup->uiTraverseTime * 6));
+
+				if (!VehicleFuelRemaining(pSoldier))
+				{
+					ReportVehicleOutOfGas(iVehicleID, pGroup->ubSectorX, pGroup->ubSectorY);
+					//Nuke the group's path, so they don't continue moving.
+					ClearMercPathsAndWaypointsForAllInGroup(pGroup);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
It's possible to empty a vehicle's gas tank by planning and cancelling movement immediately even without unpausing the game. The "never left" check was not applied to vehicle movement groups resulting in fuel being consumed on "arrival" in the same sector. With check applied, fuel will be only consumed if any time elapsed.

STR:
1. Plan a movement with a vehicle to another sector and confirm it.
2. Cancel the planned movement without unpausing the game.
3. Notice that passengers are instantly back in the sector and available for another assignment yet fuel bar is down.
4. This can be repeated infinitely until all fuel is gone.