### PR TITLE
Fix bug in OCTH prone CTH calculation (by Seven)

### DIFF
--- a/Tactical/Weapons.cpp
+++ b/Tactical/Weapons.cpp
@@ -7480,7 +7480,7 @@ UINT32 CalcChanceToHitGun(SOLDIERTYPE *pSoldier, INT32 sGridNo, INT16 ubAimTime,
 	else
 	{
 		INT16 moda = GetToHitBonus(pInHand, iRange, bLightLevel, stance && iRange > MIN_PRONE_RANGE);
-		INT16 modb = GetToHitBonus(pInHand, iRange, bLightLevel, gAnimControl[pSoldier->usAnimState].ubEndHeight && iRange > MIN_PRONE_RANGE);
+		INT16 modb = GetToHitBonus(pInHand, iRange, bLightLevel, gAnimControl[pSoldier->usAnimState].ubEndHeight == ANIM_PRONE && iRange > MIN_PRONE_RANGE);
 		iChance += (INT32)((gGameExternalOptions.ubProneModifierPercentage * moda + (100 - gGameExternalOptions.ubProneModifierPercentage) * modb) / 100);
 	}
 


### PR DESCRIPTION
GetToHitBonus() expects BOOLEAN for fProneStance argument, with no comparison to ANIM_PRONE, the ubEndHeight ended up adding bipod bonuses to *all* stances