### PR TITLE
Reduce code duplication

### DIFF
--- a/Multiplayer/client.cpp
+++ b/Multiplayer/client.cpp
@@ -815,10 +815,8 @@ void recievePATH(RPCParameters *rpcParameters)
 	SendGetNewSoldierPathEvent( pSoldier, SNetPath->sDestGridNo, SNetPath->ubNewState );	
 
 	INT16 sCellX, sCellY;	
-	
-	sCellX = CenterX( SNetPath->sAtGridNo );
-	sCellY = CenterY( SNetPath->sAtGridNo );
-	
+	ConvertGridNoToCenterCellXY(SNetPath->sAtGridNo, &sCellX, &sCellY);
+
 	if (( gAnimControl[ pSoldier->usAnimState ].uiFlags & ( ANIM_MOVING | ANIM_SPECIALMOVE ) ) && !(pSoldier->flags.fNoAPToFinishMove ) )
 	{
 	}
@@ -4251,8 +4249,7 @@ void UpdateSoldierFromNetwork  (RPCParameters *rpcParameters)
 	pSoldier->stats.bLife=SUpdateNetworkSoldier->bLife;
 
 	INT16  sCellX, sCellY;
-	sCellX = CenterX( SUpdateNetworkSoldier->sAtGridNo );
-	sCellY = CenterY( SUpdateNetworkSoldier->sAtGridNo );	
+	ConvertGridNoToCenterCellXY(SUpdateNetworkSoldier->sAtGridNo, &sCellX, &sCellY);
 
 	if( pSoldier->sGridNo != SUpdateNetworkSoldier->sAtGridNo)
 	{

--- a/Strategic/Strategic Movement.cpp
+++ b/Strategic/Strategic Movement.cpp
@@ -1757,30 +1757,30 @@ void AddCorpsesToBloodcatLair( INT16 sSectorX, INT16 sSectorY )
 	Corpse.usFlags = ROTTING_CORPSE_FIND_SWEETSPOT_FROM_GRIDNO;
 
 	// 1st gridno
-	Corpse.sGridNo								= 14319; //dnl!!!
-	ConvertGridNoToXY( Corpse.sGridNo, &sXPos, &sYPos );
-	Corpse.dXPos									= (FLOAT)( CenterX( sXPos ) );
-	Corpse.dYPos									= (FLOAT)( CenterY( sYPos ) );
+	Corpse.sGridNo = 14319; //dnl!!!
+	ConvertGridNoToCenterCellXY(Corpse.sGridNo, &sXPos, &sYPos);
+	Corpse.dXPos = (FLOAT)( sXPos );
+	Corpse.dYPos = (FLOAT)( sYPos );
 
 	//Add the rotting corpse info to the sectors unloaded rotting corpse file
 	AddRottingCorpseToUnloadedSectorsRottingCorpseFile( sSectorX, sSectorY, 0, &Corpse);
 
 
 	// 2nd gridno
-	Corpse.sGridNo								= 9835; //dnl!!!
-	ConvertGridNoToXY( Corpse.sGridNo, &sXPos, &sYPos );
-	Corpse.dXPos									= (FLOAT)( CenterX( sXPos ) );
-	Corpse.dYPos									= (FLOAT)( CenterY( sYPos ) );
+	Corpse.sGridNo = 9835; //dnl!!!
+	ConvertGridNoToCenterCellXY(Corpse.sGridNo, &sXPos, &sYPos);
+	Corpse.dXPos = (FLOAT)(sXPos);
+	Corpse.dYPos = (FLOAT)(sYPos);
 
 	//Add the rotting corpse info to the sectors unloaded rotting corpse file
 	AddRottingCorpseToUnloadedSectorsRottingCorpseFile( sSectorX, sSectorY, 0, &Corpse);
 
 
 	// 3rd gridno
-	Corpse.sGridNo								= 11262; //dnl!!!
-	ConvertGridNoToXY( Corpse.sGridNo, &sXPos, &sYPos );
-	Corpse.dXPos									= (FLOAT)( CenterX( sXPos ) );
-	Corpse.dYPos									= (FLOAT)( CenterY( sYPos ) );
+	Corpse.sGridNo = 11262; //dnl!!!
+	ConvertGridNoToCenterCellXY(Corpse.sGridNo, &sXPos, &sYPos);
+	Corpse.dXPos = (FLOAT)(sXPos);
+	Corpse.dYPos = (FLOAT)(sYPos);
 
 	//Add the rotting corpse info to the sectors unloaded rotting corpse file
 	AddRottingCorpseToUnloadedSectorsRottingCorpseFile( sSectorX, sSectorY, 0, &Corpse);

--- a/Strategic/strategicmap.cpp
+++ b/Strategic/strategicmap.cpp
@@ -4773,8 +4773,8 @@ void DoneFadeOutAdjacentSector( )
 						curr->pSoldier->ubWaitActionToDo = 1;
 						// OK, here we have been given a position, a gridno has been given to use as well....
 						sOldGridNo = curr->pSoldier->sGridNo;
-						sWorldX = CenterX( sGridNo );
-						sWorldY = CenterY( sGridNo );
+						ConvertGridNoToCenterCellXY(sGridNo, &sWorldX, &sWorldY);
+
 						curr->pSoldier->EVENT_SetSoldierPosition( sWorldX, sWorldY );
 						if ( sGridNo != sOldGridNo )
 						{

--- a/Tactical/Air Raid.cpp
+++ b/Tactical/Air Raid.cpp
@@ -352,9 +352,8 @@ INT32 PickRandomLocationAtMinSpacesAway( INT32 sGridNo, INT16 sMinValue, INT16 s
 
 	DebugMsg(TOPIC_JA2,DBG_LEVEL_3,"PickRandomLocationAtMinSpacesAway");
 
-	sX = CenterX( sGridNo );
-	sY = CenterY( sGridNo );
-	
+	ConvertGridNoToCenterCellXY(sGridNo, &sX, &sY);
+
 	while(TileIsOutOfBounds(sNewGridNo))
 	{
 		sNewX = sX + sMinValue + (INT16)Random( sRandomVar );
@@ -596,8 +595,7 @@ void BeginBombing( )
 	sGridNo = PickRandomLocationAtMinSpacesAway( gsDiveTargetLocation , 300, 200 );
 
 	// Save X, y:
-	gsDiveX = CenterX( sGridNo );
-	gsDiveY = CenterY( sGridNo );
+	ConvertGridNoToCenterCellXY(sGridNo, &gsDiveX, &gsDiveY);
 
 	RESETTIMECOUNTER( giTimerAirRaidUpdate, RAID_DELAY );
 
@@ -657,8 +655,7 @@ void BeginDive( )
 	sGridNo = PickRandomLocationAtMinSpacesAway( gsDiveTargetLocation, 300, 200 );
 
 	// Save X, y:
-	gsDiveX = CenterX( sGridNo );
-	gsDiveY = CenterY( sGridNo );
+	ConvertGridNoToCenterCellXY(sGridNo, &gsDiveX, &gsDiveY);
 
 	RESETTIMECOUNTER( giTimerAirRaidUpdate, RAID_DELAY );
 	giNumTurnsSinceDiveStarted = 0;
@@ -760,8 +757,7 @@ void DoDive(	)
 
 			DebugMsg(TOPIC_JA2,DBG_LEVEL_3,"DoDive: move towards target");
 			// Move Towards target....
-			sTargetX = CenterX( gsDiveTargetLocation );
-			sTargetY = CenterY( gsDiveTargetLocation );
+			ConvertGridNoToCenterCellXY(gsDiveTargetLocation, &sTargetX, &sTargetY);
 
 			// Determine deltas
 			dDeltaX = (FLOAT)( sTargetX - gsDiveX );
@@ -886,7 +882,7 @@ void DoBombing(	)
 	INT16		sRange;
 	INT32		sGridNo, sOldGridNo, sBombGridNo;
 
-	INT16		sTargetX, sTargetY;
+	INT16		sTargetX, sTargetY, sBombX, sBombY;
 	UINT16	usItem;
 	INT16		sStrafeX, sStrafeY;
 	FLOAT		dDeltaX, dDeltaY, dAngle, dDeltaXPos, dDeltaYPos;
@@ -933,8 +929,7 @@ void DoBombing(	)
 			RESETTIMECOUNTER( giTimerAirRaidUpdate, RAID_DELAY );
 
 			// Move Towards target....
-			sTargetX = CenterX( gsDiveTargetLocation );
-			sTargetY = CenterY( gsDiveTargetLocation );
+			ConvertGridNoToCenterCellXY(gsDiveTargetLocation, &sTargetX, &sTargetY);
 
 			// Determine deltas
 			dDeltaX = (FLOAT)( sTargetX - gsDiveX );
@@ -1002,7 +997,8 @@ void DoBombing(	)
 						}
 
 						// Drop bombs...
-						InternalIgniteExplosion( NOBODY, CenterX( sBombGridNo ), CenterY( sBombGridNo ), 0, sBombGridNo, usItem, fLocate , (UINT8)IsRoofPresentAtGridNo( sBombGridNo ) );
+						ConvertGridNoToCenterCellXY(sBombGridNo, &sBombX, &sBombY);
+						InternalIgniteExplosion( NOBODY, sBombX, sBombY, 0, sBombGridNo, usItem, fLocate , (UINT8)IsRoofPresentAtGridNo( sBombGridNo ) );
 
 					}
 

--- a/Tactical/Handle Items.cpp
+++ b/Tactical/Handle Items.cpp
@@ -5919,8 +5919,7 @@ void SetOffBoobyTrap( ITEM_POOL * pItemPool )
 	if ( pItemPool )
 	{
 		INT16 sX, sY;
-		sX = CenterX( pItemPool->sGridNo );
-		sY = CenterY( pItemPool->sGridNo );
+		ConvertGridNoToCenterCellXY(pItemPool->sGridNo, &sX, &sY);
 		IgniteExplosion( NOBODY, sX, sY, (INT16) (gpWorldLevelData[pItemPool->sGridNo].sHeight + pItemPool->bRenderZHeightAboveLevel), pItemPool->sGridNo, MINI_GRENADE, 0 );
 		RemoveItemFromPool( pItemPool->sGridNo, pItemPool->iItemIndex, pItemPool->ubLevel );
 	}

--- a/Tactical/Handle Items.cpp
+++ b/Tactical/Handle Items.cpp
@@ -2187,7 +2187,7 @@ void HandleSoldierThrowItem( SOLDIERTYPE *pSoldier, INT32 sGridNo )
 					pSoldier->usPendingAnimation = LOB_ITEM;
 			}
 			// Draw item depending on distance from buddy
-			else if ( GetRangeFromGridNoDiff( sGridNo, pSoldier->sGridNo ) < MIN_LOB_RANGE )
+			else if (PythSpacesAway( sGridNo, pSoldier->sGridNo ) < MIN_LOB_RANGE )
 			{
 				//ddd maybe need to add check for throwing item class - grenade
 				if( (pSoldier->pThrowParams->ubActionCode == THROW_ARM_ITEM) && 

--- a/Tactical/Handle UI.cpp
+++ b/Tactical/Handle UI.cpp
@@ -5619,7 +5619,7 @@ UINT32 UIHandleTOnTerrain( UI_EVENT *pUIEvent )
 		sTargetGridNo = MercPtrs[ ubTargID ]->sGridNo;
 	}
 
-	uiRange = GetRangeFromGridNoDiff( pSoldier->sGridNo, sTargetGridNo );
+	uiRange = PythSpacesAway( pSoldier->sGridNo, sTargetGridNo );
 
 
 	if ( uiRange <= NPC_TALK_RADIUS )
@@ -6610,7 +6610,7 @@ BOOLEAN HandleTalkInit(	)
 			}
 
 			// Check distance
-			uiRange = GetRangeFromGridNoDiff( pSoldier->sGridNo, usMapPos );
+			uiRange = PythSpacesAway( pSoldier->sGridNo, usMapPos );
 
 			// Double check path
 			if ( GetCivType( pTSoldier ) != CIV_TYPE_NA )

--- a/Tactical/Interface Dialogue.cpp
+++ b/Tactical/Interface Dialogue.cpp
@@ -1827,7 +1827,7 @@ void HandleNPCDoAction( UINT8 ubTargetNPC, UINT16 usActionCode, UINT8 ubQuoteNum
 	EXITGRID								ExitGrid;
 	INT32 iRandom = 0;
 	UINT8										ubMineIndex;
-
+	INT16 sX, sY, sX2, sY2;
 
 	pSoldier2 = NULL;
 	//ScreenMsg( FONT_MCOLOR_LTYELLOW, MSG_INTERFACE, L"Handling %s, action %d at %ld", gMercProfiles[ ubTargetNPC ].zNickname, usActionCode, GetJA2Clock() );
@@ -1840,7 +1840,9 @@ void HandleNPCDoAction( UINT8 ubTargetNPC, UINT16 usActionCode, UINT8 ubQuoteNum
 		if (pSoldier && pSoldier2)
 		{
 			// see if we are facing this person
-			ubDesiredMercDir = atan8(CenterX(pSoldier->sGridNo),CenterY(pSoldier->sGridNo),CenterX(pSoldier2->sGridNo),CenterY(pSoldier2->sGridNo));
+			ConvertGridNoToCenterCellXY(pSoldier->sGridNo, &sX, &sY);
+			ConvertGridNoToCenterCellXY(pSoldier2->sGridNo, &sX2, &sY2);
+			ubDesiredMercDir = atan8(sX, sY, sX2, sY2);
 			// if not already facing in that direction,
 			if (pSoldier->ubDirection != ubDesiredMercDir)
 			{
@@ -2317,7 +2319,9 @@ void HandleNPCDoAction( UINT8 ubTargetNPC, UINT16 usActionCode, UINT8 ubQuoteNum
 					if (!TileIsOutOfBounds(sGridNo))
 					{
 						// see if we are facing this person
-						ubDesiredMercDir = atan8(CenterX(pSoldier->sGridNo),CenterY(pSoldier->sGridNo),CenterX(sGridNo),CenterY(sGridNo));
+						ConvertGridNoToCenterCellXY(pSoldier->sGridNo, &sX, &sY);
+						ConvertGridNoToCenterCellXY(sGridNo, &sX2, &sY2);
+						ubDesiredMercDir = atan8(sX, sY, sX2, sY2);
 						// if not already facing in that direction,
 						if (pSoldier->ubDirection != ubDesiredMercDir)
 						{

--- a/Tactical/Interface Dialogue.cpp
+++ b/Tactical/Interface Dialogue.cpp
@@ -5636,7 +5636,9 @@ void HandleRaulBlowingHimselfUp()
 
 		//blow himself up with, hmmm, lets say TNT.  :)
 		usItem = HAND_GRENADE;
-		IgniteExplosion( RAUL_UB, CenterX( pSoldier->sGridNo ), CenterY( pSoldier->sGridNo ), 0, pSoldier->sGridNo, usItem, pSoldier->pathing.bLevel );
+		INT16 sX, sY;
+		ConvertGridNoToCenterCellXY(pSoldier->sGridNo, &sX, &sY);
+		IgniteExplosion( RAUL_UB, sX, sY, 0, pSoldier->sGridNo, usItem, pSoldier->pathing.bLevel );
 
 		SetJa25GeneralFlag( JA_GF__RAUL_BLOW_HIMSELF_UP );
 	}

--- a/Tactical/Interface Items.cpp
+++ b/Tactical/Interface Items.cpp
@@ -9570,7 +9570,7 @@ BOOLEAN HandleItemPointerClick( INT32 usMapPos )
 BOOLEAN ItemCursorInLobRange( INT32 usMapPos )
 {
 	// Draw item depending on distance from buddy
-	if ( GetRangeFromGridNoDiff( usMapPos, gpItemPointerSoldier->sGridNo ) > MIN_LOB_RANGE )
+	if (PythSpacesAway( usMapPos, gpItemPointerSoldier->sGridNo ) > MIN_LOB_RANGE )
 	{
 		return( FALSE );
 	}

--- a/Tactical/Interface.cpp
+++ b/Tactical/Interface.cpp
@@ -2478,14 +2478,16 @@ BOOLEAN DrawCTHIndicator()
 
 	//////////////////////////////////
 	// Calculate Aperture
-
+	INT16 sX, sY;
 	// Calculate the center point of the shooter, in world coordinates.
-	FLOAT dStartX = (FLOAT) CenterX( gCTHDisplay.iShooterGridNo );
-	FLOAT dStartY = (FLOAT) CenterY( gCTHDisplay.iShooterGridNo );
+	ConvertGridNoToCenterCellXY(gCTHDisplay.iShooterGridNo, &sX, &sY);
+	FLOAT dStartX = (FLOAT) sX;
+	FLOAT dStartY = (FLOAT) sY;
 
 	// Calculate the center point of the target, in world coordinates.
-	FLOAT dEndX = (FLOAT) CenterX( gCTHDisplay.iTargetGridNo );
-	FLOAT dEndY = (FLOAT) CenterY( gCTHDisplay.iTargetGridNo );
+	ConvertGridNoToCenterCellXY(gCTHDisplay.iTargetGridNo, &sX, &sY);
+	FLOAT dEndX = (FLOAT) sX;
+	FLOAT dEndY = (FLOAT) sY;
 
 	// Calculate a delta: the difference between the shooter and target.
 	FLOAT dDeltaX = dEndX - dStartX;

--- a/Tactical/Items.cpp
+++ b/Tactical/Items.cpp
@@ -9262,13 +9262,16 @@ void CheckEquipmentForDamage( SOLDIERTYPE *pSoldier, INT32 iDamage )
 		if (fBlowsUp)
 		{
 			// blow it up!
+			INT16 sX, sY;
+			ConvertGridNoToCenterCellXY(pSoldier->sGridNo, &sX, &sY);
+
 			if ( gTacticalStatus.ubAttackBusyCount )
 			{
-				IgniteExplosion( pSoldier->ubAttackerID, CenterX( pSoldier->sGridNo ), CenterY( pSoldier->sGridNo ), 0, pSoldier->sGridNo, pSoldier->inv[ bSlot ].usItem, pSoldier->pathing.bLevel, pSoldier->ubDirection, &pSoldier->inv[ bSlot ] );
+				IgniteExplosion( pSoldier->ubAttackerID, sX, sY, 0, pSoldier->sGridNo, pSoldier->inv[ bSlot ].usItem, pSoldier->pathing.bLevel, pSoldier->ubDirection, &pSoldier->inv[ bSlot ] );
 			}
 			else
 			{
-				IgniteExplosion( pSoldier->ubID, CenterX( pSoldier->sGridNo ), CenterY( pSoldier->sGridNo ), 0, pSoldier->sGridNo, pSoldier->inv[ bSlot ].usItem, pSoldier->pathing.bLevel, pSoldier->ubDirection, &pSoldier->inv[ bSlot ] );
+				IgniteExplosion( pSoldier->ubID, sX, sY, 0, pSoldier->sGridNo, pSoldier->inv[ bSlot ].usItem, pSoldier->pathing.bLevel, pSoldier->ubDirection, &pSoldier->inv[ bSlot ] );
 			}
 
 			//ADB when something in a stack blows up the whole stack goes, so no need to worry about number of items
@@ -9333,7 +9336,9 @@ BOOLEAN DamageItemOnGround( OBJECTTYPE * pObject, INT32 sGridNo, INT8 bLevel, IN
 	if ( fBlowsUp )
 	{
 		// OK, Ignite this explosion!
-		IgniteExplosion( ubOwner, CenterX( sGridNo ), CenterY( sGridNo ), 0, sGridNo, pObject->usItem, bLevel, DIRECTION_IRRELEVANT, pObject );
+		INT16 sX, sY;
+		ConvertGridNoToCenterCellXY(sGridNo, &sX, &sY);
+		IgniteExplosion( ubOwner, sX, sY, 0, sGridNo, pObject->usItem, bLevel, DIRECTION_IRRELEVANT, pObject );
 
 		// SANDRO - merc records
 		if ( (pObject->fFlags & OBJECT_ARMED_BOMB) && ((*pObject)[0]->data.misc.ubBombOwner > 1) )

--- a/Tactical/Keys.cpp
+++ b/Tactical/Keys.cpp
@@ -669,7 +669,9 @@ void HandleDoorTrap( SOLDIERTYPE * pSoldier, DOOR * pDoor )
 	{
 		case EXPLOSION:
 			// cause damage as a regular hand grenade
-			IgniteExplosion( NOBODY, CenterX( pSoldier->sGridNo ), CenterY( pSoldier->sGridNo ), 25, pSoldier->sGridNo, HAND_GRENADE, 0 );
+			INT16 sX, sY;
+			ConvertGridNoToCenterCellXY(pSoldier->sGridNo, &sX, &sY);
+			IgniteExplosion( NOBODY, sX, sY, 25, pSoldier->sGridNo, HAND_GRENADE, 0 );
 			break;
 
  		case SIREN:
@@ -760,8 +762,7 @@ BOOLEAN AttemptToBlowUpLock(SOLDIERTYPE * pSoldier, DOOR * pDoor)
 		sGridNo = pDoor->sGridNo;
 
 		// Get sX, sy;
-		sX = CenterX(sGridNo);
-		sY = CenterY(sGridNo);
+		ConvertGridNoToCenterCellXY(sGridNo, &sX, &sY);
 
 		// Get Z position, based on orientation....
 		sZ = 20;

--- a/Tactical/Rotting Corpses.cpp
+++ b/Tactical/Rotting Corpses.cpp
@@ -561,10 +561,7 @@ INT32	AddRottingCorpse( ROTTING_CORPSE_DEFINITION *pCorpseDef )
 	}
 	else
 	{
-		INT16 sX, sY;
-		ConvertGridNoToCenterCellXY(pCorpse->def.sGridNo, &sX, &sY);
-		AniParams.sX = sX;
-		AniParams.sY = sY;
+		ConvertGridNoToCenterCellXY(pCorpse->def.sGridNo, &AniParams.sX, &AniParams.sY);
 	}
 		
 	AniParams.sZ									= (INT16)pCorpse->def.sHeightAdjustment;
@@ -1550,7 +1547,6 @@ void VaporizeCorpse( INT32 sGridNo, INT8 asLevel, UINT16 usStructureID )
 	ROTTING_CORPSE	*pCorpse = NULL;
 	INT32 sBaseGridNo;
 	ANITILE_PARAMS		AniParams;
-	INT16 sX, sY;
 
 	pStructure = FindStructureByID( sGridNo, usStructureID );
 
@@ -1591,9 +1587,7 @@ void VaporizeCorpse( INT32 sGridNo, INT8 asLevel, UINT16 usStructureID )
 		AniParams.sDelay = (INT16)( 80 );
 		AniParams.sStartFrame = 0;
 		AniParams.uiFlags = ANITILE_CACHEDTILE | ANITILE_FORWARD;
-		ConvertGridNoToCenterCellXY(sBaseGridNo, &sX, &sY);
-		AniParams.sX = sX;
-		AniParams.sY = sY;
+		ConvertGridNoToCenterCellXY(sBaseGridNo, &AniParams.sX, &AniParams.sY);
 		AniParams.sZ = (INT16)pCorpse->def.sHeightAdjustment;
 
 		strcpy( AniParams.zCachedFile, "TILECACHE\\GEN_BLOW.STI" );

--- a/Tactical/Rotting Corpses.cpp
+++ b/Tactical/Rotting Corpses.cpp
@@ -561,8 +561,10 @@ INT32	AddRottingCorpse( ROTTING_CORPSE_DEFINITION *pCorpseDef )
 	}
 	else
 	{
-		AniParams.sX = CenterX(pCorpse->def.sGridNo);
-		AniParams.sY = CenterY(pCorpse->def.sGridNo);
+		INT16 sX, sY;
+		ConvertGridNoToCenterCellXY(pCorpse->def.sGridNo, &sX, &sY);
+		AniParams.sX = sX;
+		AniParams.sY = sY;
 	}
 		
 	AniParams.sZ									= (INT16)pCorpse->def.sHeightAdjustment;
@@ -1548,6 +1550,7 @@ void VaporizeCorpse( INT32 sGridNo, INT8 asLevel, UINT16 usStructureID )
 	ROTTING_CORPSE	*pCorpse = NULL;
 	INT32 sBaseGridNo;
 	ANITILE_PARAMS		AniParams;
+	INT16 sX, sY;
 
 	pStructure = FindStructureByID( sGridNo, usStructureID );
 
@@ -1588,8 +1591,9 @@ void VaporizeCorpse( INT32 sGridNo, INT8 asLevel, UINT16 usStructureID )
 		AniParams.sDelay = (INT16)( 80 );
 		AniParams.sStartFrame = 0;
 		AniParams.uiFlags = ANITILE_CACHEDTILE | ANITILE_FORWARD;
-		AniParams.sX = CenterX( sBaseGridNo );
-		AniParams.sY = CenterY( sBaseGridNo );
+		ConvertGridNoToCenterCellXY(sBaseGridNo, &sX, &sY);
+		AniParams.sX = sX;
+		AniParams.sY = sY;
 		AniParams.sZ = (INT16)pCorpse->def.sHeightAdjustment;
 
 		strcpy( AniParams.zCachedFile, "TILECACHE\\GEN_BLOW.STI" );
@@ -2284,10 +2288,12 @@ BOOLEAN AddCorpseFromObject(OBJECTTYPE* pObj, INT32 sGridNo, INT8 bLevel )
 		Corpse.ubBodyType = REGMALE;
 	}
 
+	INT16 sX, sY;
+	ConvertGridNoToCenterCellXY(sGridNo, &sX, &sY);
+
 	Corpse.sGridNo = sGridNo;
-	
-	Corpse.dXPos = CenterX(Corpse.sGridNo);
-	Corpse.dYPos = CenterY(Corpse.sGridNo);
+	Corpse.dXPos = sX;
+	Corpse.dYPos = sY;
 
 	Corpse.sHeightAdjustment = 0;
 

--- a/Tactical/ShopKeeper Interface.cpp
+++ b/Tactical/ShopKeeper Interface.cpp
@@ -776,7 +776,7 @@ BOOLEAN EnterShopKeeperInterface()
 	else
 		pShopkeeper = FindSoldierByProfileID( armsDealerInfo[gbSelectedArmsDealerID].ubShopKeeperID, FALSE );
 
-	if ( GetRangeFromGridNoDiff( pSoldier->sGridNo, pShopkeeper->sGridNo ) > NPC_TALK_RADIUS )
+	if (PythSpacesAway( pSoldier->sGridNo, pShopkeeper->sGridNo ) > NPC_TALK_RADIUS )
 	{
 		//so now we know we are too far away to trade, so instead of just quitting,
 		//either post a message or run to the guy like HandleTalkInit does
@@ -6668,7 +6668,7 @@ BOOLEAN CanMercInteractWithSelectedShopkeeper( SOLDIERTYPE *pSoldier )
 		if ( SoldierTo3DLocationLineOfSightTest( pSoldier, sDestGridNo, bDestLevel, 3, TRUE, CALC_FROM_ALL_DIRS ) )
 		{
 			// Get range to shopkeeper
-			uiRange = GetRangeFromGridNoDiff( pSoldier->sGridNo, sDestGridNo );
+			uiRange = PythSpacesAway( pSoldier->sGridNo, sDestGridNo );
 
 			// and is close enough to talk to the shopkeeper (use this define INSTEAD of PASSING_ITEM_DISTANCE_OKLIFE!)
 			if ( uiRange <= NPC_TALK_RADIUS )

--- a/Tactical/Soldier Add.cpp
+++ b/Tactical/Soldier Add.cpp
@@ -1367,11 +1367,9 @@ void InternalSoldierInSectorSleep( SOLDIERTYPE *pSoldier, INT32 sGridNo, BOOLEAN
 	usAnim = STANDING;
 	}
 
-	// OK, look for sutable placement....
+	// OK, look for suitable placement....
 	sGoodGridNo = FindGridNoFromSweetSpotWithStructData( pSoldier, usAnim, sGridNo, 5, &ubNewDirection, FALSE );
-
-	sWorldX = CenterX( sGoodGridNo );
-	sWorldY = CenterY( sGoodGridNo );
+	ConvertGridNoToCenterCellXY(sGoodGridNo, &sWorldX, &sWorldY);
 
 	pSoldier->EVENT_SetSoldierPosition( sWorldX, sWorldY );
 
@@ -1408,11 +1406,9 @@ void SoldierInSectorIncompaciated( SOLDIERTYPE *pSoldier, INT32 sGridNo )
 		return;
 	}
 
-	// OK, look for sutable placement....
+	// OK, look for suitable placement....
 	sGoodGridNo = FindGridNoFromSweetSpotWithStructData( pSoldier, STAND_FALLFORWARD_STOP, sGridNo, 5, &ubNewDirection, FALSE );
-
-	sWorldX = CenterX( sGoodGridNo );
-	sWorldY = CenterY( sGoodGridNo );
+	ConvertGridNoToCenterCellXY(sGoodGridNo, &sWorldX, &sWorldY);
 
 	pSoldier->EVENT_SetSoldierPosition( sWorldX, sWorldY );
 
@@ -1444,11 +1440,9 @@ void SoldierInSectorPatient( SOLDIERTYPE *pSoldier, INT32 sGridNo )
 		return;
 	}
 
-	// OK, look for sutable placement....
+	// OK, look for suitable placement....
 	sGoodGridNo = FindGridNoFromSweetSpotWithStructData( pSoldier, BEING_PATIENT, sGridNo, 5, &ubNewDirection, FALSE );
-
-	sWorldX = CenterX( sGoodGridNo );
-	sWorldY = CenterY( sGoodGridNo );
+	ConvertGridNoToCenterCellXY(sGoodGridNo, &sWorldX, &sWorldY);
 
 	pSoldier->EVENT_SetSoldierPosition( sWorldX, sWorldY );
 
@@ -1479,11 +1473,9 @@ void SoldierInSectorDoctor( SOLDIERTYPE *pSoldier, INT32 sGridNo )
 		return;
 	}
 
-	// OK, look for sutable placement....
+	// OK, look for suitable placement....
 	sGoodGridNo = FindGridNoFromSweetSpotWithStructData( pSoldier, BEING_DOCTOR, sGridNo, 5, &ubNewDirection, FALSE );
-
-	sWorldX = CenterX( sGoodGridNo );
-	sWorldY = CenterY( sGoodGridNo );
+	ConvertGridNoToCenterCellXY(sGoodGridNo, &sWorldX, &sWorldY);
 
 	pSoldier->EVENT_SetSoldierPosition( sWorldX, sWorldY );
 
@@ -1514,11 +1506,9 @@ void SoldierInSectorRepair( SOLDIERTYPE *pSoldier, INT32 sGridNo )
 		return;
 	}
 
-	// OK, look for sutable placement....
+	// OK, look for suitable placement....
 	sGoodGridNo = FindGridNoFromSweetSpotWithStructData( pSoldier, BEING_REPAIRMAN, sGridNo, 5, &ubNewDirection, FALSE );
-
-	sWorldX = CenterX( sGoodGridNo );
-	sWorldY = CenterY( sGoodGridNo );
+	ConvertGridNoToCenterCellXY(sGoodGridNo, &sWorldX, &sWorldY);
 
 	pSoldier->EVENT_SetSoldierPosition( sWorldX, sWorldY );
 
@@ -1550,8 +1540,7 @@ void AddSoldierToSectorGridNo( SOLDIERTYPE *pSoldier, INT32 sGridNo, UINT8 ubDir
 	DebugMsg(TOPIC_JA2,DBG_LEVEL_3,String("AddSoldierToSectorGridNo"));
 
 	// Add merc to gridno
-	sWorldX = CenterX( sGridNo );
-	sWorldY = CenterY( sGridNo );
+	ConvertGridNoToCenterCellXY(sGridNo, &sWorldX, &sWorldY);
 
 	// Set reserved location!
 	pSoldier->sReservedMovementGridNo = NOWHERE;

--- a/Tactical/Soldier Ani.cpp
+++ b/Tactical/Soldier Ani.cpp
@@ -280,7 +280,7 @@ BOOLEAN AdjustToNextAnimationFrame( SOLDIERTYPE *pSoldier )
 					INT16		sXPos, sYPos;
 
 					//sNewGridNo = NewGridNo( pSoldier->sGridNo, (UINT16)DirectionInc( pSoldier->ubDirection ) );
-					ConvertMapPosToWorldTileCenter( pSoldier->sTempNewGridNo, &sXPos, &sYPos );
+					ConvertGridNoToCenterCellXY( pSoldier->sTempNewGridNo, &sXPos, &sYPos );
 					pSoldier->EVENT_SetSoldierPosition( (FLOAT)sXPos, (FLOAT)sYPos );
 				}
 

--- a/Tactical/Soldier Ani.cpp
+++ b/Tactical/Soldier Ani.cpp
@@ -717,8 +717,7 @@ BOOLEAN AdjustToNextAnimationFrame( SOLDIERTYPE *pSoldier )
 
 				// CODE: End Hop Fence
 				// MOVE TO FORCASTED GRIDNO
-				sX = CenterX( pSoldier->sForcastGridno );
-				sY = CenterY( pSoldier->sForcastGridno );
+				ConvertGridNoToCenterCellXY(pSoldier->sForcastGridno, &sX, &sY);
 
 				pSoldier->EVENT_InternalSetSoldierPosition( (FLOAT) sX, (FLOAT) sY, FALSE, FALSE, FALSE );
 				pSoldier->EVENT_SetSoldierDirection(	gTwoCDirection[ pSoldier->ubDirection ] );

--- a/Tactical/Soldier Control.cpp
+++ b/Tactical/Soldier Control.cpp
@@ -11776,13 +11776,13 @@ UINT8 GetDirectionFromXY( INT16 sXPos, INT16 sYPos, SOLDIERTYPE *pSoldier )
 	return(atan8( sXPos2, sYPos2, sXPos, sYPos ));
 }
 
-INT16 GetDirectionFromCenterCellXYGridNo(INT32 sGridNoDest, INT32 sGridNoSrc)
+INT16 GetDirectionFromCenterCellXYGridNo(INT32 EndGridNo, INT32 StartGridNo)
 {
 	INT16 sXPos2, sYPos2;
 	INT16 sXPos, sYPos;
 
-	ConvertGridNoToCenterCellXY(sGridNoSrc, &sXPos, &sYPos);
-	ConvertGridNoToCenterCellXY(sGridNoDest, &sXPos2, &sYPos2);
+	ConvertGridNoToCenterCellXY(StartGridNo, &sXPos, &sYPos);
+	ConvertGridNoToCenterCellXY(EndGridNo, &sXPos2, &sYPos2);
 
 	return(atan8(sXPos2, sYPos2, sXPos, sYPos));
 }

--- a/Tactical/Soldier Control.cpp
+++ b/Tactical/Soldier Control.cpp
@@ -5041,8 +5041,10 @@ void SOLDIERTYPE::EVENT_FireSoldierWeapon( INT32 sTargetGridNo )
 						}
 						else if (!TileIsOutOfBounds(sTargetGridNo) && !GridNoOnScreen(sTargetGridNo))
 						{
-							INT16 sNewCenterWorldX = CenterX(sTargetGridNo);
-							INT16 sNewCenterWorldY = CenterY(sTargetGridNo);
+							INT16 sNewCenterWorldX;
+							INT16 sNewCenterWorldY;
+							ConvertGridNoToCenterCellXY(sTargetGridNo, &sNewCenterWorldX, &sNewCenterWorldY);
+
 							SetRenderCenter(sNewCenterWorldX, sNewCenterWorldY);
 
 							// Plot new path!
@@ -12272,8 +12274,7 @@ void SOLDIERTYPE::ReviveSoldier( void )
 		this->BeginSoldierGetup( );
 
 		// Makesure center of tile
-		sX = CenterX( this->sGridNo );
-		sY = CenterY( this->sGridNo );
+		ConvertGridNoToCenterCellXY(this->sGridNo, &sX, &sY);
 
 		this->EVENT_SetSoldierPosition( (FLOAT)sX, (FLOAT)sY );
 
@@ -13973,8 +13974,7 @@ void SOLDIERTYPE::EVENT_StopMerc( INT32 sGridNo, INT8 bDirection )
 
 	// MOVE GUY TO GRIDNO--- SHOULD BE THE SAME UNLESS IN MULTIPLAYER
 	// Makesure center of tile
-	sX = CenterX( sGridNo );
-	sY = CenterY( sGridNo );
+	ConvertGridNoToCenterCellXY(sGridNo, &sX, &sY);
 
 	//Cancel pending events
 	if ( !this->flags.fDelayedMovement )

--- a/Tactical/Soldier Control.cpp
+++ b/Tactical/Soldier Control.cpp
@@ -11588,9 +11588,12 @@ void SOLDIERTYPE::MoveMerc( FLOAT dMovementChange, FLOAT dAngle, BOOLEAN fCheckR
 				// adjust both gridno and x,y coordinates
 				if (sOldGridNo != this->sGridNo)
 				{
-					CorpseDef.sGridNo	= sOldGridNo;
-					CorpseDef.dXPos		= CenterX(CorpseDef.sGridNo);
-					CorpseDef.dYPos		= CenterY(CorpseDef.sGridNo);
+					INT16 sX, sY;
+					ConvertGridNoToCenterCellXY(sOldGridNo, &sX, &sY);
+
+					CorpseDef.sGridNo = sOldGridNo;
+					CorpseDef.dXPos = sX;
+					CorpseDef.dYPos	= sY;
 				}
 				else
 				{
@@ -11606,9 +11609,12 @@ void SOLDIERTYPE::MoveMerc( FLOAT dMovementChange, FLOAT dAngle, BOOLEAN fCheckR
 					INT16 base_y = 0;
 					ConvertMapPosToWorldTileCenter(pCorpse->def.sGridNo, &base_x, &base_y);
 
+					INT16 sX, sY;
+					ConvertGridNoToCenterCellXY(pCorpse->def.sGridNo, &sX, &sY);
+
 					CorpseDef.sGridNo	= pCorpse->def.sGridNo;
-					CorpseDef.dXPos		= CenterX(CorpseDef.sGridNo) + dx;
-					CorpseDef.dYPos		= CenterY(CorpseDef.sGridNo) + dy;
+					CorpseDef.dXPos		= sX + dx;
+					CorpseDef.dYPos		= sY + dy;
 				}
 
 				CorpseDef.usFlags		|= ROTTING_CORPSE_USE_XY_PROVIDED;

--- a/Tactical/Soldier Control.cpp
+++ b/Tactical/Soldier Control.cpp
@@ -11768,6 +11768,17 @@ UINT8 GetDirectionFromXY( INT16 sXPos, INT16 sYPos, SOLDIERTYPE *pSoldier )
 	return(atan8( sXPos2, sYPos2, sXPos, sYPos ));
 }
 
+INT16 GetDirectionFromCenterCellXYGridNo(INT32 sGridNoDest, INT32 sGridNoSrc)
+{
+	INT16 sXPos2, sYPos2;
+	INT16 sXPos, sYPos;
+
+	ConvertGridNoToCenterCellXY(sGridNoSrc, &sXPos, &sYPos);
+	ConvertGridNoToCenterCellXY(sGridNoDest, &sXPos2, &sYPos2);
+
+	return(atan8(sXPos2, sYPos2, sXPos, sYPos));
+}
+
 
 //#if 0
 UINT8 atan8( INT16 sXPos, INT16 sYPos, INT16 sXPos2, INT16 sYPos2 )

--- a/Tactical/Soldier Control.cpp
+++ b/Tactical/Soldier Control.cpp
@@ -15879,7 +15879,7 @@ BOOLEAN		SOLDIERTYPE::SeemsLegit( UINT8 ubObserverID )
 	}
 
 	UINT8 covertlevel = NUM_SKILL_TRAITS( this, COVERT_NT );	// our level in covert operations
-	INT32 distance = GetRangeFromGridNoDiff( this->sGridNo, pSoldier->sGridNo );
+	INT32 distance = PythSpacesAway( this->sGridNo, pSoldier->sGridNo );
 
 	// if we are closer than this, our cover will always break if we do not have the skill
 	// if we have the skill, our cover will blow if we dress up as a soldier, but not if we are dressed like a civilian
@@ -23216,7 +23216,7 @@ BOOLEAN SOLDIERTYPE::PlayerSoldierStartTalking( UINT8 ubTargetID, BOOLEAN fValid
 			return(FALSE);
 		}
 
-		uiRange = GetRangeFromGridNoDiff( this->sGridNo, pTSoldier->sGridNo );
+		uiRange = PythSpacesAway( this->sGridNo, pTSoldier->sGridNo );
 
 		if ( uiRange > (NPC_TALK_RADIUS * 2) )
 		{

--- a/Tactical/Soldier Control.cpp
+++ b/Tactical/Soldier Control.cpp
@@ -7361,7 +7361,7 @@ void SOLDIERTYPE::EVENT_InternalSetSoldierDestination( UINT16	usNewDirection, BO
 	// Get dest gridno, convert to center coords
 	sNewGridNo = NewGridNo( this->sGridNo, DirectionInc( (UINT8)usNewDirection ) );
 
-	ConvertMapPosToWorldTileCenter( sNewGridNo, &sXPos, &sYPos );
+	ConvertGridNoToCenterCellXY( sNewGridNo, &sXPos, &sYPos );
 
 	// Save new dest gridno, x, y
 	this->pathing.sDestination = sNewGridNo;
@@ -11546,7 +11546,7 @@ void SOLDIERTYPE::MoveMerc( FLOAT dMovementChange, FLOAT dAngle, BOOLEAN fCheckR
 				{
 					INT16 this_base_x = 0;
 					INT16 this_base_y = 0;
-					ConvertMapPosToWorldTileCenter( this->sGridNo, &this_base_x, &this_base_y );
+					ConvertGridNoToCenterCellXY( this->sGridNo, &this_base_x, &this_base_y );
 
 					dx = this->dXPos - this_base_x;
 					dy = this->dYPos - this_base_y;
@@ -11554,7 +11554,7 @@ void SOLDIERTYPE::MoveMerc( FLOAT dMovementChange, FLOAT dAngle, BOOLEAN fCheckR
 
 				INT16 base_x = 0;
 				INT16 base_y = 0;
-				ConvertMapPosToWorldTileCenter( gridnotouse, &base_x, &base_y );
+				ConvertGridNoToCenterCellXY( gridnotouse, &base_x, &base_y );
 
 				pSoldier->EVENT_InternalSetSoldierPosition( base_x + dx, base_y + dy, FALSE, FALSE, FALSE );
 			}
@@ -11600,14 +11600,14 @@ void SOLDIERTYPE::MoveMerc( FLOAT dMovementChange, FLOAT dAngle, BOOLEAN fCheckR
 					// move corpse a bit
 					INT16 this_base_x = 0;
 					INT16 this_base_y = 0;
-					ConvertMapPosToWorldTileCenter(this->sGridNo, &this_base_x, &this_base_y);
+					ConvertGridNoToCenterCellXY(this->sGridNo, &this_base_x, &this_base_y);
 
 					FLOAT dx = this->dXPos - this_base_x;
 					FLOAT dy = this->dYPos - this_base_y;
 						
 					INT16 base_x = 0;
 					INT16 base_y = 0;
-					ConvertMapPosToWorldTileCenter(pCorpse->def.sGridNo, &base_x, &base_y);
+					ConvertGridNoToCenterCellXY(pCorpse->def.sGridNo, &base_x, &base_y);
 
 					INT16 sX, sY;
 					ConvertGridNoToCenterCellXY(pCorpse->def.sGridNo, &sX, &sY);
@@ -20882,7 +20882,7 @@ void	SOLDIERTYPE::CancelDrag()
 		{
 			INT16 base_x = 0;
 			INT16 base_y = 0;
-			ConvertMapPosToWorldTileCenter(pSoldier->sGridNo, &base_x, &base_y);
+			ConvertGridNoToCenterCellXY(pSoldier->sGridNo, &base_x, &base_y);
 
 			pSoldier->EVENT_InternalSetSoldierPosition(base_x, base_y, FALSE, FALSE, FALSE);
 		}

--- a/Tactical/Soldier Control.h
+++ b/Tactical/Soldier Control.h
@@ -2205,7 +2205,7 @@ UINT8 GetDirectionFromGridNo( INT32 sGridNo, SOLDIERTYPE *pSoldier );
 UINT8 atan8( INT16 sXPos, INT16 sYPos, INT16 sXPos2, INT16 sYPos2 );
 UINT8 atan8FromAngle( DOUBLE dAngle );
 INT16 GetDirectionToGridNoFromGridNo(INT32 sGridNoDest, INT32 sGridNoSrc);
-INT16 GetDirectionFromCenterCellXYGridNo( INT32 sGridNoDest, INT32 sGridNoSrc );
+INT16 GetDirectionFromCenterCellXYGridNo(INT32 EndGridNo, INT32 StartGridNo);
 // This function is now obsolete.	Call ReduceAttackBusyCount instead.
 // void ReleaseSoldiersAttacker( SOLDIERTYPE *pSoldier );
 

--- a/Tactical/Soldier Control.h
+++ b/Tactical/Soldier Control.h
@@ -2204,7 +2204,8 @@ BOOLEAN GetDirectionChangeAmount( INT32 sGridNo, SOLDIERTYPE *pSoldier, UINT8 ui
 UINT8 GetDirectionFromGridNo( INT32 sGridNo, SOLDIERTYPE *pSoldier );
 UINT8 atan8( INT16 sXPos, INT16 sYPos, INT16 sXPos2, INT16 sYPos2 );
 UINT8 atan8FromAngle( DOUBLE dAngle );
-INT16 GetDirectionToGridNoFromGridNo( INT32 sGridNoDest, INT32 sGridNoSrc );
+INT16 GetDirectionToGridNoFromGridNo(INT32 sGridNoDest, INT32 sGridNoSrc);
+INT16 GetDirectionFromCenterCellXYGridNo( INT32 sGridNoDest, INT32 sGridNoSrc );
 // This function is now obsolete.	Call ReduceAttackBusyCount instead.
 // void ReleaseSoldiersAttacker( SOLDIERTYPE *pSoldier );
 

--- a/Tactical/Soldier Find.cpp
+++ b/Tactical/Soldier Find.cpp
@@ -814,8 +814,7 @@ BOOLEAN SoldierLocationRelativeToScreen( INT32 sGridNo, UINT16 usReasonID, INT8 
 
 	*puiScrollFlags = 0;
 
-	sX = CenterX( sGridNo );
-	sY = CenterY( sGridNo );
+	ConvertGridNoToCenterCellXY(sGridNo, &sX, &sY);
 
 	// Get screen coordinates for current position of soldier
 	GetWorldXYAbsoluteScreenXY( (INT16)(sX/CELL_X_SIZE), (INT16)(sY/CELL_Y_SIZE), &sWorldX, &sWorldY);
@@ -954,25 +953,28 @@ BOOLEAN FindRelativeSoldierPosition( SOLDIERTYPE *pSoldier, UINT16 *usFlags, INT
 					// Then, depending on whether this is the gridno we are looking at, this will be head or legs
 					if ( gGameExternalOptions.fAllowTargetHeadAndLegIfProne )
 					{
-						INT16 sWorldX, sWorldY;
+						INT16 sWorldX, sWorldY, sX, sY;
 						GetMouseWorldCoords( &sWorldX, &sWorldY );
 
 						// Flugente: we measure the distance of the bullet's location to the location of the soldier, and to the 2 gridnos his head and leg occupy
 						// From this we can decide what body part was hit
-						FLOAT bodycenterX = (FLOAT)CenterX( pSoldier->sGridNo );
-						FLOAT bodycenterY = (FLOAT)CenterY( pSoldier->sGridNo );
+						ConvertGridNoToCenterCellXY(pSoldier->sGridNo, &sX, &sY);
+						FLOAT bodycenterX = (FLOAT) sX;
+						FLOAT bodycenterY = (FLOAT) sY;
 
 						FLOAT difftobodycenter = sqrt( (bodycenterX - sWorldX) * (bodycenterX - sWorldX) + (bodycenterY - sWorldY) * (bodycenterY - sWorldY) );
 						
 						INT32 viewdirectiongridno = NewGridNo( pSoldier->sGridNo, DirectionInc( pSoldier->ubDirection ) );
-						FLOAT nextgridnocenterX = (FLOAT)CenterX( viewdirectiongridno );
-						FLOAT nextgridnocenterY = (FLOAT)CenterY( viewdirectiongridno );
+						ConvertGridNoToCenterCellXY(viewdirectiongridno, &sX, &sY);
+						FLOAT nextgridnocenterX = (FLOAT) sX;
+						FLOAT nextgridnocenterY = (FLOAT) sY;
 
 						FLOAT difftonextgridno = sqrt( (nextgridnocenterX - sWorldX) * (nextgridnocenterX - sWorldX) + (nextgridnocenterY - sWorldY) * (nextgridnocenterY - sWorldY) );
 						
 						INT32 oppositeviewdirectiongridno = NewGridNo( pSoldier->sGridNo, DirectionInc( gOppositeDirection[pSoldier->ubDirection] ) );
-						FLOAT oppositenextgridnocenterX = (FLOAT)CenterX( oppositeviewdirectiongridno );
-						FLOAT oppositenextgridnocenterY = (FLOAT)CenterY( oppositeviewdirectiongridno );
+						ConvertGridNoToCenterCellXY(oppositeviewdirectiongridno, &sX, &sY);
+						FLOAT oppositenextgridnocenterX = (FLOAT) sX;
+						FLOAT oppositenextgridnocenterY = (FLOAT) sY;
 
 						FLOAT difftooppositenextgridno = sqrt( (oppositenextgridnocenterX - sWorldX) * (oppositenextgridnocenterX - sWorldX) + (oppositenextgridnocenterY - sWorldY) * (oppositenextgridnocenterY - sWorldY) );
 
@@ -1030,13 +1032,15 @@ UINT8 QuickFindSoldier( INT32 sGridNo )
 
 void GetGridNoScreenPos( INT32 sGridNo, UINT8 ubLevel, INT16 *psScreenX, INT16 *psScreenY )
 {
-		INT16 sScreenX, sScreenY;
+		INT16 sScreenX, sScreenY, sX, sY;
 		FLOAT dOffsetX, dOffsetY;
 		FLOAT dTempX_S, dTempY_S;
 
+		ConvertGridNoToCenterCellXY(sGridNo, &sX, &sY);
+
 		// Get 'TRUE' merc position
-		dOffsetX = (FLOAT)( CenterX( sGridNo ) - gsRenderCenterX );
-		dOffsetY = (FLOAT)( CenterY( sGridNo ) - gsRenderCenterY );
+		dOffsetX = (FLOAT)( sX - gsRenderCenterX );
+		dOffsetY = (FLOAT)( sY - gsRenderCenterY );
 
 		// OK, DONT'T ASK... CONVERSION TO PROPER Y NEEDS THIS...
 		dOffsetX -= CELL_Y_SIZE;

--- a/Tactical/Soldier Tile.cpp
+++ b/Tactical/Soldier Tile.cpp
@@ -738,8 +738,7 @@ BOOLEAN TeleportSoldier( SOLDIERTYPE *pSoldier, INT32 sGridNo, BOOLEAN fForce )
 	if ( NewOKDestination( pSoldier, sGridNo, TRUE, 0 ) || fForce )
 	{
 		// TELEPORT TO THIS LOCATION!
-		sX = CenterX( sGridNo );
-		sY = CenterY( sGridNo );
+		ConvertGridNoToCenterCellXY(sGridNo, &sX, &sY);
 		pSoldier->EVENT_SetSoldierPosition( (FLOAT) sX, (FLOAT) sY );
 
 		pSoldier->pathing.sFinalDestination = sGridNo;

--- a/Tactical/Tactical Save.cpp
+++ b/Tactical/Tactical Save.cpp
@@ -1878,8 +1878,10 @@ BOOLEAN LoadRottingCorpsesFromTempCorpseFile( INT16 sMapX, INT16 sMapY, INT8 bMa
 			def.sGridNo = gMapInformation.sWestGridNo;
 		}
 		//Recalculate the dx,dy info
-		def.dXPos = CenterX( def.sGridNo );
-		def.dYPos = CenterY( def.sGridNo );
+		INT16 sX, sY;
+		ConvertGridNoToCenterCellXY(def.sGridNo, &sX, &sY);
+		def.dXPos = sX;
+		def.dYPos = sY;
 		// If not from loading a save....
 		if( !(gTacticalStatus.uiFlags & LOADING_SAVED_GAME ) )
 		{
@@ -2737,15 +2739,14 @@ BOOLEAN AddDeadSoldierToUnLoadedSector( INT16 sMapX, INT16 sMapY, UINT8 bMapZ, S
 	memset( &Corpse, 0, sizeof( ROTTING_CORPSE_DEFINITION ) );
 
 	// Setup some values!
-	Corpse.ubBodyType							= pSoldier->ubBodyType;
-	Corpse.sGridNo								= sGridNo;
+	ConvertGridNoToCenterCellXY(sGridNo, &sXPos, &sYPos);
 
-	ConvertGridNoToXY( sGridNo, &sXPos, &sYPos );
-
-	Corpse.dXPos									= (FLOAT)( CenterX( sXPos ) );
-	Corpse.dYPos									= (FLOAT)( CenterY( sYPos ) );
-	Corpse.sHeightAdjustment			= pSoldier->sHeightAdjustment;
-	Corpse.bVisible								=	TRUE;
+	Corpse.ubBodyType			= pSoldier->ubBodyType;
+	Corpse.sGridNo				= sGridNo;
+	Corpse.dXPos				= (FLOAT)( sXPos );
+	Corpse.dYPos				= (FLOAT)( sYPos );
+	Corpse.sHeightAdjustment	= pSoldier->sHeightAdjustment;
+	Corpse.bVisible				=	TRUE;
 
 	SET_PALETTEREP_ID ( Corpse.HeadPal,		pSoldier->HeadPal );
 	SET_PALETTEREP_ID ( Corpse.VestPal,		pSoldier->VestPal );

--- a/Tactical/UI Cursors.cpp
+++ b/Tactical/UI Cursors.cpp
@@ -676,8 +676,12 @@ UINT8 HandleActivatedTargetCursor( SOLDIERTYPE *pSoldier, INT32 usMapPos, BOOLEA
 						gCTHDisplay.iTargetGridNo = usMapPos;
 						
 						// Calculate distance to target
-						FLOAT dDeltaX = (FLOAT)(CenterX( pSoldier->sGridNo ) - CenterX( usMapPos ));
-						FLOAT dDeltaY = (FLOAT)(CenterY( pSoldier->sGridNo ) - CenterY( usMapPos ));
+						INT16 sX, sY, sXMap, sYMap;
+						ConvertGridNoToCenterCellXY(pSoldier->sGridNo, &sX, &sY);
+						ConvertGridNoToCenterCellXY(usMapPos, &sXMap, &sYMap);
+
+						FLOAT dDeltaX = (FLOAT)( sX - sXMap );
+						FLOAT dDeltaY = (FLOAT)( sY - sYMap );
 						FLOAT d2DDistance = sqrt((dDeltaX*dDeltaX)+(dDeltaY*dDeltaY));
 
 						CalcMagFactorSimple( pSoldier, d2DDistance, pSoldier->aiData.bShownAimTime, usMapPos );
@@ -782,8 +786,12 @@ UINT8 HandleActivatedTargetCursor( SOLDIERTYPE *pSoldier, INT32 usMapPos, BOOLEA
 						gbCtHBurstCount = 0;
 
 						// Calculate distance to target
-						FLOAT dDeltaX = (FLOAT)(CenterX( pSoldier->sGridNo ) - CenterX( usMapPos ));
-						FLOAT dDeltaY = (FLOAT)(CenterY( pSoldier->sGridNo ) - CenterY( usMapPos ));
+						INT16 sX, sY, sXMap, sYMap;
+						ConvertGridNoToCenterCellXY(pSoldier->sGridNo, &sX, &sY);
+						ConvertGridNoToCenterCellXY(usMapPos, &sXMap, &sYMap);
+
+						FLOAT dDeltaX = (FLOAT)(sX - sXMap);
+						FLOAT dDeltaY = (FLOAT)(sY - sYMap);
 						FLOAT d2DDistance = sqrt((dDeltaX*dDeltaX)+(dDeltaY*dDeltaY));
 
 						CalcMagFactorSimple( pSoldier, d2DDistance, pSoldier->aiData.bShownAimTime, usMapPos );
@@ -884,8 +892,12 @@ UINT8 HandleActivatedTargetCursor( SOLDIERTYPE *pSoldier, INT32 usMapPos, BOOLEA
 					gCTHDisplay.iTargetGridNo = usMapPos;
 
 					// Calculate distance to target
-					FLOAT dDeltaX = (FLOAT)(CenterX( pSoldier->sGridNo ) - CenterX( usMapPos ));
-					FLOAT dDeltaY = (FLOAT)(CenterY( pSoldier->sGridNo ) - CenterY( usMapPos ));
+					INT16 sX, sY, sXMap, sYMap;
+					ConvertGridNoToCenterCellXY(pSoldier->sGridNo, &sX, &sY);
+					ConvertGridNoToCenterCellXY(usMapPos, &sXMap, &sYMap);
+
+					FLOAT dDeltaX = (FLOAT)(sX - sXMap);
+					FLOAT dDeltaY = (FLOAT)(sY - sYMap);
 					FLOAT d2DDistance = sqrt((dDeltaX*dDeltaX)+(dDeltaY*dDeltaY));
 
 					CalcMagFactorSimple( pSoldier, d2DDistance, pSoldier->aiData.bShownAimTime, usMapPos );

--- a/Tactical/Vehicles.cpp
+++ b/Tactical/Vehicles.cpp
@@ -1787,7 +1787,9 @@ BOOLEAN ExitVehicle( SOLDIERTYPE *pSoldier )
 		pSoldier->aiData.bOppList[ pVehicle->ubID ] = 1;
 
 		// Add to sector....
-		pSoldier->EVENT_SetSoldierPosition( CenterX( sGridNo ), CenterY( sGridNo ) );
+		INT16 sX, sY;
+		ConvertGridNoToCenterCellXY(pSoldier->sGridNo, &sX, &sY);
+		pSoldier->EVENT_SetSoldierPosition( sX, sY );
 
 		// anv: since now they can shoot it's important to set passenger to proper stance
 		// namely, back to standing, because we set them to crouching when entering
@@ -2064,7 +2066,9 @@ void HandleCriticalHitForVehicleInLocation( UINT8 ubID, INT16 sDmg, INT32 sGridN
 		pVehicleList[ ubID ].fDestroyed	= TRUE;
 
 		// Explode vehicle...
-		IgniteExplosion( ubAttackerID, CenterX( sGridNo ), CenterY( sGridNo ), 0, sGridNo, GREAT_BIG_EXPLOSION, 0 );
+		INT16 sX, sY;
+		ConvertGridNoToCenterCellXY(sGridNo, &sX, &sY);
+		IgniteExplosion( ubAttackerID, sX, sY, 0, sGridNo, GREAT_BIG_EXPLOSION, 0 );
 
 		if ( pSoldier != NULL )
 		{

--- a/Tactical/Weapons.cpp
+++ b/Tactical/Weapons.cpp
@@ -1774,9 +1774,11 @@ void GetTargetWorldPositions( SOLDIERTYPE *pSoldier, INT32 sTargetGridNo, FLOAT 
 					if ( gGameExternalOptions.fAllowTargetHeadAndLegIfProne && gAnimControl[pTargetSoldier->usAnimState].ubHeight == ANIM_PRONE )
 					{
 						INT32 viewdirectiongridno = NewGridNo( pTargetSoldier->sGridNo, DirectionInc( pTargetSoldier->ubDirection ) );
+						INT16 sX, sY;
+						ConvertGridNoToCenterCellXY(viewdirectiongridno, &sX, &sY);
 
-						dTargetX = (0.3f * dTargetX + 0.7f * (FLOAT)CenterX( viewdirectiongridno )) / 1.0f;
-						dTargetY = (0.3f * dTargetY + 0.7f * (FLOAT)CenterY( viewdirectiongridno )) / 1.0f;
+						dTargetX = (0.3f * dTargetX + 0.7f * (FLOAT)sX) / 1.0f;
+						dTargetY = (0.3f * dTargetY + 0.7f * (FLOAT)sY) / 1.0f;
 					}
 				}
 				break;
@@ -1790,9 +1792,11 @@ void GetTargetWorldPositions( SOLDIERTYPE *pSoldier, INT32 sTargetGridNo, FLOAT 
 					if ( gGameExternalOptions.fAllowTargetHeadAndLegIfProne && gAnimControl[pTargetSoldier->usAnimState].ubHeight == ANIM_PRONE )
 					{
 						INT32 viewdirectiongridno = NewGridNo( pTargetSoldier->sGridNo, DirectionInc( gOppositeDirection[pTargetSoldier->ubDirection] ) );
+						INT16 sX, sY;
+						ConvertGridNoToCenterCellXY(viewdirectiongridno, &sX, &sY);
 
-						dTargetX = (0.3f * dTargetX + 0.7f * (FLOAT)CenterX( viewdirectiongridno )) / 1.0f;
-						dTargetY = (0.3f * dTargetY + 0.7f * (FLOAT)CenterY( viewdirectiongridno )) / 1.0f;
+						dTargetX = (0.3f * dTargetX + 0.7f * (FLOAT)sX) / 1.0f;
+						dTargetY = (0.3f * dTargetY + 0.7f * (FLOAT)sY) / 1.0f;
 					}
 				}
 				break;
@@ -2719,11 +2723,14 @@ BOOLEAN UseGunNCTH( SOLDIERTYPE *pSoldier , INT32 sTargetGridNo )
 	{
 		if ( WillExplosiveWeaponFail( pSoldier, pObjHand ) )
 		{
+			INT16 sX, sY;
+			ConvertGridNoToCenterCellXY(pSoldier->sGridNo, &sX, &sY);
+
 			if ( Item[usUBItem].singleshotrocketlauncher  )
 			{
 				CreateItem( Item[usItemNum].discardedlauncheritem , (*pObjHand)[0]->data.objectStatus, pObjHand );
 				
-				// Flugente: why would we keep a piece of scrap in our ahnds in the first place? just drop it to the ground
+				// Flugente: why would we keep a piece of scrap in our hands in the first place? just drop it to the ground
 				AddItemToPool( pSoldier->sGridNo, pObjHand, 1, pSoldier->pathing.bLevel, 0, -1 );
 
 				// Delete object
@@ -2731,20 +2738,21 @@ BOOLEAN UseGunNCTH( SOLDIERTYPE *pSoldier , INT32 sTargetGridNo )
 
 				DirtyMercPanelInterface( pSoldier, DIRTYLEVEL2 );
 
+
 				if ( Item[usUBItem].usBuddyItem != 0 && Item[Item[usUBItem].usBuddyItem].usItemClass & IC_EXPLOSV )
 				{
-					IgniteExplosion( pSoldier->ubID, CenterX( pSoldier->sGridNo ), CenterY( pSoldier->sGridNo ), 0, pSoldier->sGridNo, Item[usUBItem].usBuddyItem, pSoldier->pathing.bLevel );
+					IgniteExplosion( pSoldier->ubID, sX, sY, 0, pSoldier->sGridNo, Item[usUBItem].usBuddyItem, pSoldier->pathing.bLevel );
 				}
 				else
 				{
-					IgniteExplosion( pSoldier->ubID, CenterX( pSoldier->sGridNo ), CenterY( pSoldier->sGridNo ), 0, pSoldier->sGridNo, C1, pSoldier->pathing.bLevel );
+					IgniteExplosion( pSoldier->ubID, sX, sY, 0, pSoldier->sGridNo, C1, pSoldier->pathing.bLevel );
 				}
 			}
 			else
 			{
 				DebugMsg( TOPIC_JA2, DBG_LEVEL_3, String("StructureHit: RPG7 item: %d, Ammo: %d", usUBItem , (*pObjHand)[0]->data.gun.usGunAmmoItem ) );
 
-				IgniteExplosion( pSoldier->ubID, CenterX( pSoldier->sGridNo ), CenterY( pSoldier->sGridNo ), 0, pSoldier->sGridNo, (*pObjHand)[0]->data.gun.usGunAmmoItem, pSoldier->pathing.bLevel );
+				IgniteExplosion( pSoldier->ubID, sX, sY, 0, pSoldier->sGridNo, (*pObjHand)[0]->data.gun.usGunAmmoItem, pSoldier->pathing.bLevel );
 				pSoldier->inv[pSoldier->ubAttackingHand ][0]->data.gun.usGunAmmoItem = NONE;
 			}
 		  // Reduce again for attack end 'cause it has been incremented for a normal attack
@@ -3644,6 +3652,9 @@ BOOLEAN UseGun( SOLDIERTYPE *pSoldier , INT32 sTargetGridNo )
 	{
 		if ( WillExplosiveWeaponFail( pSoldier, pObjUsed ) )
 		{
+			INT16 sX, sY;
+			ConvertGridNoToCenterCellXY(pSoldier->sGridNo, &sX, &sY);
+
 			if ( Item[usUBItem].singleshotrocketlauncher  )
 			{
 				CreateItem( Item[usUBItem].discardedlauncheritem , (*pObjUsed)[0]->data.objectStatus, pObjUsed );
@@ -3656,20 +3667,21 @@ BOOLEAN UseGun( SOLDIERTYPE *pSoldier , INT32 sTargetGridNo )
 
 				DirtyMercPanelInterface( pSoldier, DIRTYLEVEL2 );
 
+
 				if ( Item[usUBItem].usBuddyItem != 0 && Item[Item[usUBItem].usBuddyItem].usItemClass & IC_EXPLOSV )
 				{
-					IgniteExplosion( pSoldier->ubID, CenterX( pSoldier->sGridNo ), CenterY( pSoldier->sGridNo ), 0, pSoldier->sGridNo, C1, pSoldier->pathing.bLevel );
+					IgniteExplosion( pSoldier->ubID, sX, sY, 0, pSoldier->sGridNo, C1, pSoldier->pathing.bLevel );
 				}
 				else
 				{
-					IgniteExplosion( pSoldier->ubID, CenterX( pSoldier->sGridNo ), CenterY( pSoldier->sGridNo ), 0, pSoldier->sGridNo, C1, pSoldier->pathing.bLevel );
+					IgniteExplosion( pSoldier->ubID, sX, sY, 0, pSoldier->sGridNo, C1, pSoldier->pathing.bLevel );
 				}
 			}
 			else
 			{
 				DebugMsg( TOPIC_JA2, DBG_LEVEL_3, String("StructureHit: RPG7 item: %d, Ammo: %d", usUBItem , (*pObjUsed)[0]->data.gun.usGunAmmoItem ) );
 
-				IgniteExplosion( pSoldier->ubID, CenterX( pSoldier->sGridNo ), CenterY( pSoldier->sGridNo ), 0, pSoldier->sGridNo, (*pObjUsed)[0]->data.gun.usGunAmmoItem, pSoldier->pathing.bLevel );
+				IgniteExplosion( pSoldier->ubID, sX, sY, 0, pSoldier->sGridNo, (*pObjUsed)[0]->data.gun.usGunAmmoItem, pSoldier->pathing.bLevel );
 			
 				OBJECTTYPE * pLaunchable = FindLaunchableAttachment( pObjUsed, usUBItem );
 				if(pLaunchable)
@@ -5168,7 +5180,9 @@ BOOLEAN UseLauncher( SOLDIERTYPE *pSoldier, INT32 sTargetGridNo )
 
 		// So we still should have ABC > 0
 		// Begin explosion due to failure...
-		IgniteExplosion( pSoldier->ubID, CenterX( pSoldier->sGridNo ), CenterY( pSoldier->sGridNo ), 0, pSoldier->sGridNo, Launchable.usItem, pSoldier->pathing.bLevel );
+		INT16 sX, sY;
+		ConvertGridNoToCenterCellXY(pSoldier->sGridNo, &sX, &sY);
+		IgniteExplosion( pSoldier->ubID, sX, sY, 0, pSoldier->sGridNo, Launchable.usItem, pSoldier->pathing.bLevel );
 
 		// Reduce again for attack end 'cause it has been incremented for a normal attack
 		// Nope, not anymore.
@@ -5677,15 +5691,18 @@ void StructureHit( INT32 iBullet, UINT16 usWeaponIndex, INT16 bWeaponStatus, UIN
 			// HEADROCK HAM 5: Fragments fired by such weapons should not explode. 
 			if ( pBullet->fFragment == false)
 			{
+				INT16 sX, sY;
+				ConvertGridNoToCenterCellXY(pSoldier->sGridNo, &sX, &sY);
+
 				if ( Item[usWeaponIndex].singleshotrocketlauncher )
 				{
 					if ( Item[usWeaponIndex].usBuddyItem != 0 && Item[Item[usWeaponIndex].usBuddyItem].usItemClass & IC_EXPLOSV )
 					{
-						IgniteExplosion( ubAttackerID, CenterX( sGridNo ), CenterY( sGridNo ), 0, sGridNo, Item[usWeaponIndex].usBuddyItem, bLevel, usDirection );
+						IgniteExplosion( ubAttackerID, sX, sY, 0, sGridNo, Item[usWeaponIndex].usBuddyItem, bLevel, usDirection );
 					}
 					else
 					{
-						IgniteExplosion( ubAttackerID, CenterX( sGridNo ), CenterY( sGridNo ), 0, sGridNo, C1, bLevel, usDirection );
+						IgniteExplosion( ubAttackerID, sX, sY, 0, sGridNo, C1, bLevel, usDirection );
 					}
 				}
 				// changed too to use 2 flag to determine
@@ -5693,7 +5710,7 @@ void StructureHit( INT32 iBullet, UINT16 usWeaponIndex, INT16 bWeaponStatus, UIN
 					//there shouldn't be a way to enter here with an UnderBarrel weapon, so retaining original code :JMich
 				{
 					DebugMsg( TOPIC_JA2, DBG_LEVEL_3, String("StructureHit: RPG7 item: %d, Ammo: %d",pAttacker->inv[HANDPOS].usItem , pAttacker->inv[HANDPOS][0]->data.gun.usGunAmmoItem ) );
-					IgniteExplosion( ubAttackerID, CenterX( sGridNo ), CenterY( sGridNo ), 0, sGridNo, pAttacker->inv[pAttacker->ubAttackingHand][0]->data.gun.usGunAmmoItem, bLevel, usDirection );
+					IgniteExplosion( ubAttackerID, sX, sY, 0, sGridNo, pAttacker->inv[pAttacker->ubAttackingHand][0]->data.gun.usGunAmmoItem, bLevel, usDirection );
 					
 					//This is just to make multishot launchers work in semi auto. It's not really a permanent solution because it still doesn't allow autofire, but it will do for now.
 					OBJECTTYPE * pLaunchable = FindLaunchableAttachment( &(pAttacker->inv[pAttacker->ubAttackingHand ]), pAttacker->inv[pAttacker->ubAttackingHand ].usItem );
@@ -5709,7 +5726,7 @@ void StructureHit( INT32 iBullet, UINT16 usWeaponIndex, INT16 bWeaponStatus, UIN
 				else if ( AmmoTypes[(*pObj)[0]->data.gun.ubGunAmmoType].explosionSize > 1)
 				{
 					// re-routed the Highexplosive value to define exposion type
-					IgniteExplosion( ubAttackerID, CenterX( sGridNo ), CenterY( sGridNo ), 0, sGridNo, AmmoTypes[(*pObj)[0]->data.gun.ubGunAmmoType].highExplosive, bLevel, usDirection );
+					IgniteExplosion( ubAttackerID, sX, sY, 0, sGridNo, AmmoTypes[(*pObj)[0]->data.gun.ubGunAmmoType].highExplosive, bLevel, usDirection );
 					// pSoldier->inv[pSoldier->ubAttackingHand ][0]->data.gun.usGunAmmoItem = NONE;
 				}
 			}
@@ -5727,7 +5744,9 @@ void StructureHit( INT32 iBullet, UINT16 usWeaponIndex, INT16 bWeaponStatus, UIN
 			//FreeUpAttacker( ubAttackerID );
 
 			// HEADROCK HAM 5 TODO: Tank shell!!
-			IgniteExplosion( ubAttackerID, CenterX( sGridNo ), CenterY( sGridNo ), 0, sGridNo, TANK_SHELL, bLevel, usDirection );
+			INT16 sX, sY;
+			ConvertGridNoToCenterCellXY(sGridNo, &sX, &sY);
+			IgniteExplosion( ubAttackerID, sX, sY, 0, sGridNo, TANK_SHELL, bLevel, usDirection );
 			//FreeUpAttacker( (UINT8) ubAttackerID );
 
 			// Moved here to keep ABC >0 as long as possible

--- a/Tactical/Weapons.cpp
+++ b/Tactical/Weapons.cpp
@@ -1714,7 +1714,7 @@ void GetTargetWorldPositions( SOLDIERTYPE *pSoldier, INT32 sTargetGridNo, FLOAT 
 	FLOAT								dTargetZ;
 	SOLDIERTYPE*						pTargetSoldier = NULL;
 	INT8								bStructHeight;
-	INT16								sXMapPos, sYMapPos;
+	INT16								sXMapPos, sYMapPos, sX, sY;
 	UINT32							uiRoll;
 	INT8								bTargetCubeLevel = 0;
 	INT8								bTargetLevel = 0;
@@ -1731,8 +1731,9 @@ void GetTargetWorldPositions( SOLDIERTYPE *pSoldier, INT32 sTargetGridNo, FLOAT 
 	{
 		// SAVE OPP ID
 		pSoldier->ubOppNum = pTargetSoldier->ubID;
-		dTargetX = (FLOAT) CenterX( pTargetSoldier->sGridNo );
-		dTargetY = (FLOAT) CenterY( pTargetSoldier->sGridNo );
+		ConvertGridNoToCenterCellXY(pTargetSoldier->sGridNo, &sX, &sY);
+		dTargetX = (FLOAT) sX;
+		dTargetY = (FLOAT) sY;
 		if (pSoldier->bAimShotLocation == AIM_SHOT_RANDOM)
 		{
 			uiRoll = PreRandom( 100 );
@@ -2893,8 +2894,8 @@ BOOLEAN UseGunNCTH( SOLDIERTYPE *pSoldier , INT32 sTargetGridNo )
 		{
 			sTempGridNo = NewGridNo(sTempGridNo, DirectionInc(pSoldier->ubDirection));
 		}
-		INT16 sX = CenterX(sTempGridNo);
-		INT16 sY = CenterY(sTempGridNo);
+		INT16 sX, sY;
+		ConvertGridNoToCenterCellXY(sTempGridNo, &sX, &sY);
 
 		AniParams.sGridNo = pSoldier->sGridNo;
 		AniParams.ubLevelID = ANI_TOPMOST_LEVEL;
@@ -3708,8 +3709,8 @@ BOOLEAN UseGun( SOLDIERTYPE *pSoldier , INT32 sTargetGridNo )
 		{
 			sTempGridNo = NewGridNo(sTempGridNo, DirectionInc(pSoldier->ubDirection));
 		}
-		INT16 sX = CenterX(sTempGridNo);
-		INT16 sY = CenterY(sTempGridNo);
+		INT16 sX, sY;
+		ConvertGridNoToCenterCellXY(sTempGridNo, &sX, &sY);
 
 		AniParams.sGridNo = pSoldier->sGridNo;
 		AniParams.ubLevelID = ANI_TOPMOST_LEVEL;
@@ -6250,7 +6251,7 @@ UINT32 CalcNewChanceToHitGun(SOLDIERTYPE *pSoldier, INT32 sGridNo, INT16 ubAimTi
 	// Basic defines
 	SOLDIERTYPE * pTarget;
 	INT32 iRange, iSightRange; //, minRange;
-
+	INT16 sX, sY, sX2, sY2;
 	UINT16	usInHand;
 	OBJECTTYPE * pInHand;
 	INT16	sDistVis, sDistVisNoScope;
@@ -6270,8 +6271,11 @@ UINT32 CalcNewChanceToHitGun(SOLDIERTYPE *pSoldier, INT32 sGridNo, INT16 ubAimTi
 
 	// calculate actual range (in units, 10 units = 1 tile)
 	iRange = GetRangeInCellCoordsFromGridNoDiff( pSoldier->sGridNo, sGridNo );
-	FLOAT dDeltaX = (FLOAT)(CenterX( pSoldier->sGridNo ) - CenterX( sGridNo ));
-	FLOAT dDeltaY = (FLOAT)(CenterY( pSoldier->sGridNo ) - CenterY( sGridNo ));
+
+	ConvertGridNoToCenterCellXY(pSoldier->sGridNo, &sX, &sY);
+	ConvertGridNoToCenterCellXY(sGridNo, &sX2, &sY2);
+	FLOAT dDeltaX = (FLOAT)( sX - sX2 );
+	FLOAT dDeltaY = (FLOAT)( sY - sY2 );
 	FLOAT d2DDistance = sqrt((dDeltaX*dDeltaX)+(dDeltaY*dDeltaY));
 
 	// Find a target in the tile

--- a/Tactical/opplist.cpp
+++ b/Tactical/opplist.cpp
@@ -6439,8 +6439,7 @@ void HearNoise(SOLDIERTYPE *pSoldier, UINT8 ubNoiseMaker, INT32 sGridNo, INT8 bL
 	// ignore muzzle flashes when turning head to see noise
 	if ( ubNoiseType == NOISE_GUNFIRE && ubNoiseMaker != NOBODY && MercPtrs[ ubNoiseMaker ]->flags.fMuzzleFlash )
 	{
-		sNoiseX = CenterX(sGridNo);
-		sNoiseY = CenterY(sGridNo);
+		ConvertGridNoToCenterCellXY(sGridNo, &sNoiseX, &sNoiseY);
 		bDirection = atan8(pSoldier->sX,pSoldier->sY,sNoiseX,sNoiseY);
 		if ( pSoldier->ubDirection != bDirection && pSoldier->ubDirection != gOneCDirection[ bDirection ] && pSoldier->ubDirection != gOneCCDirection[ bDirection ] )
 		{
@@ -6461,8 +6460,7 @@ void HearNoise(SOLDIERTYPE *pSoldier, UINT8 ubNoiseMaker, INT32 sGridNo, INT8 bL
 	if (PythSpacesAway(pSoldier->sGridNo,sGridNo) <= sDistVisible )
 	{
 		// just use the XXadjustedXX center of the gridno
-		sNoiseX = CenterX(sGridNo);
-		sNoiseY = CenterY(sGridNo);
+		ConvertGridNoToCenterCellXY(sGridNo, &sNoiseX, &sNoiseY);
 
 		if (pSoldier->ubDirection != atan8(pSoldier->sX,pSoldier->sY,sNoiseX,sNoiseY))
 		{

--- a/Tactical/opplist.cpp
+++ b/Tactical/opplist.cpp
@@ -6130,10 +6130,8 @@ void ProcessNoise(UINT8 ubNoiseMaker, INT32 sGridNo, INT8 bLevel, UINT8 ubTerrTy
 			{
 				// ALL RIGHT!	Passed all the tests, this listener hears this noise!!!
 				HearNoise(pSoldier,ubSource,sGridNo,bLevel,ubEffVolume,ubNoiseType, (UINT8 *)&bSeen);
-
 				bHeard = TRUE;
-
-				ubNoiseDir = atan8(CenterX(pSoldier->sGridNo),CenterY(pSoldier->sGridNo),CenterX(sGridNo),CenterY(sGridNo));
+				ubNoiseDir = GetDirectionFromCenterCellXYGridNo(pSoldier->sGridNo, sGridNo);
 
 				// check the 'noise heard & reported' bit for that soldier & direction
 				if ( ubNoiseType != NOISE_MOVEMENT || bTeam != OUR_TEAM || (pSoldier->aiData.bInterruptDuelPts != NO_INTERRUPT) || !(pSoldier->ubMovementNoiseHeard & (1 << ubNoiseDir) ) )

--- a/TacticalAI/AIUtils.cpp
+++ b/TacticalAI/AIUtils.cpp
@@ -144,7 +144,7 @@ BOOLEAN ConsiderProne( SOLDIERTYPE * pSoldier )
 	}
 	// We don't want to go prone if there is a nearby enemy
 	ClosestKnownOpponent( pSoldier, &sOpponentGridNo, &bOpponentLevel );
-	iRange = GetRangeFromGridNoDiff( pSoldier->sGridNo, sOpponentGridNo );
+	iRange = PythSpacesAway( pSoldier->sGridNo, sOpponentGridNo );
 	if (iRange > 10)
 	{
 		return( TRUE );

--- a/TacticalAI/AIUtils.cpp
+++ b/TacticalAI/AIUtils.cpp
@@ -2724,7 +2724,7 @@ INT32 CalcManThreatValue( SOLDIERTYPE *pEnemy, INT32 sMyGrid, UINT8 ubReduceForC
 		else
 		{
 			// ADD 5% if man's already facing me
-			if (pEnemy->ubDirection == atan8(CenterX(pEnemy->sGridNo),CenterY(pEnemy->sGridNo),CenterX(sMyGrid),CenterY(sMyGrid)))
+			if (pEnemy->ubDirection == GetDirectionFromCenterCellXYGridNo(pEnemy->sGridNo, sMyGrid))
 			{
 				iThreatValue += (iThreatValue / 20);
 			}
@@ -3619,13 +3619,13 @@ UINT8 CountFriendsInDirection( SOLDIERTYPE *pSoldier, INT32 sTargetGridNo )
 
 	CHECKF(pSoldier);
 
-	ubMyDir = atan8(CenterX(sTargetGridNo),CenterY(sTargetGridNo),CenterX(pSoldier->sGridNo),CenterY(pSoldier->sGridNo));
+	ubMyDir = GetDirectionFromCenterCellXYGridNo(sTargetGridNo, pSoldier->sGridNo);
 
 	// Run through each friendly.
 	for ( UINT8 iCounter = gTacticalStatus.Team[ pSoldier->bTeam ].bFirstID ; iCounter <= gTacticalStatus.Team[ pSoldier->bTeam ].bLastID ; iCounter ++ )
 	{
 		pFriend = MercPtrs[ iCounter ];
-		ubFriendDir = atan8(CenterX(sTargetGridNo),CenterY(sTargetGridNo),CenterX(pFriend->sGridNo),CenterY(pFriend->sGridNo));
+		ubFriendDir = GetDirectionFromCenterCellXYGridNo(sTargetGridNo, pFriend->sGridNo);
 
 		if (pFriend != pSoldier &&
 			pFriend->bActive &&
@@ -4811,7 +4811,7 @@ BOOLEAN AnyCoverFromSpot( INT32 sSpot, INT8 bLevel, INT32 sThreatLoc, INT8 bThre
 		return FALSE;
 	}
 
-	ubDirection = atan8(CenterX(sSpot), CenterY(sSpot), CenterX(sThreatLoc), CenterY(sThreatLoc));
+	ubDirection = GetDirectionFromCenterCellXYGridNo(sSpot, sThreatLoc);
 	sCoverSpot = NewGridNo( sSpot, DirectionInc( ubDirection ) );
 
 	if ( TileIsOutOfBounds( sCoverSpot ) )
@@ -5001,7 +5001,7 @@ UINT8 AIDirection(INT32 sSpot1, INT32 sSpot2)
 		return DIRECTION_IRRELEVANT;
 	}
 
-	return atan8(CenterX(sSpot1), CenterY(sSpot1), CenterX(sSpot2), CenterY(sSpot2));
+	return GetDirectionFromCenterCellXYGridNo(sSpot1, sSpot2);
 }
 
 BOOLEAN AICheckIsSniper(SOLDIERTYPE *pSoldier)

--- a/TacticalAI/Attacks.cpp
+++ b/TacticalAI/Attacks.cpp
@@ -783,7 +783,6 @@ BOOLEAN CloseEnoughForGrenadeToss( INT32 sGridNo, INT32 sGridNo2 )
 {
 	INT32	sTempGridNo;
 	UINT8	ubDirection;
-	INT16	sXPos, sYPos, sXPos2, sYPos2;
 	UINT8	ubMovementCost;
 
 	if (sGridNo == sGridNo2 )
@@ -815,13 +814,7 @@ BOOLEAN CloseEnoughForGrenadeToss( INT32 sGridNo, INT32 sGridNo2 )
 		// so we can now do a loop safely
 
 		sTempGridNo = sGridNo;
-
-		sXPos = CenterX( sGridNo );
-		sYPos = CenterY( sGridNo );
-		sXPos2 = CenterX( sGridNo2 );
-		sYPos2 = CenterY( sGridNo2 );
-		ubDirection = atan8( sXPos, sYPos, sXPos2, sYPos2 );
-
+		ubDirection = GetDirectionFromCenterCellXYGridNo(sGridNo, sGridNo2);
 		// For each step of the loop, we are checking for door or obstacle movement costs.	If we
 		// find we're blocked, then this is no good for grenade tossing!
 		do

--- a/TacticalAI/CreatureDecideAction.cpp
+++ b/TacticalAI/CreatureDecideAction.cpp
@@ -481,7 +481,7 @@ INT8 CreatureDecideActionYellow( SOLDIERTYPE * pSoldier )
 	if (pSoldier->aiData.bMobility != CREATURE_IMMOBILE)
 	{
 		// determine direction from this soldier in which the noise lies
-		ubNoiseDir = atan8(CenterX(pSoldier->sGridNo),CenterY(pSoldier->sGridNo),CenterX(sNoiseGridNo),CenterY(sNoiseGridNo));
+		ubNoiseDir = GetDirectionFromCenterCellXYGridNo(pSoldier->sGridNo, sNoiseGridNo);
 
 		// if soldier is not already facing in that direction,
 		// and the noise source is close enough that it could possibly be seen
@@ -849,7 +849,7 @@ INT8 CreatureDecideActionRed(SOLDIERTYPE *pSoldier, UINT8 ubUnconsciousOK)
 		if (!TileIsOutOfBounds(sClosestOpponent))
 			{
 			// determine direction from this soldier to the closest opponent
-			ubOpponentDir = atan8(CenterX(pSoldier->sGridNo),CenterY(pSoldier->sGridNo),CenterX(sClosestOpponent),CenterY(sClosestOpponent));
+			ubOpponentDir = GetDirectionFromCenterCellXYGridNo(pSoldier->sGridNo, sClosestOpponent);
 
 			 // if soldier is not already facing in that direction,
 			 // and the opponent is close enough that he could possibly be seen
@@ -1410,7 +1410,7 @@ INT8 CreatureDecideActionBlack( SOLDIERTYPE * pSoldier )
 				}
 				else if (GetAPsToLook( pSoldier ) <= pSoldier->bActionPoints) // turn to face enemy
 				{
-				bDirection = atan8(CenterX(pSoldier->sGridNo),CenterY(pSoldier->sGridNo),CenterX(sClosestOpponent),CenterY(sClosestOpponent));
+				bDirection = GetDirectionFromCenterCellXYGridNo(pSoldier->sGridNo, sClosestOpponent);
 
 				// if we're not facing towards him
 				if (pSoldier->ubDirection != bDirection && ValidCreatureTurn( pSoldier, bDirection ) )

--- a/TacticalAI/DecideAction.cpp
+++ b/TacticalAI/DecideAction.cpp
@@ -473,8 +473,7 @@ INT8 DecideActionSchedule( SOLDIERTYPE * pSoldier )
 		switch( pSoldier->bAIScheduleProgress )
 		{
 		case 0:
-			sX = CenterX( pSoldier->sOffWorldGridNo );
-			sY = CenterY( pSoldier->sOffWorldGridNo );
+			ConvertGridNoToCenterCellXY(pSoldier->sOffWorldGridNo, &sX, &sY);
 			pSoldier->EVENT_SetSoldierPosition( sX, sY );
 			pSoldier->bInSector = TRUE;
 			MoveSoldierFromAwayToMercSlot( pSoldier );

--- a/TacticalAI/DecideAction.cpp
+++ b/TacticalAI/DecideAction.cpp
@@ -565,7 +565,7 @@ INT8 DecideActionBoxerEnteringRing(SOLDIERTYPE *pSoldier)
 			if (!TileIsOutOfBounds(sDesiredMercLoc))
 			{
 				// see if we are facing this person
-				ubDesiredMercDir = atan8(CenterX(pSoldier->sGridNo),CenterY(pSoldier->sGridNo),CenterX(sDesiredMercLoc),CenterY(sDesiredMercLoc));
+				ubDesiredMercDir = GetDirectionFromCenterCellXYGridNo(pSoldier->sGridNo, sDesiredMercLoc);
 
 				// if not already facing in that direction,
 				if ( pSoldier->ubDirection != ubDesiredMercDir && pSoldier->InternalIsValidStance( ubDesiredMercDir, gAnimControl[ pSoldier->usAnimState ].ubEndHeight ) )
@@ -626,7 +626,7 @@ INT8 DecideActionNamedNPC( SOLDIERTYPE * pSoldier )
 			}
 
 			// see if we are facing this person
-			ubDesiredMercDir = atan8(CenterX(pSoldier->sGridNo),CenterY(pSoldier->sGridNo),CenterX(sDesiredMercLoc),CenterY(sDesiredMercLoc));
+			ubDesiredMercDir = GetDirectionFromCenterCellXYGridNo(pSoldier->sGridNo, sDesiredMercLoc);
 
 			// if not already facing in that direction,
 			if (pSoldier->ubDirection != ubDesiredMercDir && pSoldier->InternalIsValidStance( ubDesiredMercDir, gAnimControl[ pSoldier->usAnimState ].ubEndHeight ) )
@@ -782,7 +782,7 @@ INT8 DecideActionGreen(SOLDIERTYPE *pSoldier)
 			UINT8 ubRingDir;
 			// face ring!
 
-			ubRingDir = atan8(CenterX(pSoldier->sGridNo),CenterY(pSoldier->sGridNo),CenterX(CENTER_OF_RING),CenterY(CENTER_OF_RING));
+			ubRingDir = GetDirectionFromCenterCellXYGridNo(pSoldier->sGridNo, CENTER_OF_RING);
 			if ( gfTurnBasedAI || GetAPsToLook( pSoldier ) <= pSoldier->bActionPoints )
 			{
 				if ( pSoldier->ubDirection != ubRingDir )
@@ -966,7 +966,7 @@ INT8 DecideActionGreen(SOLDIERTYPE *pSoldier)
 				if ( PythSpacesAway(pSoldier->sGridNo, MercPtrs[ubPerson]->sGridNo) < 2 )
 				{
 					// see if we are facing this person
-					UINT8 ubDesiredMercDir = atan8(CenterX(pSoldier->sGridNo),CenterY(pSoldier->sGridNo),CenterX(MercPtrs[ubPerson]->sGridNo),CenterY(MercPtrs[ubPerson]->sGridNo));
+					UINT8 ubDesiredMercDir = GetDirectionFromCenterCellXYGridNo(pSoldier->sGridNo, MercPtrs[ubPerson]->sGridNo);
 
 					// if not already facing in that direction,
 					if ( pSoldier->ubDirection != ubDesiredMercDir )
@@ -1495,8 +1495,7 @@ INT8 DecideActionGreen(SOLDIERTYPE *pSoldier)
 						UINT8 ubNoiseDir;
 						
 						if (TileIsOutOfBounds(sNoiseGridNo) || 
-							(ubNoiseDir = atan8(CenterX(pSoldier->sGridNo),CenterY(pSoldier->sGridNo),CenterX(sNoiseGridNo),CenterY(sNoiseGridNo))
-							) == pSoldier->ubDirection )
+							( ubNoiseDir = GetDirectionFromCenterCellXYGridNo(pSoldier->sGridNo, sNoiseGridNo) ) == pSoldier->ubDirection )
 						
 						{
 							pSoldier->aiData.usActionData = PreRandom(8);
@@ -1668,7 +1667,7 @@ INT8 DecideActionYellow(SOLDIERTYPE *pSoldier)
 					if ( PythSpacesAway(pSoldier->sGridNo, MercPtrs[ubPerson]->sGridNo) < 2 )
 					{
 						// see if we are facing this person
-						UINT8 ubDesiredMercDir = atan8(CenterX(pSoldier->sGridNo),CenterY(pSoldier->sGridNo),CenterX(MercPtrs[ubPerson]->sGridNo),CenterY(MercPtrs[ubPerson]->sGridNo));
+						UINT8 ubDesiredMercDir = GetDirectionFromCenterCellXYGridNo(pSoldier->sGridNo, MercPtrs[ubPerson]->sGridNo);
 
 						// if not already facing in that direction,
 						if ( pSoldier->ubDirection != ubDesiredMercDir )
@@ -1721,7 +1720,7 @@ INT8 DecideActionYellow(SOLDIERTYPE *pSoldier)
 				if ( PythSpacesAway(pSoldier->sGridNo, MercPtrs[ubPerson]->sGridNo) < 2 )
 				{
 					// see if we are facing this person
-					UINT8 ubDesiredMercDir = atan8(CenterX(pSoldier->sGridNo),CenterY(pSoldier->sGridNo),CenterX(MercPtrs[ubPerson]->sGridNo),CenterY(MercPtrs[ubPerson]->sGridNo));
+					UINT8 ubDesiredMercDir = GetDirectionFromCenterCellXYGridNo(pSoldier->sGridNo, MercPtrs[ubPerson]->sGridNo);
 
 					// if not already facing in that direction,
 					if ( pSoldier->ubDirection != ubDesiredMercDir )
@@ -1798,7 +1797,7 @@ INT8 DecideActionYellow(SOLDIERTYPE *pSoldier)
 	////////////////////////////////////////////////////////////////////////////
 
 	// determine direction from this soldier in which the noise lies
-	ubNoiseDir = atan8(CenterX(pSoldier->sGridNo),CenterY(pSoldier->sGridNo),CenterX(sNoiseGridNo),CenterY(sNoiseGridNo));
+	ubNoiseDir = GetDirectionFromCenterCellXYGridNo(pSoldier->sGridNo, sNoiseGridNo);
 
 	// if soldier is not already facing in that direction,
 	// and the noise source is close enough that it could possibly be seen
@@ -3293,7 +3292,7 @@ INT8 DecideActionRed(SOLDIERTYPE *pSoldier)
 					if ( PythSpacesAway(pSoldier->sGridNo, MercPtrs[ubPerson]->sGridNo) < 2 )
 					{
 						// see if we are facing this person
-						UINT8 ubDesiredMercDir = atan8(CenterX(pSoldier->sGridNo),CenterY(pSoldier->sGridNo),CenterX(MercPtrs[ubPerson]->sGridNo),CenterY(MercPtrs[ubPerson]->sGridNo));
+						UINT8 ubDesiredMercDir = GetDirectionFromCenterCellXYGridNo(pSoldier->sGridNo, MercPtrs[ubPerson]->sGridNo);
 
 						// if not already facing in that direction,
 						if ( pSoldier->ubDirection != ubDesiredMercDir )
@@ -3341,7 +3340,7 @@ INT8 DecideActionRed(SOLDIERTYPE *pSoldier)
 				if ( PythSpacesAway(pSoldier->sGridNo, MercPtrs[ubPerson]->sGridNo) < 2 )
 				{
 					// see if we are facing this person
-					UINT8 ubDesiredMercDir = atan8(CenterX(pSoldier->sGridNo),CenterY(pSoldier->sGridNo),CenterX(MercPtrs[ubPerson]->sGridNo),CenterY(MercPtrs[ubPerson]->sGridNo));
+					UINT8 ubDesiredMercDir = GetDirectionFromCenterCellXYGridNo(pSoldier->sGridNo, MercPtrs[ubPerson]->sGridNo);
 
 					// if not already facing in that direction,
 					if ( pSoldier->ubDirection != ubDesiredMercDir )
@@ -4521,7 +4520,7 @@ INT8 DecideActionRed(SOLDIERTYPE *pSoldier)
 		if (!TileIsOutOfBounds(sClosestOpponent))
 		{
 			// determine direction from this soldier to the closest opponent
-			ubOpponentDir = atan8(CenterX(pSoldier->sGridNo),CenterY(pSoldier->sGridNo),CenterX(sClosestOpponent),CenterY(sClosestOpponent));
+			ubOpponentDir = GetDirectionFromCenterCellXYGridNo(pSoldier->sGridNo, sClosestOpponent);
 
 			// if soldier is not already facing in that direction,
 			// and the opponent is close enough that he could possibly be seen
@@ -4625,7 +4624,7 @@ INT8 DecideActionRed(SOLDIERTYPE *pSoldier)
 			
 			if (!TileIsOutOfBounds(sClosestDisturbance))
 			{
-				ubOpponentDir = atan8( CenterX( pSoldier->sGridNo ), CenterY( pSoldier->sGridNo ), CenterX( sClosestDisturbance ), CenterY( sClosestDisturbance ) );
+				ubOpponentDir = GetDirectionFromCenterCellXYGridNo(pSoldier->sGridNo, sClosestDisturbance);
 				if ( pSoldier->ubDirection == ubOpponentDir )
 				{
 					ubOpponentDir = (UINT8) PreRandom( NUM_WORLD_DIRECTIONS );
@@ -4768,7 +4767,7 @@ INT8 DecideActionRed(SOLDIERTYPE *pSoldier)
 					if (!gfTurnBasedAI || (GetAPsToReadyWeapon( pSoldier, READY_RIFLE_CROUCH ) + GetAPsToChangeStance( pSoldier, ANIM_CROUCH )) <= pSoldier->bActionPoints)
 					{
 						// determine direction from this soldier to the closest opponent
-						ubOpponentDir = atan8(CenterX(pSoldier->sGridNo),CenterY(pSoldier->sGridNo),CenterX(sClosestOpponent),CenterY(sClosestOpponent));
+						ubOpponentDir = GetDirectionFromCenterCellXYGridNo(pSoldier->sGridNo, sClosestOpponent);
 
 						if (!WeaponReady(pSoldier) && 
 							pSoldier->ubDirection == ubOpponentDir &&
@@ -4802,7 +4801,7 @@ INT8 DecideActionRed(SOLDIERTYPE *pSoldier)
 		
 		if (!TileIsOutOfBounds(sClosestDisturbance))
 		{
-			ubOpponentDir = atan8( CenterX( pSoldier->sGridNo ), CenterY( pSoldier->sGridNo ), CenterX( sClosestDisturbance ), CenterY( sClosestDisturbance ) );
+			ubOpponentDir = GetDirectionFromCenterCellXYGridNo(pSoldier->sGridNo, sClosestDisturbance);
 			if ( pSoldier->ubDirection != ubOpponentDir )
 			{
 				if ( !gfTurnBasedAI || GetAPsToLook( pSoldier ) <= pSoldier->bActionPoints )
@@ -6994,7 +6993,7 @@ L_NEWAIM:
 			if(!TileIsOutOfBounds(pSoldier->sLastTarget))
 				sClosestOpponent = pSoldier->sLastTarget;
 			pSoldier->aiData.bNextAction = AI_ACTION_CHANGE_FACING;
-			pSoldier->aiData.usNextActionData = atan8(CenterX(sBestCover),CenterY(sBestCover),CenterX(sClosestOpponent),CenterY(sClosestOpponent));
+			pSoldier->aiData.usNextActionData = GetDirectionFromCenterCellXYGridNo(sBestCover, sClosestOpponent);
 		}
 		return(AI_ACTION_TAKE_COVER);
 	}
@@ -7088,7 +7087,7 @@ L_NEWAIM:
 							// if we have a closest seen opponent						
 							if (!TileIsOutOfBounds(sClosestOpponent))
 							{
-								bDirection = atan8(CenterX(pSoldier->sGridNo),CenterY(pSoldier->sGridNo),CenterX(sClosestOpponent),CenterY(sClosestOpponent));
+								bDirection = GetDirectionFromCenterCellXYGridNo(pSoldier->sGridNo, sClosestOpponent);
 
 								// if we're not facing towards him
 								if (pSoldier->ubDirection != bDirection)
@@ -7149,7 +7148,7 @@ L_NEWAIM:
 			{
 				if(!TileIsOutOfBounds(pSoldier->sLastTarget))//dnl ch58 150913
 					sClosestOpponent = pSoldier->sLastTarget;
-				bDirection = atan8(CenterX(pSoldier->sGridNo),CenterY(pSoldier->sGridNo),CenterX(sClosestOpponent),CenterY(sClosestOpponent));
+				bDirection = GetDirectionFromCenterCellXYGridNo(pSoldier->sGridNo, sClosestOpponent);
 
 				// if we're not facing towards him
 				if ( pSoldier->ubDirection != bDirection && pSoldier->InternalIsValidStance( bDirection, gAnimControl[ pSoldier->usAnimState ].ubEndHeight ) )
@@ -7801,7 +7800,7 @@ INT8 ArmedVehicleDecideActionGreen( SOLDIERTYPE *pSoldier )
 						UINT8 ubNoiseDir;
 
 						if ( TileIsOutOfBounds( sNoiseGridNo ) ||
-							 (ubNoiseDir = atan8( CenterX( pSoldier->sGridNo ), CenterY( pSoldier->sGridNo ), CenterX( sNoiseGridNo ), CenterY( sNoiseGridNo ) )
+							 (ubNoiseDir = GetDirectionFromCenterCellXYGridNo(pSoldier->sGridNo, sNoiseGridNo)
 							 ) == pSoldier->ubDirection )
 
 						{
@@ -7904,7 +7903,7 @@ INT8 ArmedVehicleDecideActionYellow( SOLDIERTYPE *pSoldier )
 	////////////////////////////////////////////////////////////////////////////
 
 	// determine direction from this soldier in which the noise lies
-	ubNoiseDir = atan8( CenterX( pSoldier->sGridNo ), CenterY( pSoldier->sGridNo ), CenterX( sNoiseGridNo ), CenterY( sNoiseGridNo ) );
+	ubNoiseDir = GetDirectionFromCenterCellXYGridNo(pSoldier->sGridNo, sNoiseGridNo);
 
 	// if soldier is not already facing in that direction,
 	// and the noise source is close enough that it could possibly be seen
@@ -9153,7 +9152,7 @@ INT8 ArmedVehicleDecideActionRed( SOLDIERTYPE *pSoldier)
 					if ( bHighestWatchLoc != -1 )
 					{
 						// see if we need turn to face that location
-						ubOpponentDir = atan8( CenterX( pSoldier->sGridNo ), CenterY( pSoldier->sGridNo ), CenterX( gsWatchedLoc[pSoldier->ubID][bHighestWatchLoc] ), CenterY( gsWatchedLoc[pSoldier->ubID][bHighestWatchLoc] ) );
+						ubOpponentDir = GetDirectionFromCenterCellXYGridNo(pSoldier->sGridNo, gsWatchedLoc[pSoldier->ubID][bHighestWatchLoc]);
 
 						// if soldier is not already facing in that direction,
 						// and the opponent is close enough that he could possibly be seen
@@ -9339,7 +9338,7 @@ INT8 ArmedVehicleDecideActionRed( SOLDIERTYPE *pSoldier)
 		if ( !TileIsOutOfBounds( sClosestOpponent ) )
 		{
 			// determine direction from this soldier to the closest opponent
-			ubOpponentDir = atan8( CenterX( pSoldier->sGridNo ), CenterY( pSoldier->sGridNo ), CenterX( sClosestOpponent ), CenterY( sClosestOpponent ) );
+			ubOpponentDir = GetDirectionFromCenterCellXYGridNo(pSoldier->sGridNo, sClosestOpponent);
 
 			// if soldier is not already facing in that direction,
 			// and the opponent is close enough that he could possibly be seen
@@ -9384,7 +9383,7 @@ INT8 ArmedVehicleDecideActionRed( SOLDIERTYPE *pSoldier)
 
 		if ( !TileIsOutOfBounds( sClosestDisturbance ) )
 		{
-			ubOpponentDir = atan8( CenterX( pSoldier->sGridNo ), CenterY( pSoldier->sGridNo ), CenterX( sClosestDisturbance ), CenterY( sClosestDisturbance ) );
+			ubOpponentDir = GetDirectionFromCenterCellXYGridNo(pSoldier->sGridNo, sClosestDisturbance);
 			if ( pSoldier->ubDirection == ubOpponentDir )
 			{
 				ubOpponentDir = (UINT8)PreRandom( NUM_WORLD_DIRECTIONS );
@@ -9435,7 +9434,7 @@ INT8 ArmedVehicleDecideActionRed( SOLDIERTYPE *pSoldier)
 
 		if ( !TileIsOutOfBounds( sClosestDisturbance ) )
 		{
-			ubOpponentDir = atan8( CenterX( pSoldier->sGridNo ), CenterY( pSoldier->sGridNo ), CenterX( sClosestDisturbance ), CenterY( sClosestDisturbance ) );
+			ubOpponentDir = GetDirectionFromCenterCellXYGridNo(pSoldier->sGridNo, sClosestDisturbance);
 			if ( pSoldier->ubDirection != ubOpponentDir )
 			{
 				if ( !gfTurnBasedAI || GetAPsToLook( pSoldier ) <= pSoldier->bActionPoints )
@@ -10019,7 +10018,7 @@ INT8 ArmedVehicleDecideActionBlack( SOLDIERTYPE *pSoldier )
 			if ( gGameExternalOptions.fEnemyTanksCanMoveInTactical )
 			{
 				// first get the direction, as we will need to pass that in to ShootingStanceChange
-				bDirection = atan8( CenterX( pSoldier->sGridNo ), CenterY( pSoldier->sGridNo ), CenterX( BestAttack.sTarget ), CenterY( BestAttack.sTarget ) );
+				bDirection = GetDirectionFromCenterCellXYGridNo(pSoldier->sGridNo, BestAttack.sTarget);
 				
 				// Change facing
 				if ( pSoldier->ubDirection != bDirection && pSoldier->InternalIsValidStance( bDirection, gAnimControl[pSoldier->usAnimState].ubEndHeight ) )
@@ -10306,7 +10305,7 @@ INT8 ArmedVehicleDecideActionBlack( SOLDIERTYPE *pSoldier )
 			{
 				if ( !TileIsOutOfBounds( pSoldier->sLastTarget ) )//dnl ch58 150913
 					sClosestOpponent = pSoldier->sLastTarget;
-				bDirection = atan8( CenterX( pSoldier->sGridNo ), CenterY( pSoldier->sGridNo ), CenterX( sClosestOpponent ), CenterY( sClosestOpponent ) );
+				bDirection = GetDirectionFromCenterCellXYGridNo(pSoldier->sGridNo, sClosestOpponent);
 
 				// if we're not facing towards him
 				if ( pSoldier->ubDirection != bDirection && pSoldier->InternalIsValidStance( bDirection, gAnimControl[pSoldier->usAnimState].ubEndHeight ) )

--- a/TileEngine/Explosion Control.cpp
+++ b/TileEngine/Explosion Control.cpp
@@ -698,8 +698,7 @@ INT8 ExplosiveDamageStructureAtGridNo( STRUCTURE * pCurrent, STRUCTURE **ppNextC
 #endif
 	
 	// Get xy
-	sX = CenterX( sGridNo );
-	sY = CenterY( sGridNo );
+	ConvertGridNoToCenterCellXY(sGridNo, &sX, &sY);
 
 	// ATE: Continue if we are only looking for walls
 	if ( fOnlyWalls && !( pCurrent->fFlags & STRUCTURE_WALLSTUFF ) )
@@ -1305,7 +1304,9 @@ INT8 ExplosiveDamageStructureAtGridNo( STRUCTURE * pCurrent, STRUCTURE **ppNextC
 					// Make secondary explosion if eplosive....
 					if ( fExplosive )
 					{
-						InternalIgniteExplosion( ubOwner, CenterX( sBaseGridNo ), CenterY( sBaseGridNo ), 0, sBaseGridNo, STRUCTURE_EXPLOSION, FALSE, bLevel );
+						INT16 sX, sY;
+						ConvertGridNoToCenterCellXY(sBaseGridNo, &sX, &sY);
+						InternalIgniteExplosion( ubOwner, sX, sY, 0, sBaseGridNo, STRUCTURE_EXPLOSION, FALSE, bLevel );
 					}
 				}
 
@@ -1477,7 +1478,9 @@ void ExplosiveDamageGridNo( INT32 sGridNo, INT16 sWoundAmt, UINT32 uiDist, BOOLE
 										}
 
 										{
-											InternalIgniteExplosion( ubOwner, CenterX( sNewGridNo2 ), CenterY( sNewGridNo2 ), 0, sNewGridNo2, RDX, FALSE, bLevel );
+											INT16 sX, sY;
+											ConvertGridNoToCenterCellXY(sNewGridNo2, &sX, &sY);
+											InternalIgniteExplosion( ubOwner, sX, sY, 0, sNewGridNo2, RDX, FALSE, bLevel );
 										}
 
 										fToBreak = TRUE;
@@ -4163,7 +4166,10 @@ void HandleExplosionQueue( void )
 						// no preplaced (owner=NOBODY) tripwire with explosive attachments allowed
 						if ( gGameExternalOptions.bAllowExplosiveAttachments && (*pObj)[0]->data.misc.ubBombOwner > 1 )
 						{
-							fAttFound=HandleAttachedExplosions( (UINT8) ((*pObj)[0]->data.misc.ubBombOwner - 2), CenterX( sGridNo ), CenterY( sGridNo ), 0, 
+							INT16 sX, sY;
+							ConvertGridNoToCenterCellXY(sGridNo, &sX, &sY);
+
+							fAttFound=HandleAttachedExplosions( (UINT8) ((*pObj)[0]->data.misc.ubBombOwner - 2), sX, sY, 0,
 											sGridNo, (*pObj)[0]->data.misc.usBombItem, FALSE, ubLevel, (*pObj)[0]->data.ubDirection, pObj);
 						}
 					}
@@ -4236,15 +4242,18 @@ void HandleExplosionQueue( void )
 					CheckForBuriedBombsAndRemoveFlags( sGridNo, ubLevel);
 					// BOOM!
 
+					INT16 sX, sY;
+					ConvertGridNoToCenterCellXY(sGridNo, &sX, &sY);
+
 					// bomb objects only store the SIDE who placed the bomb! :-(
 					if ( (*pObj)[0]->data.misc.ubBombOwner > 1 )
 					{
-						IgniteExplosion( (UINT8) ((*pObj)[0]->data.misc.ubBombOwner - 2), CenterX( sGridNo ), CenterY( sGridNo ), 0, sGridNo, (*pObj)[0]->data.misc.usBombItem, ubLevel, (*pObj)[0]->data.ubDirection, pObj);
+						IgniteExplosion( (UINT8) ((*pObj)[0]->data.misc.ubBombOwner - 2), sX, sY, 0, sGridNo, (*pObj)[0]->data.misc.usBombItem, ubLevel, (*pObj)[0]->data.ubDirection, pObj);
 					}
 					else
 					{
 						// pre-placed
-						IgniteExplosion( NOBODY, CenterX( sGridNo ), CenterY( sGridNo ), 0, sGridNo, (*pObj)[0]->data.misc.usBombItem, ubLevel, (*pObj)[0]->data.ubDirection );
+						IgniteExplosion( NOBODY, sX, sY, 0, sGridNo, (*pObj)[0]->data.misc.usBombItem, ubLevel, (*pObj)[0]->data.ubDirection );
 					}
 				}
 /*				if ( FindWorldItemForBuriedBombInGridNo(sGridNo, ubLevel) != -1 )
@@ -5530,8 +5539,8 @@ void FireFragmentsTrapGun( SOLDIERTYPE* pThrower, INT32 gridno, INT16 sZ, OBJECT
 	INT16 horizontalarc = 5;
 	INT16 verticalarc	= 0;
 
-	INT16 sX = CenterX(gridno);
-	INT16 sY = CenterY(gridno);
+	INT16 sX, sY;
+	ConvertGridNoToCenterCellXY(gridno, &sX, &sY);
 
 	AssertMsg( ubFragRange > 0 , "Fragmentation data lacks range property!" );
 
@@ -6331,7 +6340,9 @@ void RoofDestruction( INT32 sGridNo, BOOLEAN fWithExplosion )
 		static UINT16 usRoofCollapseExplosionIndex = 1727;
 		if ( HasItemFlag( usRoofCollapseExplosionIndex, ROOF_COLLAPSE_ITEM ) || GetFirstItemWithFlag( &usRoofCollapseExplosionIndex, ROOF_COLLAPSE_ITEM ) )
 		{
-			InternalIgniteExplosion( NOBODY, CenterX( sGridNo ), CenterY( sGridNo ), 0, sGridNo, usRoofCollapseExplosionIndex, FALSE, 0 );
+			INT16 sX, sY;
+			ConvertGridNoToCenterCellXY(sGridNo, &sX, &sY);
+			InternalIgniteExplosion( NOBODY, sX, sY, 0, sGridNo, usRoofCollapseExplosionIndex, FALSE, 0 );
 		}
 
 		if ( Chance( 15 ) )
@@ -6340,7 +6351,9 @@ void RoofDestruction( INT32 sGridNo, BOOLEAN fWithExplosion )
 
 			if ( debrissmokeitem )
 			{
-				InternalIgniteExplosion( NOBODY, CenterX( sGridNo ), CenterY( sGridNo ), 0, sGridNo, debrissmokeitem, FALSE, 0 );
+				INT16 sX, sY;
+				ConvertGridNoToCenterCellXY(sGridNo, &sX, &sY);
+				InternalIgniteExplosion( NOBODY, sX, sY, 0, sGridNo, debrissmokeitem, FALSE, 0 );
 			}
 		}
 	}

--- a/TileEngine/Isometric Utils.cpp
+++ b/TileEngine/Isometric Utils.cpp
@@ -931,7 +931,7 @@ void ConvertGridNoToCellXY( INT32 sGridNo, INT16 *sXPos, INT16 *sYPos )
 	*sXPos = ( *sXPos * CELL_X_SIZE );
 }
 
-void ConvertGridNoToCenterCellXY( INT32 sGridNo, INT16 *sXPos, INT16 *sYPos )
+void ConvertGridNoToCenterCellXY( const INT32 sGridNo, INT16 *sXPos, INT16 *sYPos )
 {
 	*sYPos = ( sGridNo / WORLD_COLS );
 	*sXPos = ( sGridNo - ( *sYPos * WORLD_COLS ) );

--- a/TileEngine/Isometric Utils.cpp
+++ b/TileEngine/Isometric Utils.cpp
@@ -919,22 +919,6 @@ void ConvertGridNoToCenterCellXY( const INT32 sGridNo, INT16 *sXPos, INT16 *sYPo
 	*sXPos = ( *sXPos * CELL_X_SIZE ) + ( CELL_X_SIZE / 2 );
 }
 
-INT32 GetRangeFromGridNoDiff( INT32 sGridNo1, INT32 sGridNo2 )
-{
-	INT32					uiDist;
-	INT16					sXPos, sYPos, sXPos2, sYPos2;
-
-	// Convert our grid-not into an XY
-	ConvertGridNoToXY( sGridNo1, &sXPos, &sYPos );
-
-	// Convert our grid-not into an XY
-	ConvertGridNoToXY( sGridNo2, &sXPos2, &sYPos2 );
-
-	uiDist = (INT32)(sqrt((double) ( sXPos2 - sXPos )*( sXPos2 - sXPos ) + ( sYPos2 - sYPos ) * ( sYPos2 - sYPos ) ));	
-
-	return( uiDist );
-}
-
 INT32 GetRangeInCellCoordsFromGridNoDiff( INT32 sGridNo1, INT32 sGridNo2 )
 {
 	INT16					sXPos, sYPos, sXPos2, sYPos2;

--- a/TileEngine/Isometric Utils.cpp
+++ b/TileEngine/Isometric Utils.cpp
@@ -965,8 +965,8 @@ INT16 PythSpacesAway(INT32 sOrigin, INT32 sDest)
 {
 	INT16 sRows,sCols,sResult;
 
-	sRows = abs((sOrigin / MAXCOL) - (sDest / MAXCOL));
-	sCols = abs((sOrigin % MAXROW) - (sDest % MAXROW));
+	sRows = (sOrigin / MAXCOL) - (sDest / MAXCOL);
+	sCols = (sOrigin % MAXROW) - (sDest % MAXROW);
 
 
 	// apply Pythagoras's theorem for right-handed triangle:

--- a/TileEngine/Isometric Utils.cpp
+++ b/TileEngine/Isometric Utils.cpp
@@ -708,27 +708,6 @@ BOOLEAN GetMouseMapPos( INT32	*psMapPos )
 }
 
 
-
-BOOLEAN ConvertMapPosToWorldTileCenter( INT32 usMapPos, INT16 *psXPos, INT16 *psYPos )
-{
-	INT16 sWorldX, sWorldY;
-	INT16 sCellX, sCellY;
-
-	// Get X, Y world GRID Coordinates
-	sWorldY = ( usMapPos / WORLD_COLS );
-	sWorldX = usMapPos - ( sWorldY * WORLD_COLS );
-
-	// Convert into cell coords
-	sCellY = sWorldY * CELL_Y_SIZE;
-	sCellX = sWorldX * CELL_X_SIZE;
-
-	// Add center tile positions
-	*psXPos = sCellX + ( CELL_X_SIZE / 2 );
-	*psYPos = sCellY + ( CELL_Y_SIZE / 2 );
-
-	return( TRUE );
-}
-
 void GetScreenXYWorldCoords( INT16 sScreenX, INT16 sScreenY, INT16 *psWorldX, INT16 *psWorldY )
 {
 	INT16 sOffsetX, sOffsetY;

--- a/TileEngine/Isometric Utils.cpp
+++ b/TileEngine/Isometric Utils.cpp
@@ -1234,30 +1234,6 @@ INT16 ExtQuickestDirection(INT16 origin, INT16 dest)
 }
 
 
-// Returns the (center ) cell coordinates in X
-INT16 CenterX( INT32 sGridNo ) 
-{
-	INT32 sYPos, sXPos;
-
-	sYPos = sGridNo / WORLD_COLS;
-	sXPos = ( sGridNo - ( sYPos * WORLD_COLS ) );
-
-	return( ( sXPos * CELL_X_SIZE ) + ( CELL_X_SIZE / 2 ) );
-}
-
-
-// Returns the (center ) cell coordinates in Y
-INT16 CenterY( INT32 sGridNo ) 
-{
-	INT32 sYPos, sXPos;
-
-	sYPos = sGridNo / WORLD_COLS;
-	sXPos = ( sGridNo - ( sYPos * WORLD_COLS ) );
-
-	return( ( sYPos * CELL_Y_SIZE ) + ( CELL_Y_SIZE / 2 ) );
-}
-
-
 INT16 MapX( INT32 sGridNo ) 
 {
 	INT32 sYPos, sXPos;

--- a/TileEngine/Isometric Utils.h
+++ b/TileEngine/Isometric Utils.h
@@ -110,12 +110,6 @@ INT16 QuickestDirection(INT16 origin, INT16 dest);
 INT16 ExtQuickestDirection(INT16 origin, INT16 dest);
 
 
-// Returns the (center ) cell coordinates in X
-INT16 CenterX( INT32 sGridNo );
-
-// Returns the (center ) cell coordinates in Y
-INT16 CenterY( INT32 sGridNo );
-
 INT16 MapX( INT32 sGridNo );
 INT16 MapY( INT32 sGridNo );
 BOOLEAN FindFenceJumpDirection( SOLDIERTYPE *pSoldier, INT32 sGridNo, INT8 bStartingDir, INT8 *pbDirection );

--- a/TileEngine/Isometric Utils.h
+++ b/TileEngine/Isometric Utils.h
@@ -90,7 +90,6 @@ BOOLEAN GridNoOnEdgeOfMap( INT32 sGridNo, INT8 * pbDirection );
 
 BOOLEAN CellXYToScreenXY(INT16 sCellX, INT16 sCellY, INT16 *sScreenX, INT16 *sScreenY);
 
-INT32 GetRangeFromGridNoDiff( INT32 sGridNo1, INT32 sGridNo2 );
 INT32 GetRangeInCellCoordsFromGridNoDiff( INT32 sGridNo1, INT32 sGridNo2 );
 
 BOOLEAN IsPointInScreenRect( INT16 sXPos, INT16 sYPos, SGPRect *pRect );

--- a/TileEngine/Isometric Utils.h
+++ b/TileEngine/Isometric Utils.h
@@ -45,7 +45,7 @@ extern UINT8 gPurpendicularDirection[ NUM_WORLD_DIRECTIONS ][ NUM_WORLD_DIRECTIO
 void ConvertDirectionToVectorInXY(UINT8 ubDirection, INT16* sXDir, INT16* sYDir);
 void ConvertGridNoToXY( INT32 sGridNo, INT16 *sXPos, INT16 *sYPos );
 void ConvertGridNoToCellXY( INT32 sGridNo, INT16 *sXPos, INT16 *sYPos );
-void ConvertGridNoToCenterCellXY( INT32 sGridNo, INT16 *sXPos, INT16 *sYPos );
+void ConvertGridNoToCenterCellXY( const INT32 sGridNo, INT16 *sXPos, INT16 *sYPos );
 
 
 // GRID NO MANIPULATION FUNCTIONS

--- a/TileEngine/Isometric Utils.h
+++ b/TileEngine/Isometric Utils.h
@@ -88,8 +88,6 @@ BOOLEAN GridNoOnVisibleWorldTile( INT32 sGridNo );
 BOOLEAN GridNoOnVisibleWorldTileGivenYLimits( INT32 sGridNo );
 BOOLEAN GridNoOnEdgeOfMap( INT32 sGridNo, INT8 * pbDirection );
 
-BOOLEAN ConvertMapPosToWorldTileCenter( INT32 usMapPos, INT16 *psXPos, INT16 *psYPos );
-
 BOOLEAN CellXYToScreenXY(INT16 sCellX, INT16 sCellY, INT16 *sScreenX, INT16 *sScreenY);
 
 INT32 GetRangeFromGridNoDiff( INT32 sGridNo1, INT32 sGridNo2 );

--- a/TileEngine/LightEffects.cpp
+++ b/TileEngine/LightEffects.cpp
@@ -84,7 +84,10 @@ void UpdateLightingSprite( LIGHTEFFECT *pLight )
 
 	LightSpritePower( pLight->iLight, TRUE );
 //	LightSpriteFake( pLight->iLight );
-	LightSpritePosition( pLight->iLight, (INT16)( CenterX( pLight->sGridNo ) / CELL_X_SIZE ), (INT16)( CenterY( pLight->sGridNo ) / CELL_Y_SIZE ) );
+	INT16 sX, sY;
+	ConvertGridNoToCenterCellXY(pLight->sGridNo, &sX, &sY);
+
+	LightSpritePosition( pLight->iLight, (INT16)( sX / CELL_X_SIZE ), (INT16)( sY / CELL_Y_SIZE ) );
 }
 
 // Flugente: create a pure light, worry about updating sight in other functions

--- a/TileEngine/SmokeEffects.cpp
+++ b/TileEngine/SmokeEffects.cpp
@@ -534,9 +534,11 @@ void AddSmokeEffectToTile( INT32 iSmokeEffectID, INT8 bType, INT32 sGridNo, INT8
 	AniParams.uiFlags	= ANITILE_CACHEDTILE | ANITILE_FORWARD | ANITILE_SMOKE_EFFECT | ANITILE_LOOPING | ANITILE_ALWAYS_TRANSLUCENT;
 	}
 
-	AniParams.sX									= CenterX( sGridNo );
-	AniParams.sY									= CenterY( sGridNo );
-	AniParams.sZ									= (INT16)0;
+	INT16 sX, sY;
+	ConvertGridNoToCenterCellXY(sGridNo, &sX, &sY);
+	AniParams.sX = sX;
+	AniParams.sY = sY;
+	AniParams.sZ = (INT16)0;
 
 	// Use the right graphic based on type..
 	switch( bType )

--- a/TileEngine/environment.cpp
+++ b/TileEngine/environment.cpp
@@ -1092,8 +1092,10 @@ void AddSnakeAmim( INT32 sGridno, UINT8 usDirection )
 {
 	if ( !TileIsOutOfBounds( sGridno ) )
 	{
-		ANITILE_PARAMS	AniParams;
+		INT16 sX, sY;
+		ConvertGridNoToCenterCellXY(sGridno, &sX, &sY);
 
+		ANITILE_PARAMS	AniParams;
 		memset( &AniParams, 0, sizeof(ANITILE_PARAMS) );
 		
 		AniParams.sGridNo = sGridno;
@@ -1101,8 +1103,8 @@ void AddSnakeAmim( INT32 sGridno, UINT8 usDirection )
 		AniParams.sDelay = 100;
 		AniParams.sStartFrame = 0;
 		AniParams.uiFlags = ANITILE_CACHEDTILE | ANITILE_FORWARD | ANITILE_USE_DIRECTION_FOR_START_FRAME;//| ANITILE_LOOPING;
-		AniParams.sX = CenterX( sGridno );
-		AniParams.sY = CenterY( sGridno );
+		AniParams.sX = sX;
+		AniParams.sY = sY;
 		AniParams.sZ = 0;
 		strcpy( AniParams.zCachedFile, "TILECACHE\\WATERSNAKE_MOVE.sti" );
 

--- a/TileEngine/environment.cpp
+++ b/TileEngine/environment.cpp
@@ -1092,9 +1092,6 @@ void AddSnakeAmim( INT32 sGridno, UINT8 usDirection )
 {
 	if ( !TileIsOutOfBounds( sGridno ) )
 	{
-		INT16 sX, sY;
-		ConvertGridNoToCenterCellXY(sGridno, &sX, &sY);
-
 		ANITILE_PARAMS	AniParams;
 		memset( &AniParams, 0, sizeof(ANITILE_PARAMS) );
 		
@@ -1103,8 +1100,7 @@ void AddSnakeAmim( INT32 sGridno, UINT8 usDirection )
 		AniParams.sDelay = 100;
 		AniParams.sStartFrame = 0;
 		AniParams.uiFlags = ANITILE_CACHEDTILE | ANITILE_FORWARD | ANITILE_USE_DIRECTION_FOR_START_FRAME;//| ANITILE_LOOPING;
-		AniParams.sX = sX;
-		AniParams.sY = sY;
+		ConvertGridNoToCenterCellXY(sGridno, &AniParams.sX, &AniParams.sY);
 		AniParams.sZ = 0;
 		strcpy( AniParams.zCachedFile, "TILECACHE\\WATERSNAKE_MOVE.sti" );
 

--- a/TileEngine/physics.cpp
+++ b/TileEngine/physics.cpp
@@ -1995,7 +1995,7 @@ void CalculateLaunchItemBasicParams( SOLDIERTYPE *pSoldier, OBJECTTYPE *pItem, I
 		{
 			// bad news - i can't throw item at myself
 			// so use dir incrementer
-			UINT8	ubDir = atan8( CenterX(pSoldier->sGridNo), CenterY(pSoldier->sGridNo), CenterX(sGridNo), CenterY(sGridNo) );
+			UINT8	ubDir = GetDirectionFromCenterCellXYGridNo(pSoldier->sGridNo, sGridNo);
 			sInterGridNo += DirIncrementer[ubDir];
 		}
 	}

--- a/TileEngine/renderworld.cpp
+++ b/TileEngine/renderworld.cpp
@@ -614,7 +614,7 @@ void ShowRiotShield( SOLDIERTYPE* pSoldier, UINT16 *pBuffer, UINT32 uiDestPitchB
 		// try to keep the shield 'moving' alongside the soldier. This won't work perfectly, but it's better than nothing		
 		INT16 base_x = 0;
 		INT16 base_y = 0;
-		ConvertMapPosToWorldTileCenter( pSoldier->sGridNo, &base_x, &base_y );
+		ConvertGridNoToCenterCellXY( pSoldier->sGridNo, &base_x, &base_y );
 
 		INT16 dx = pSoldier->sX - base_x;
 		INT16 dy = pSoldier->sY - base_y;


### PR DESCRIPTION
This came about when I was looking at display cover functionality, again, and noticed that in the hot loop, we were using functions CenterX & CenterY to calculate coordinates for X and Y separately, duplicating work.

While going through the code for references to these functions, also noticed a lack of a utility function for calculating direction based on center coordinates, even though there was a clear need for one.

I'd like to chip away at the stupid amount of duplicate code we have and maybe this could serve as a starting point?