### PR TITLE
Simplified rework foodsystem allowed items

### DIFF
--- a/Tactical/Item Types.h
+++ b/Tactical/Item Types.h
@@ -871,7 +871,6 @@ extern OBJECTTYPE gTempObject;
 #define ITEM_fProvidesRobotCamo			0x0000010000000000		// rftr: robot attachments
 #define ITEM_fProvidesRobotNightVision	0x0000020000000000		// rftr: robot attachments
 #define ITEM_fProvidesRobotLaserBonus	0x0000040000000000		// rftr: robot attachments
-#define ITEM_FoodSystemExclusive	    0x0000080000000000		// kitty: item exclusively available with food feature
 
 // ----------------------------------------------------------------
 

--- a/Tactical/Items.cpp
+++ b/Tactical/Items.cpp
@@ -1271,14 +1271,13 @@ BOOLEAN ItemIsLegal( UINT16 usItemIndex, BOOLEAN fIgnoreCoolness )
 	if ( Item[usItemIndex].ubCoolness == 0 && !fIgnoreCoolness )
 		return FALSE;
 
-
-	// kitty: no food items if the food system is off
-	// whether the item is exclusive is defined by tag
-	// replaced previous system which used Item[usItemIndex].foodtype > 0 as criteria
-	// that also restricted dual use items (i.e. drugs that also have a foodtype, like coffee, etc.)
-	if (!gGameExternalOptions.fFoodSystem && ItemIsOnlyInFood(usItemIndex))
-	{
-		return FALSE;
+	// silversurfer: no food items if the food system is off
+	if (!UsingFoodSystem() && Item[usItemIndex].foodtype > 0)
+	{ 
+		// silversurfer: Only restrict food for now. Water can be used to replenish lost energy so it is useful even without the food system.
+		// kitty: and only if food isn't a drug at the same time, to make sure using those drugs without food system is possible
+			if (Food[Item[usItemIndex].foodtype].bFoodPoints > 0 && Item[usItemIndex].drugtype == 0 )
+				return FALSE;
 	}
 
 	// kitty: no disease items if the disease system is off
@@ -16130,4 +16129,3 @@ BOOLEAN ItemIsOnlyInDisease(UINT16 usItem) { return HasItemFlag2(usItem, ITEM_Di
 BOOLEAN ItemProvidesRobotCamo(UINT16 usItem) { return HasItemFlag2(usItem, ITEM_fProvidesRobotCamo); }
 BOOLEAN ItemProvidesRobotNightvision(UINT16 usItem) { return HasItemFlag2(usItem, ITEM_fProvidesRobotNightVision); }
 BOOLEAN ItemProvidesRobotLaserBonus(UINT16 usItem) { return HasItemFlag2(usItem, ITEM_fProvidesRobotLaserBonus); }
-BOOLEAN ItemIsOnlyInFood(UINT16 usItem) { return HasItemFlag2(usItem, ITEM_FoodSystemExclusive); }

--- a/Tactical/Items.h
+++ b/Tactical/Items.h
@@ -251,7 +251,6 @@ BOOLEAN ItemIsOnlyInDisease(UINT16 usItem);
 BOOLEAN ItemProvidesRobotCamo(UINT16 usItem);
 BOOLEAN ItemProvidesRobotNightvision(UINT16 usItem);
 BOOLEAN ItemProvidesRobotLaserBonus(UINT16 usItem);
-BOOLEAN ItemIsOnlyInFood(UINT16 usItem);
 
 //Existing functions without header def's, added them here, just incase I'll need to call
 //them from the editor.

--- a/Utils/XML_Items.cpp
+++ b/Utils/XML_Items.cpp
@@ -1592,12 +1592,6 @@ itemEndElementHandle(void *userData, const XML_Char *name)
 			pData->curElement = ELEMENT;
 			pData->curItem.iTransportGroupMaxProgress = (INT8)atoi(pData->szCharData);
 		}
-        else if (strcmp(name, "FoodSystemExclusive") == 0)
-		{
-		    pData->curElement = ELEMENT;
-			if ((BOOLEAN)atol(pData->szCharData))
-				pData->curItem.usItemFlag2 |= ITEM_FoodSystemExclusive;
-		}
 
 		--pData->maxReadDepth;
 	}
@@ -2231,7 +2225,6 @@ BOOLEAN WriteItemStats()
 			if (ItemProvidesRobotNightvision(cnt))			FilePrintf(hFile, "\t\t<ProvidesRobotNightVision>%d</ProvidesRobotNightVision>\r\n", 1);
 			if (ItemProvidesRobotLaserBonus(cnt))			FilePrintf(hFile, "\t\t<ProvidesRobotLaserBonus>%d</ProvidesRobotLaserBonus>\r\n", 1);
 			if (ItemIsOnlyInDisease(cnt))					FilePrintf(hFile, "\t\t<DiseaseSystemExclusive>%d</DiseaseSystemExclusive>\r\n", 1);
-			if (ItemIsOnlyInFood(cnt))					    FilePrintf(hFile, "\t\t<FoodSystemExclusive>%d</FoodSystemExclusive>\r\n", 1);
 
 			FilePrintf(hFile,"\t</ITEM>\r\n");
 		}


### PR DESCRIPTION
simplified the previous commit
now no more need for a tag when checking IsItemLegal for Food System
ontop of checking for foodpoints, now also check if is drug 
as a result, as previously, all eatable food will be excluded without food system, 
but now only if it isn't a drug at the same time 
and no more tag to check for that in items.xml needed