### PR TITLE
Face gear offset fix

### DIFF
--- a/Tactical/Faces.cpp
+++ b/Tactical/Faces.cpp
@@ -1467,8 +1467,8 @@ void GetXYForRightIconPlacement_FaceGera( FACETYPE *pFace, UINT16 ubIndex, INT16
 	usHeight				= pTrav->usHeight;
 	usWidth					= pTrav->usWidth;
 
-	sX = sFaceX + ( usWidth * bNumIcons ) + 1;
-	sY = sFaceY + pFace->usFaceHeight - usHeight - 1;
+	sX = sFaceX + ( usWidth * bNumIcons );
+	sY = sFaceY + pFace->usFaceHeight - usHeight;
 
 	*psX = sX;
 	*psY = sY;


### PR DESCRIPTION
Face gear (with TOPTION_SHOW_TACTICAL_FACE_GEAR) was offset by one in X and Y compared to the face, probably due to copypasta from portrait icons, causing rendered assets to be shifted and cut off. Most noticeable on gas masks. "GetXYForRightIconPlacement_FaceGera" is only used for face gear, so this offset can be safely removed.

Before:
![facegear_before](https://github.com/1dot13/source/assets/13915300/727810cd-3003-4515-b094-935492500674)
After:
![facegear_after](https://github.com/1dot13/source/assets/13915300/3180fcc7-2518-47af-bf64-3ac894c21961)

