### PR TITLE
Call RemovePlayerFromGroup instead of RemoveGroup

### DIFF
--- a/Strategic/Merc Contract.cpp
+++ b/Strategic/Merc Contract.cpp
@@ -995,13 +995,13 @@ BOOLEAN StrategicRemoveMerc( SOLDIERTYPE *pSoldier )
 			if( ( pSoldier->bAssignment != VEHICLE ) && !( pSoldier->flags.uiStatusFlags & ( SOLDIER_DRIVER | SOLDIER_PASSENGER ) ) )
 			//if ( pSoldier->bAssignment != VEHICLE )
 			{ //Can only remove groups if they aren't persistant (not in a squad or vehicle)
-				RemoveGroup( pSoldier->ubGroupID );
+				RemovePlayerFromGroup(pSoldier->ubGroupID, pSoldier);
 			}
 			else
 			{
 				// remove him from any existing merc slot he could be in
 				RemoveMercSlot( pSoldier );
-		TakeSoldierOutOfVehicle( pSoldier );
+				TakeSoldierOutOfVehicle( pSoldier );
 			}
 		}
 


### PR DESCRIPTION
There was a bug in a provided save where a merc's group had persistent flag set, even though the assignment was DRILL_MILITIA, which should never have a persistent group. When the code was calling RemoveGroup() instead of RemovePlayerFromGroup() at this point, it would crash the game with an assertion error in CancelEmptyPersistentGroupMovement() as the group in fact was not empty! Now we're removing the merc first and then checking if the group is empty and if so, attempt to delete it.