### PR TITLE
Merc arrival location fix

### DIFF
--- a/Ja2/gamescreen.cpp
+++ b/Ja2/gamescreen.cpp
@@ -628,7 +628,14 @@ UINT32	MainGameScreenHandle(void)
 				InternalLocateGridNo( gGameUBOptions.LOCATEGRIDNO, TRUE );
         }
 #else
+		if (gfFirstHeliRun)
+		{
 			InternalLocateGridNo( gGameExternalOptions.iInitialMercArrivalLocation, TRUE );
+		}
+		else
+		{
+			InternalLocateGridNo(gMapInformation.sCenterGridNo, TRUE);
+		}
 #endif
 		// Flugente: we might have reloaded the game, so we are currently not dropping mercs out of a helicopter
 		gfIngagedInDrop = FALSE;

--- a/Strategic/strategicmap.cpp
+++ b/Strategic/strategicmap.cpp
@@ -3382,27 +3382,22 @@ void UpdateMercInSector( SOLDIERTYPE *pSoldier, INT16 sSectorX, INT16 sSectorY, 
 				break;
 
 			case INSERTION_CODE_ARRIVING_GAME:
-				// Are we in Omerta!
-				if ( sSectorX == gWorldSectorX && gWorldSectorX == 9 && sSectorY == gWorldSectorY && gWorldSectorY == 1 && bSectorZ == gbWorldSectorZ && gbWorldSectorZ == 0 )
+#ifdef JA2UB
+				pSoldier->ubStrategicInsertionCode = INSERTION_CODE_GRIDNO;
+				pSoldier->sInsertionGridNo = gGameUBOptions.LOCATEGRIDNO;
+#else
+				extern BOOLEAN gfFirstHeliRun;
+				if (gfFirstHeliRun)
 				{
-					// TODO.WANNE: Hardcoded grid number
-					// Try another location and walk into map
-					pSoldier->sInsertionGridNo = 4379;//dnl!!!
+					pSoldier->ubStrategicInsertionCode = INSERTION_CODE_GRIDNO;
+					pSoldier->sInsertionGridNo = gGameExternalOptions.iInitialMercArrivalLocation;
 				}
 				else
 				{
-#ifdef JA2UB
-					//pSoldier->ubStrategicInsertionCode = INSERTION_CODE_NORTH;
-					//pSoldier->sInsertionGridNo		   = gMapInformation.sNorthGridNo;
-					pSoldier->ubStrategicInsertionCode = INSERTION_CODE_GRIDNO;
-					pSoldier->sInsertionGridNo = gGameUBOptions.LOCATEGRIDNO;
-#else
-					//pSoldier->ubStrategicInsertionCode = INSERTION_CODE_NORTH;
-					//pSoldier->sInsertionGridNo				 = gMapInformation.sNorthGridNo;
-					pSoldier->ubStrategicInsertionCode = INSERTION_CODE_GRIDNO;
-					pSoldier->sInsertionGridNo = gGameExternalOptions.iInitialMercArrivalLocation;
-#endif
+					pSoldier->ubStrategicInsertionCode = INSERTION_CODE_CENTER;
+					pSoldier->sInsertionGridNo = gMapInformation.sCenterGridNo;
 				}
+#endif
 				break;
 			case INSERTION_CODE_CHOPPER:
 				// Try another location and walk into map

--- a/Tactical/Merc Entering.cpp
+++ b/Tactical/Merc Entering.cpp
@@ -1038,26 +1038,27 @@ UINT8 SpawnAirDropElite( INT32 sGridNo )
 
 	// Flugente hack		
 	pSoldier = TacticalCreateEliteEnemy( );
+	if ( pSoldier == nullptr)
+	{
+		return NOBODY;
+	}
 
 	//Add soldier strategic info, so it doesn't break the counters!
-	if ( pSoldier )
+	if ( !gbWorldSectorZ )
 	{
-		if ( !gbWorldSectorZ )
+		SECTORINFO *pSector = &SectorInfo[SECTOR( gWorldSectorX, gWorldSectorY )];
+		switch ( pSoldier->ubSoldierClass )
 		{
-			SECTORINFO *pSector = &SectorInfo[SECTOR( gWorldSectorX, gWorldSectorY )];
-			switch ( pSoldier->ubSoldierClass )
-			{
-			case SOLDIER_CLASS_ADMINISTRATOR:	pSector->ubNumAdmins++; pSector->ubAdminsInBattle++; break;
-			case SOLDIER_CLASS_ARMY:			pSector->ubNumTroops++; pSector->ubTroopsInBattle++; break;
-			case SOLDIER_CLASS_ELITE:			pSector->ubNumElites++; pSector->ubElitesInBattle++; break;
-			}
+		case SOLDIER_CLASS_ADMINISTRATOR:	pSector->ubNumAdmins++; pSector->ubAdminsInBattle++; break;
+		case SOLDIER_CLASS_ARMY:			pSector->ubNumTroops++; pSector->ubTroopsInBattle++; break;
+		case SOLDIER_CLASS_ELITE:			pSector->ubNumElites++; pSector->ubElitesInBattle++; break;
 		}
-
-		pSoldier->ubStrategicInsertionCode = INSERTION_CODE_CHOPPER;
-		pSoldier->usStrategicInsertionData = sGridNo; // required, otherwise soldiers will spawn in map before jumping out of the heli
-		UpdateMercInSector( pSoldier, gWorldSectorX, gWorldSectorY, gbWorldSectorZ );
-		//AllTeamsLookForAll( NO_INTERRUPTS );
 	}
+
+	pSoldier->ubStrategicInsertionCode = INSERTION_CODE_CHOPPER;
+	pSoldier->usStrategicInsertionData = sGridNo; // required, otherwise soldiers will spawn in map before jumping out of the heli
+	UpdateMercInSector( pSoldier, gWorldSectorX, gWorldSectorY, gbWorldSectorZ );
+	//AllTeamsLookForAll( NO_INTERRUPTS );
 
 	return pSoldier->ubID;
 }

--- a/Tactical/Merc Hiring.cpp
+++ b/Tactical/Merc Hiring.cpp
@@ -50,6 +50,7 @@
 	#include "DynamicDialogue.h"// added by Flugente
 	#include "Dialogue Control.h"	// added by Flugente
 #include "connect.h"
+#include "Map Information.h"
 
 #ifdef JA2UB
 #include "Soldier Control.h"
@@ -534,16 +535,23 @@ void MercArrivesCallback(	UINT8	ubSoldierID )
 		#ifdef JA2UB
 		if ( pSoldier->ubStrategicInsertionCode != INSERTION_CODE_CHOPPER && pSoldier->sSectorX == gGameExternalOptions.ubDefaultArrivalSectorX && pSoldier->sSectorY == gGameExternalOptions.ubDefaultArrivalSectorY && gGameUBOptions.InGameHeli == TRUE )
 		#else
-		if ( pSoldier->ubStrategicInsertionCode != INSERTION_CODE_CHOPPER && pSoldier->sSectorX == gGameExternalOptions.ubDefaultArrivalSectorX && pSoldier->sSectorY == gGameExternalOptions.ubDefaultArrivalSectorY )
+		if (pSoldier->ubStrategicInsertionCode != INSERTION_CODE_CHOPPER )
 		#endif
 		{
 			gfTacticalDoHeliRun = TRUE;
-			SetHelicopterDroppoint(gGameExternalOptions.iInitialMercArrivalLocation);
+			if (gfFirstHeliRun)
+			{
+				SetHelicopterDroppoint(gGameExternalOptions.iInitialMercArrivalLocation);
+			}
+			else
+			{
+				SetHelicopterDroppoint(gMapInformation.sCenterGridNo);
+			}
 
 			// OK, If we are in mapscreen, get out...
 			if ( guiCurrentScreen == MAP_SCREEN )
 			{
-		// ATE: Make sure the current one is selected!
+				// ATE: Make sure the current one is selected!
 				ChangeSelectedMapSector( gWorldSectorX, gWorldSectorY, 0 );
 
 				RequestTriggerExitFromMapscreen( MAP_EXIT_TO_TACTICAL );
@@ -554,17 +562,14 @@ void MercArrivesCallback(	UINT8	ubSoldierID )
 
 		UpdateMercInSector( pSoldier, pSoldier->sSectorX, pSoldier->sSectorY, pSoldier->bSectorZ );
 	}
+	// Strategic map arrival to a sector that's not loaded
 	else
 	{
-		// OK, otherwise, set them in north area, so once we load again, they are here.
 #ifdef JA2UB
-		//pSoldier->ubStrategicInsertionCode = INSERTION_CODE_NORTH;
 		pSoldier->ubStrategicInsertionCode = INSERTION_CODE_GRIDNO;
 		pSoldier->usStrategicInsertionData = gGameUBOptions.LOCATEGRIDNO;
 #else
-		//pSoldier->ubStrategicInsertionCode = INSERTION_CODE_NORTH;
-		pSoldier->ubStrategicInsertionCode = INSERTION_CODE_GRIDNO;
-		pSoldier->usStrategicInsertionData = gGameExternalOptions.iInitialMercArrivalLocation;
+		pSoldier->ubStrategicInsertionCode = INSERTION_CODE_CENTER;
 #endif
 	}
 


### PR DESCRIPTION
Closes #164 

Initial heli insertion uses the gridno defined in modsettings.ini but all subsequent arrivals default to map center insertion point. 

All subsequent arrivals also now play the heli drop animation any loaded sector when mercs arrive, when previously it would only happen if the initial arrival sector was loaded.