### PR TITLE
Fix bloodcat ambush endless loop

### DIFF
--- a/Tactical/Soldier Add.cpp
+++ b/Tactical/Soldier Add.cpp
@@ -1201,7 +1201,14 @@ BOOLEAN InternalAddSoldierToSector( UINT8 ubID, BOOLEAN fCalculateDirection, BOO
 			if( fCalculateDirection )
 				ubDirection = ubCalculatedDirection;
 			else
+			{
+				// Override calculated direction if we were told to....
+				if ( pSoldier->ubInsertionDirection >= 100 )
+				{
+					pSoldier->ubInsertionDirection -= 100;
+				}
 				ubDirection = pSoldier->ubInsertionDirection;
+			}
 		}
 		else
 		{			


### PR DESCRIPTION
Some bloodcats during ambushes could have ubInsertionDirection with values > 100, which then causes endless looping in pathfinding algorithms as valid direction values range from 0 to 7