### PR TITLE
Fix inventory cloning bug

### DIFF
--- a/Strategic/strategicmap.cpp
+++ b/Strategic/strategicmap.cpp
@@ -6665,18 +6665,16 @@ BOOLEAN CheckAndHandleUnloadingOfCurrentWorld( )
 
 	if ( guiCurrentScreen == AUTORESOLVE_SCREEN )
 	{
-		if ( gWorldSectorX == sBattleSectorX && gWorldSectorY == sBattleSectorY && gbWorldSectorZ == sBattleSectorZ )
-		{	//Yes, this is and looks like a hack.  The conditions of this if statement doesn't work inside
-			//TrashWorld() or more specifically, TacticalRemoveSoldier() from within TrashWorld().  Because
-			//we are in the autoresolve screen, soldiers are internally created different (from pointers instead of
-			//the MercPtrs[]).  It keys on the fact that we are in the autoresolve screen.  So, by switching the
-			//screen, it'll delete the soldiers in the loaded world properly, then later on, once autoresolve is
-			//complete, it'll delete the autoresolve soldiers properly.  As you can now see, the above if conditions
-			//don't change throughout this whole process which makes it necessary to do it this way.
-			guiCurrentScreen = MAP_SCREEN;
-			TrashWorld( );
-			guiCurrentScreen = AUTORESOLVE_SCREEN;
-		}
+		//Yes, this is and looks like a hack.  The conditions of this if statement doesn't work inside
+		//TrashWorld() or more specifically, TacticalRemoveSoldier() from within TrashWorld().  Because
+		//we are in the autoresolve screen, soldiers are internally created different (from pointers instead of
+		//the MercPtrs[]).  It keys on the fact that we are in the autoresolve screen.  So, by switching the
+		//screen, it'll delete the soldiers in the loaded world properly, then later on, once autoresolve is
+		//complete, it'll delete the autoresolve soldiers properly.  As you can now see, the above if conditions
+		//don't change throughout this whole process which makes it necessary to do it this way.
+		guiCurrentScreen = MAP_SCREEN;
+		TrashWorld( );
+		guiCurrentScreen = AUTORESOLVE_SCREEN;
 	}
 	else
 	{


### PR DESCRIPTION
- If we have a sector already loaded (eg. Drassen airport)
- Squad in a different sector encounters enemies and goes to autoresolve
- After pressing DONE in autoresolve screen -> we miss calling the TrashWorld() function in CheckAndHandleUnloadingOfCurrentWorld() due to battle sector not being the same as loaded sector.
- Selected sector gets reset from Drassen airport to invalid values by same function
- Now we have the loaded sector's whole inventory existing in gWorldItems
- Enter any sector in tactical mode and the gWorldItems gets added into its sector inventory in EnterSector()

Because the TrashItems() work in a way where it only sets gWorldItems elements to not existing if it finds them in a loaded map's structure data, we will pretty much always have that original bugged out set of items present in gWorlItems and they will constantly be added to sector inventories from then on once the bug has been triggered.