### PR TITLE
Collapsed movement deadlock and crash fix

### DIFF
--- a/Tactical/Points.cpp
+++ b/Tactical/Points.cpp
@@ -3214,7 +3214,7 @@ BOOLEAN CheckForMercContMove( SOLDIERTYPE *pSoldier )
 		return( FALSE );
 	}
 
-	if( pSoldier->stats.bLife >= OKLIFE )
+	if( pSoldier->stats.bLife >= OKLIFE && !(pSoldier->bCollapsed && pSoldier->bBreath < OKBREATH) )
 	{
 		if( pSoldier->sGridNo != pSoldier->pathing.sFinalDestination || pSoldier->bGoodContPath	)
 		{

--- a/Tactical/Soldier Control.cpp
+++ b/Tactical/Soldier Control.cpp
@@ -21837,6 +21837,8 @@ void SoldierCollapse( SOLDIERTYPE *pSoldier )
 
 	pSoldier->bCollapsed = TRUE;
 
+	pSoldier->usUIMovementMode = CRAWLING;
+
 	pSoldier->ReceivingSoldierCancelServices( );
 
 	// CC has requested - handle sight here...


### PR DESCRIPTION
STR:
1. Enter turn-based combat.
2. Run around until you run out of energy and collapse mid-movement.
3. Notice that cursor is set to run mode even though merc is prone.
4. Trying to run or continuing interrupted movement without manually switching to crawl at this point while cause dead lock.
5. Switching to crawl movement mode and trying to move while still out of energy will cause failed movement animation, but save a new movement plan for that merc. Trying to continue this new movement will cause crash on the second try.

Solution: switch movement mode to crawl on collapse. Check collapsed state and energy before continuing movement.

[ReproSaves.zip](https://github.com/1dot13/source/files/12784333/ReproSaves.zip)
