### PR TITLE
Fix loading item temp files

### DIFF
--- a/Tactical/Tactical Save.cpp
+++ b/Tactical/Tactical Save.cpp
@@ -1027,6 +1027,7 @@ BOOLEAN SaveCurrentSectorsInformationToTempItemFile( )
 	// handle all reachable before save
 	HandleAllReachAbleItemsInTheSector( gWorldSectorX, gWorldSectorY, gbWorldSectorZ );
 	UpdateWorldItems(gWorldSectorX, gWorldSectorY, gbWorldSectorZ, guiNumWorldItems, gWorldItems);
+	PruneWorldItems();
 
 	std::vector<ROTTING_CORPSE_DEFINITION> corpsedefvector;
 
@@ -3169,7 +3170,6 @@ void LoadWorldItemsFromTempFiles(INT16 sMapX, INT16 sMapY, INT8 bMapZ)
 
 void SaveWorldItemsToTempFiles()
 {
-	PruneWorldItems();
 	for (size_t i = 0; i < gAllWorldItems.sectors.size(); i++)
 	{
 		const auto x = gAllWorldItems.sectors[i].x;

--- a/Tactical/World Items.cpp
+++ b/Tactical/World Items.cpp
@@ -149,6 +149,11 @@ void PruneWorldItems(void)
 		}
 		else
 		{
+			auto x = gAllWorldItems.sectors[i].x;
+			auto y = gAllWorldItems.sectors[i].y;
+			auto z = gAllWorldItems.sectors[i].z;
+			ReSetSectorFlag(x, y, z, SF_ITEM_TEMP_FILE_EXISTS);
+
 			gAllWorldItems.sectors.erase(gAllWorldItems.sectors.begin() + i);
 			gAllWorldItems.NumItems.erase(gAllWorldItems.NumItems.begin() + i);
 			gAllWorldItems.Items.erase(gAllWorldItems.Items.begin() + i);


### PR DESCRIPTION
Call PruneWorldItems() before sectorinfo gets written to the save file. Resetting the SF_ITEM_TEMP_FILE_EXISTS  would not transfer correctly into the save file.