### PR TITLE
Fix CTD

### DIFF
--- a/Utils/_Ja25GermanText.cpp
+++ b/Utils/_Ja25GermanText.cpp
@@ -263,7 +263,7 @@ STR16 gzIMPMajorTraitsHelpTextsRadioOperator[]=
 	L"Kann Artillerieunterstützung von Verbündeten in Nachbarsektoren anfordern\n",
 	L"Kann Funkfrequenzen abhören und feindliche Truppen aufspüren\n",
 	L"Kann den Funkverkehr im ganzen Sektor stören\n",
-	L"Kann nach feindlichen Störsendern suchen, wenn solche aktiv sind\n"
+	L"Kann nach feindlichen Störsendern suchen, wenn solche aktiv sind\n",
 	L"Kann Unterstützung durch Milizen aus Nachbarsektoren anfordern\n",
 };
 


### PR DESCRIPTION
Fix illegal array access when creating an IMP and the help texts are referenced. With the missing comma, the array length was 5 and it's supposed to be 6.