### PR TITLE
Revert "Disable AI logging by default"

### DIFF
--- a/TacticalAI/AIMain.cpp
+++ b/TacticalAI/AIMain.cpp
@@ -209,7 +209,7 @@ STR szAction[] = {
 // sevenfm
 UINT32 guiAIStartCounter = 0, guiAILastCounter = 0;
 //UINT8 gubAISelectedSoldier = NOBODY;
-BOOLEAN gfLogsEnabled = FALSE;
+BOOLEAN gfLogsEnabled = TRUE;
 
 void DebugAI( INT8 bMsgType, SOLDIERTYPE *pSoldier, STR szOutput, INT8 bAction )
 {


### PR DESCRIPTION
This reverts commit 5a74323d1f8b074a3142bea288f30d46a90352c4.
Logging is active only if it finds "Logs" folder, therefore this should stay as true.