### PR TITLE
Disable AI logging by default

### DIFF
--- a/TacticalAI/AIMain.cpp
+++ b/TacticalAI/AIMain.cpp
@@ -209,7 +209,7 @@ STR szAction[] = {
 // sevenfm
 UINT32 guiAIStartCounter = 0, guiAILastCounter = 0;
 //UINT8 gubAISelectedSoldier = NOBODY;
-BOOLEAN gfLogsEnabled = TRUE;
+BOOLEAN gfLogsEnabled = FALSE;
 
 void DebugAI( INT8 bMsgType, SOLDIERTYPE *pSoldier, STR szOutput, INT8 bAction )
 {

--- a/TacticalAI/AIMain.cpp
+++ b/TacticalAI/AIMain.cpp
@@ -217,7 +217,7 @@ void DebugAI( INT8 bMsgType, SOLDIERTYPE *pSoldier, STR szOutput, INT8 bAction )
 	CHAR8	msg[1024];
 	CHAR8	buf[1024];
 
-	if (!gfLogsEnabled)
+	if (!gfLogsEnabled || pSoldier == nullptr)
 		return;
 
 	memset(buf, 0, 1024 * sizeof(char));
@@ -235,17 +235,14 @@ void DebugAI( INT8 bMsgType, SOLDIERTYPE *pSoldier, STR szOutput, INT8 bAction )
 
 	sprintf(msg, "");
 
-	if (pSoldier)
-	{
-		sprintf(buf, "[%d] (%d)", pSoldier->ubID, pSoldier->sGridNo);
-		strcat(msg, buf);
+	sprintf(buf, "[%d] (%d)", pSoldier->ubID, pSoldier->sGridNo);
+	strcat(msg, buf);
 
-		if (pSoldier->ubProfile != NO_PROFILE)
-		{
-			wcstombs(buf, pSoldier->GetName(), 1024 - 1);
-			strcat(msg, " ");
-			strcat(msg, buf);
-		}
+	if (pSoldier->ubProfile != NO_PROFILE)
+	{
+		wcstombs(buf, pSoldier->GetName(), 1024 - 1);
+		strcat(msg, " ");
+		strcat(msg, buf);
 	}
 
 	strcat(msg, " ");
@@ -266,13 +263,10 @@ void DebugAI( INT8 bMsgType, SOLDIERTYPE *pSoldier, STR szOutput, INT8 bAction )
 		strcat(msg, " ");
 		strcat(msg, szAction[bAction]);
 
-		if (pSoldier)
-		{
-			sprintf(buf, " %d", pSoldier->aiData.usActionData);
-			strcat(msg, buf);
-		}
+		sprintf(buf, " %d", pSoldier->aiData.usActionData);
+		strcat(msg, buf);
 
-		if (pSoldier && pSoldier->aiData.bNextAction != AI_ACTION_NONE)
+		if (pSoldier->aiData.bNextAction != AI_ACTION_NONE)
 		{
 			strcat(msg, " ");
 			strcat(msg, szAction[pSoldier->aiData.bNextAction]);


### PR DESCRIPTION
Should only be used when specifically working on or debugging AI actions. In other times it needlessly slows the game down.