### PR TITLE
Copy drag info to dummy soldier

### DIFF
--- a/Tactical/Soldier Add.cpp
+++ b/Tactical/Soldier Add.cpp
@@ -93,6 +93,9 @@ INT32 FindGridNoFromSweetSpot( SOLDIERTYPE *pSoldier, INT32 sSweetGridNo, INT8 u
 	soldier.pathing.bLevel = 0;
 	soldier.bTeam = 1;
 	soldier.sGridNo = sSweetGridNo;
+	soldier.sDragCorpseID = pSoldier->sDragCorpseID;
+	soldier.sDragGridNo = pSoldier->sDragGridNo;
+	soldier.usDragPersonID = pSoldier->usDragPersonID;
 
 	sTop		= ubRadius;
 	sBottom = -ubRadius;


### PR DESCRIPTION
Fixes merc location shifted by one tile during loading a save when A* pathfinding is enabled.

closes #131 