### PR TITLE
Fix music playing when crepitus is present

### DIFF
--- a/Strategic/Meanwhile.cpp
+++ b/Strategic/Meanwhile.cpp
@@ -864,7 +864,7 @@ void EndMeanwhile( )
 	{
 		// We leave this sector open for our POWs to escape!
 		// Set music mode to enemy present!
-		UseCreatureMusic(HostileZombiesPresent());
+		CheckForZombieMusic();
 
 		SetMusicMode( MUSIC_TACTICAL_ENEMYPRESENT );
 

--- a/Strategic/PreBattle Interface.cpp
+++ b/Strategic/PreBattle Interface.cpp
@@ -1071,8 +1071,8 @@ void InitPreBattleInterface( GROUP *pBattleGroup, BOOLEAN fPersistantPBI )
 	//Disable the options button when the auto resolve	screen comes up
 	EnableDisAbleMapScreenOptionsButton( FALSE );
 
-	UseCreatureMusic(HostileZombiesPresent());
-	
+	CheckForZombieMusic();
+
 #ifdef NEWMUSIC
 	GlobalSoundID  = MusicSoundValues[ SECTOR( gubPBSectorX, gubPBSectorY ) ].SoundTacticalTensor[gubPBSectorZ];
 	if ( MusicSoundValues[ SECTOR( gubPBSectorX, gubPBSectorY ) ].SoundTacticalTensor[gubPBSectorZ] != -1 )

--- a/Strategic/Strategic Movement.cpp
+++ b/Strategic/Strategic Movement.cpp
@@ -1085,7 +1085,7 @@ void PrepareForPreBattleInterface( GROUP *pPlayerDialogGroup, GROUP *pInitiating
 	}
 
 	//Set music
-	UseCreatureMusic(HostileZombiesPresent());
+	CheckForZombieMusic();
 
 #ifdef NEWMUSIC
 	GlobalSoundID  = MusicSoundValues[ SECTOR( gWorldSectorX, gWorldSectorY ) ].SoundTacticalTensor[gbWorldSectorZ];

--- a/Tactical/Merc Entering.cpp
+++ b/Tactical/Merc Entering.cpp
@@ -991,7 +991,7 @@ void HandleFirstHeliDropOfGame( )
 			SayQuoteFromAnyBodyInSector( QUOTE_ENEMY_PRESENCE );
 			
 			// Start music
-			UseCreatureMusic(HostileZombiesPresent());
+			CheckForZombieMusic();
 
 #ifdef NEWMUSIC
 			GlobalSoundID  = MusicSoundValues[ SECTOR( gWorldSectorX, gWorldSectorY ) ].SoundTacticalTensor[gbWorldSectorZ];

--- a/Tactical/Overhead.cpp
+++ b/Tactical/Overhead.cpp
@@ -6664,7 +6664,7 @@ void ExitCombatMode( )
     // unused
     //gfForceMusicToTense = TRUE;
 
-    UseCreatureMusic(HostileZombiesPresent());
+    CheckForZombieMusic();
 
 #ifdef NEWMUSIC
 	GlobalSoundID  = MusicSoundValues[ SECTOR( gWorldSectorX, gWorldSectorY ) ].SoundTacticalTensor[gbWorldSectorZ];
@@ -6706,63 +6706,62 @@ void ExitCombatMode( )
 }
 
 
-void SetEnemyPresence( )
+void SetEnemyPresence()
 {
-    // We have an ememy present....
-    DebugMsg(TOPIC_JA2,DBG_LEVEL_3,String("SetEnemyPresence"));
+	// We have an ememy present....
+	DebugMsg( TOPIC_JA2, DBG_LEVEL_3, String( "SetEnemyPresence" ) );
 
-    // Check if we previously had no enemys present and we are in a virgin secotr ( no enemys spotted yet )
-    if ( !gTacticalStatus.fEnemyInSector && gTacticalStatus.fVirginSector )
-    {
-        // If we have a guy selected, say quote!
-        // For now, display ono status message
-        ScreenMsg( FONT_MCOLOR_LTYELLOW, MSG_INTERFACE, TacticalStr[ ENEMY_IN_SECTOR_STR ] );
+	// Check if we previously had no enemys present and we are in a virgin secotr ( no enemys spotted yet )
+	if ( !gTacticalStatus.fEnemyInSector && gTacticalStatus.fVirginSector )
+	{
+		// If we have a guy selected, say quote!
+		// For now, display ono status message
+		ScreenMsg( FONT_MCOLOR_LTYELLOW, MSG_INTERFACE, TacticalStr[ENEMY_IN_SECTOR_STR] );
 
-        // Change music modes..
+		// Change music modes..
 
-        // If we are just starting game, don't do this!
+		// If we are just starting game, don't do this!
 
 #ifdef JA2UB    
-        //Ja25: no meanwhiles
-        if ( !DidGameJustStart() )
+		//Ja25: no meanwhiles
+		if ( !DidGameJustStart() )
 #else
-            if ( !DidGameJustStart() && !AreInMeanwhile( ) )
-
+		if ( !DidGameJustStart() && !AreInMeanwhile() )
 #endif
-            {
+		{
 
-                UseCreatureMusic(HostileZombiesPresent());
+            CheckForZombieMusic();
 
 #ifdef NEWMUSIC
-				GlobalSoundID  = MusicSoundValues[ SECTOR( gWorldSectorX, gWorldSectorY ) ].SoundTacticalTensor[gbWorldSectorZ];
-				if ( MusicSoundValues[ SECTOR( gWorldSectorX, gWorldSectorY ) ].SoundTacticalTensor[gbWorldSectorZ] != -1 )
-					SetMusicModeID( MUSIC_TACTICAL_ENEMYPRESENT, MusicSoundValues[ SECTOR( gWorldSectorX, gWorldSectorY ) ].SoundTacticalTensor[gbWorldSectorZ] );
-				else
+			GlobalSoundID = MusicSoundValues[SECTOR( gWorldSectorX, gWorldSectorY )].SoundTacticalTensor[gbWorldSectorZ];
+			if ( MusicSoundValues[SECTOR( gWorldSectorX, gWorldSectorY )].SoundTacticalTensor[gbWorldSectorZ] != -1 )
+				SetMusicModeID( MUSIC_TACTICAL_ENEMYPRESENT, MusicSoundValues[SECTOR( gWorldSectorX, gWorldSectorY )].SoundTacticalTensor[gbWorldSectorZ] );
+			else
 #endif
-					SetMusicMode( MUSIC_TACTICAL_ENEMYPRESENT );
+			SetMusicMode( MUSIC_TACTICAL_ENEMYPRESENT );
 
-                DebugMsg(TOPIC_JA2,DBG_LEVEL_3,String("SetEnemyPresence: warnings = false"));
-                sniperwarning = FALSE;
-                biggunwarning = FALSE;
-                gogglewarning = FALSE;
-                checkBonusMilitia = TRUE;
-                //          airstrikeavailable = TRUE;
-            }
-            else
-            {
-                DebugMsg(TOPIC_JA2,DBG_LEVEL_3,String("SetEnemyPresence: warnings = true"));
-                sniperwarning = TRUE;
-                biggunwarning = TRUE;
-                //gogglewarning = TRUE;
-                //          airstrikeavailable = FALSE;
-            }
+			DebugMsg( TOPIC_JA2, DBG_LEVEL_3, String( "SetEnemyPresence: warnings = false" ) );
+			sniperwarning = FALSE;
+			biggunwarning = FALSE;
+			gogglewarning = FALSE;
+			checkBonusMilitia = TRUE;
+			//          airstrikeavailable = TRUE;
+		}
+		else
+		{
+			DebugMsg( TOPIC_JA2, DBG_LEVEL_3, String( "SetEnemyPresence: warnings = true" ) );
+			sniperwarning = TRUE;
+			biggunwarning = TRUE;
+			//gogglewarning = TRUE;
+			//          airstrikeavailable = FALSE;
+		}
 
-        // Say quote...
-        //SayQuoteFromAnyBodyInSector( QUOTE_ENEMY_PRESENCE );
+		// Say quote...
+		//SayQuoteFromAnyBodyInSector( QUOTE_ENEMY_PRESENCE );
 
-        gTacticalStatus.fEnemyInSector = TRUE;
+		gTacticalStatus.fEnemyInSector = TRUE;
 
-    }
+	}
 }
 
 
@@ -7078,7 +7077,7 @@ BOOLEAN CheckForEndOfCombatMode( BOOLEAN fIncrementTurnsNotSeen )
         // Begin tense music....
         // unused
         //gfForceMusicToTense = TRUE;
-        UseCreatureMusic(HostileZombiesPresent());
+        CheckForZombieMusic();
 
 #ifdef NEWMUSIC
 		GlobalSoundID  = MusicSoundValues[ SECTOR( gWorldSectorX, gWorldSectorY ) ].SoundTacticalTensor[gbWorldSectorZ];

--- a/Tactical/Rotting Corpses.cpp
+++ b/Tactical/Rotting Corpses.cpp
@@ -3259,3 +3259,26 @@ FLOAT GetCorpseRotFactor( ROTTING_CORPSE* pCorpse )
 
 	return (FLOAT)(min(gGameExternalOptions.usCorpseDelayUntilRotting, GetWorldTotalMin() - pCorpse->def.uiTimeOfDeath)) / gGameExternalOptions.usCorpseDelayUntilRotting;
 }
+
+void CheckForZombieMusic()
+{
+	extern UINT8 LightGetColors( SGPPaletteEntry * pPal );
+
+	if ( gGameSettings.fOptions[TOPTION_ZOMBIES] )
+	{
+		SGPPaletteEntry	LColors[3];
+		LightGetColors( LColors );
+
+		// If we're underground in the creature caves, use creepy music based on the cave light colors.
+		// Without this, the crepitus cave music is not working correctly as these checks override the original musicmode choice
+		// See PrepareCreaturesForBattle() in Creature Spreading.cpp
+		if ( gbWorldSectorZ )
+		{
+			UseCreatureMusic( LColors->peBlue || HostileZombiesPresent() );
+		}
+		else
+		{
+			UseCreatureMusic( HostileZombiesPresent() );
+		}
+	}
+}

--- a/Tactical/Rotting Corpses.h
+++ b/Tactical/Rotting Corpses.h
@@ -242,4 +242,6 @@ BOOLEAN CorpseOkToDress( ROTTING_CORPSE* pCorpse );
 // Flugente: how rotten is this corpse? values from 0 to 1, 1 as soon as it is rotting
 FLOAT GetCorpseRotFactor( ROTTING_CORPSE* pCorpse );
 
+void CheckForZombieMusic();
+
 #endif


### PR DESCRIPTION
UseCreatureMusic( HostileZombiesPresent() ); was overriding the music mode set in PrepareCreaturesForBattle() when encountering crepitus or being in the creature caves, resulting in regular tense and battle music being played.

Fixes #340 