### PR TITLE
Improve AbstractXMLParser error reporting

### DIFF
--- a/Ja2/Init.cpp
+++ b/Ja2/Init.cpp
@@ -438,11 +438,13 @@ BOOLEAN LoadExternalGameplayData(STR directoryName, BOOLEAN isMultiplayer)
 		if (isMultiplayer == false)
 		{
 			using namespace LogicalBodyTypes;
-			SGP_THROW_IFFALSE(Layers::Instance().LoadFromFile(directoryName, LBT_LAYERSFILENAME), LBT_LAYERSFILENAME);
-			SGP_THROW_IFFALSE(PaletteDB::Instance().LoadFromFile(directoryName, LBT_PALETTESFILENAME), LBT_PALETTESFILENAME);
-			SGP_THROW_IFFALSE(SurfaceDB::Instance().LoadFromFile(directoryName, LBT_ANIMSURFACESFILENAME), LBT_ANIMSURFACESFILENAME);
-			SGP_THROW_IFFALSE(FilterDB::Instance().LoadFromFile(directoryName, LBT_FILTERSFILENAME), LBT_FILTERSFILENAME);
-			SGP_THROW_IFFALSE(BodyTypeDB::Instance().LoadFromFile(directoryName, LBT_BODYTYPESFILENAME), LBT_BODYTYPESFILENAME);
+			CHAR8 errorBuf[512]{"Failed loading LogicalBodyTypes external data!"};
+
+			SGP_THROW_IFFALSE(Layers::Instance().LoadFromFile(directoryName, LBT_LAYERSFILENAME, errorBuf), errorBuf);
+			SGP_THROW_IFFALSE(PaletteDB::Instance().LoadFromFile(directoryName, LBT_PALETTESFILENAME, errorBuf), errorBuf);
+			SGP_THROW_IFFALSE(SurfaceDB::Instance().LoadFromFile(directoryName, LBT_ANIMSURFACESFILENAME, errorBuf), errorBuf);
+			SGP_THROW_IFFALSE(FilterDB::Instance().LoadFromFile(directoryName, LBT_FILTERSFILENAME, errorBuf), errorBuf);
+			SGP_THROW_IFFALSE(BodyTypeDB::Instance().LoadFromFile(directoryName, LBT_BODYTYPESFILENAME, errorBuf), errorBuf);
 		}
 	}
 

--- a/Tactical/LogicalBodyTypes/AbstractXMLLoader.h
+++ b/Tactical/LogicalBodyTypes/AbstractXMLLoader.h
@@ -55,7 +55,7 @@ private:
 public:
 	AbstractXMLLoader(XML_StartElementHandler startHandler, XML_EndElementHandler endHandler, XML_CharacterDataHandler charHandler, ParseDataFactoryFunc parseDataFactF = MakeParseData);
 	~AbstractXMLLoader(void);
-	bool LoadFromFile(const char* directoryName, const char* fileName);
+	bool LoadFromFile(const char* directoryName, const char* fileName, CHAR8* errorBuf);
 	const char* GetFileName();
 	const char* GetDirectoryName();
 	void SetFileName(const char* fileName);


### PR DESCRIPTION
The more detailed error message that used to go only to Livelog.txt is now also displayed in the ingame error screen, providing more helpful error message to players when making bug reports/asking for help