### PR TITLE
Check that a dropped backpack belongs to a controllable merc

### DIFF
--- a/Tactical/Turn Based Input.cpp
+++ b/Tactical/Turn Based Input.cpp
@@ -8318,7 +8318,7 @@ void HandleTBBackpacks(void)
 		{
 			pTeamSoldier = MercPtrs[ubLoop];
 
-			if (pTeamSoldier->flags.DropPackFlag)
+			if (OK_CONTROLLABLE_MERC(pTeamSoldier) && pTeamSoldier->flags.DropPackFlag)
 			{
 				backpackDropped = true;
 				break;


### PR DESCRIPTION
Fixes incorrect handle BP pickup behavior if a merc drops a backpack and then leaves the sector. Previously it would always find that one backpack without the owner present in the sector, thus always opt for "Pick up backpacks" branch.