### PR TITLE
Fix Attachable Launchers Slot  Tooltips

### DIFF
--- a/Tactical/Interface Items.cpp
+++ b/Tactical/Interface Items.cpp
@@ -5769,14 +5769,6 @@ void UpdateAttachmentTooltips(OBJECTTYPE *pObject, UINT8 ubStatusIndex)
 						//search primary item launchables.xml
 						usAttachment = Launchable[usLoop][0];
 					}
-
-					if (usAttachment > 0 && !Item[usAttachment].hiddenaddon && !Item[usAttachment].hiddenattachment && ItemIsLegal(usAttachment))
-					{
-						if (std::find(attachList.begin(), attachList.end(), usAttachment) == attachList.end())
-						{
-							attachList.push_back(usAttachment);
-						}
-					}
 					else
 					{
 						//search for launchables made valid by other attachments
@@ -5785,9 +5777,20 @@ void UpdateAttachmentTooltips(OBJECTTYPE *pObject, UINT8 ubStatusIndex)
 						while (cnt)
 						{
 							if (Launchable[usLoop][1] == *p && AttachmentSlots[usLoopSlotID].nasAttachmentClass & Item[Launchable[usLoop][0]].nasAttachmentClass)
+							{
 								usAttachment = Launchable[usLoop][0];
+								break;
+							}
 
 							cnt--, p++;
+						}
+					}
+
+					if (usAttachment > 0 && !Item[usAttachment].hiddenaddon && !Item[usAttachment].hiddenattachment && ItemIsLegal(usAttachment))
+					{
+						if (std::find(attachList.begin(), attachList.end(), usAttachment) == attachList.end())
+						{
+							attachList.push_back(usAttachment);
 						}
 					}
 				}


### PR DESCRIPTION
fix:
launchables made valid by attached launchers are now again  shown as tooltip and can be attached to slot with click

fixes

https://github.com/1dot13/source/issues/298