### PR TITLE
Read new MercOpinions.xml format

### DIFF
--- a/Tactical/CMakeLists.txt
+++ b/Tactical/CMakeLists.txt
@@ -93,6 +93,7 @@ set(TacticalSrc
 "${CMAKE_CURRENT_SOURCE_DIR}/VehicleMenu.cpp"
 "${CMAKE_CURRENT_SOURCE_DIR}/Weapons.cpp"
 "${CMAKE_CURRENT_SOURCE_DIR}/World Items.cpp"
+"${CMAKE_CURRENT_SOURCE_DIR}/XML.cpp"
 "${CMAKE_CURRENT_SOURCE_DIR}/XML_AmmoStrings.cpp"
 "${CMAKE_CURRENT_SOURCE_DIR}/XML_AmmoTypes.cpp"
 "${CMAKE_CURRENT_SOURCE_DIR}/XML_Armour.cpp"

--- a/Tactical/XML.cpp
+++ b/Tactical/XML.cpp
@@ -1,0 +1,9 @@
+#include "XML.h"
+
+const XML_Char* GetAttribute(const XML_Char* name, const XML_Char** atts) {
+	for (const XML_Char** pIter = atts; *pIter != NULL; pIter++) {
+		const XML_Char* key = *pIter++;
+		if (strcmp(key, name) == 0) return *pIter;
+	}
+	return NULL;
+}

--- a/Tactical/XML.h
+++ b/Tactical/XML.h
@@ -1,6 +1,7 @@
 #ifndef __XML_H
 #define __XML_H
 
+#include "expat.h"
 #include "armsdealerinvinit.h"
 #include "EnemyItemDrops.h"
 #include "Loading Screen.h"
@@ -580,5 +581,7 @@ extern BOOLEAN ReadInAimOldArchive(STR fileName, BOOLEAN localizedVersion);
 
 extern BOOLEAN ReadInHistorys(STR fileName, BOOLEAN localizedVersion );
 extern BOOLEAN ReadInDifficultySettings(STR fileName, BOOLEAN localizedVersion);
+
+extern const XML_Char* GetAttribute(const XML_Char* name, const XML_Char** atts);
 
 #endif

--- a/Tactical/XML_Opinions.cpp
+++ b/Tactical/XML_Opinions.cpp
@@ -70,21 +70,21 @@ opinionStartElementHandle(void *userData, const XML_Char *name, const XML_Char *
 
 			pData->maxReadDepth++; //we are not skipping this element
 		}
-		else if(pData->curElement == ELEMENT)
+		else if (pData->curElement == ELEMENT && strcmp(name, "AnOpinion") == 0)
 		{
-			for(UINT8 i = 0; i < NUMBER_OF_OPINIONS; ++i)
+			pData->curElement = ELEMENT;
+			pData->maxReadDepth++; //we are not skipping this element
+
+			XML_Char const* anID = GetAttribute("id", atts);
+			XML_Char const* modifier = GetAttribute("modifier", atts);
+
+			INT32 id, value;
+			id = atoi(anID);
+			value = atoi(modifier);
+
+			if (id >= 0 && id < NUMBER_OF_OPINIONS)
 			{
-				XML_Char bla[12];
-				sprintf(bla, "Opinion%d", i);
-				
-				if(strcmp(name, bla) == 0)
-				{
-					pData->curElement = ELEMENT_PROPERTY;
-
-					pData->maxReadDepth++; //we are not skipping this element
-
-					break;
-				}
+				pData->curProfile.bMercOpinion[id] = value;
 			}
 		}
 
@@ -92,8 +92,8 @@ opinionStartElementHandle(void *userData, const XML_Char *name, const XML_Char *
 	}
 
 	pData->currentDepth++;
-
 }
+
 
 static void XMLCALL
 opinionCharacterDataHandle(void *userData, const XML_Char *str, int len)
@@ -149,24 +149,6 @@ opinionEndElementHandle(void *userData, const XML_Char *name)
 			pData->curIndex = (UINT32) strtoul(pData->szCharData, NULL, 0);
 		}
 
-		else
-		{
-			for(UINT8 i = 0; i < NUMBER_OF_OPINIONS; ++i)
-			{
-				XML_Char bla[12];
-				sprintf(bla, "Opinion%d", i);
-				
-				if(strcmp(name, bla) == 0)
-				{
-					pData->curElement = ELEMENT;
-
-					pData->curProfile.bMercOpinion[i] = (INT8) atol(pData->szCharData);
-
-					break;
-				}
-			}
-		}
-		
 		pData->maxReadDepth--;
 	}
 
@@ -315,7 +297,10 @@ BOOLEAN WriteMercOpinions()
 			UINT8 cnt_b = 0;
 			for (cnt_b = 0; cnt_b < NUMBER_OF_OPINIONS; ++cnt_b)
 			{
-				FilePrintf(hFile,"\t\t<Opinion%d>%d</Opinion%d>\r\n", cnt_b, gMercProfiles[ cnt ].bMercOpinion[cnt_b], cnt_b);
+				if (gMercProfiles[cnt].bMercOpinion[cnt_b] != 0)
+				{
+					FilePrintf(hFile, "\t\t<AnOpinion id = \"%d\" modifier = \"%d\" />\r\n", cnt_b, gMercProfiles[cnt].bMercOpinion[cnt_b]);
+				}
 			}
 			
 


### PR DESCRIPTION
Requires accompanying gameDir change https://github.com/1dot13/gamedir/pull/95.

MercOpinions.xml now only contains opinions that are not 0. A new tag with fields "id" and "modifier" are used instead of old ones that had 255 \<Opinion%d\> $value$ \</Opinion%d\> tags for all profiles.

Loading time of MercOpinions.xml went down from ~4.047 s to 0.011 s due to this change with default 1.13 VFS config.


A small cmd utility tool for converting existing MercOpinions.xml data into the new format is available at https://github.com/Asdow/JA2-ConvertXMLData/tree/master