### PR TITLE
inherit minimum cmake version from ja2

### DIFF
--- a/ext/VFS/CMakeLists.txt
+++ b/ext/VFS/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 2.6)
-
 project(bfVFS)
 
 set(BFVFS_VERSION_MAJOR 1)


### PR DESCRIPTION
all this does is silence the warning that cmake 2.6 is deprecated, we're never building bfVFS standalone anyway.