### PR TITLE
Fix UB mapeditor sector load

### DIFF
--- a/Editor/LoadScreen.cpp
+++ b/Editor/LoadScreen.cpp
@@ -173,7 +173,15 @@ void LoadSaveScreenEntry()
 		vfs::CVirtualProfile* prof = it.value();
 		memset(&FileInfo, 0, sizeof(GETFILESTRUCT));
 		strcpy(FileInfo.zFileName, "< ");
-		strcat(FileInfo.zFileName, prof->cName.utf8().c_str());
+		// Cut filename off if it's too long for the buffer
+		if (strlen(prof->cName.utf8().c_str()) > FILENAME_BUFLEN-4)
+		{
+			strncpy(FileInfo.zFileName+1, prof->cName.utf8().c_str(), FILENAME_BUFLEN-4);
+		}
+		else
+		{
+			strcat(FileInfo.zFileName, prof->cName.utf8().c_str());
+		}
 		strcat(FileInfo.zFileName, " >");
 		FileInfo.zFileName[FILENAME_BUFLEN] = 0;
 		FileInfo.uiFileAttribs = FILE_IS_DIRECTORY;

--- a/Editor/LoadScreen.h
+++ b/Editor/LoadScreen.h
@@ -1,7 +1,7 @@
 #include "BuildDefines.h"
 #include "Fileman.h"
 
-#define FILENAME_BUFLEN (20 + 4 + 1)//dnl ch39 190909 +4 is for ".dat", +1 is for '\0' //dnl ch81 021213
+#define FILENAME_BUFLEN (30 + 4 + 1)//dnl ch39 190909 +4 is for ".dat", +1 is for '\0' //dnl ch81 021213
 
 #ifdef JA2EDITOR
 


### PR DESCRIPTION
Fixes #367 

Paths to Unfinished profiles that are displayed were too long to fit the filename buffer resulting in assertion error in void SetInputFieldStringWith8BitString( UINT8 ubField, const STR8 szNewText )