### PR TITLE
fix missing icon in executable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
-dummy.cpp
-
 # CLion
 /.idea/
 /cmake-build-*/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,8 +139,10 @@ foreach(app IN LISTS ApplicationTargets)
   foreach(lang IN LISTS LangTargets)
     # executable for an application/language combination, e.g. JA2_ENGLISH.exe
     set(exe ${app}_${lang})
-    file(WRITE dummy.cpp "")
-    add_executable(${exe} WIN32 dummy.cpp)
+    add_executable(${exe} WIN32
+      sgp/sgp.cpp
+      Ja2/Res/Ja2.rc
+    )
     target_link_libraries(${exe} PRIVATE ${Ja2_Libraries} $<IF:${usingMsBuild},legacy_stdio_definitions.lib,>)
     target_link_options(${exe} PRIVATE $<IF:${usingMsBuild},/SAFESEH:NO,>)
 

--- a/Ja2/CMakeLists.txt
+++ b/Ja2/CMakeLists.txt
@@ -34,5 +34,4 @@ set(Ja2Src
 "${CMAKE_CURRENT_SOURCE_DIR}/XML_DifficultySettings.cpp"
 "${CMAKE_CURRENT_SOURCE_DIR}/XML_IntroFiles.cpp"
 "${CMAKE_CURRENT_SOURCE_DIR}/XML_Layout_MainMenu.cpp"
-${CMAKE_CURRENT_SOURCE_DIR}/Res/ja2.rc
 PARENT_SCOPE)

--- a/sgp/CMakeLists.txt
+++ b/sgp/CMakeLists.txt
@@ -21,7 +21,6 @@ set(sgpSrc
 "${CMAKE_CURRENT_SOURCE_DIR}/PCX.cpp"
 "${CMAKE_CURRENT_SOURCE_DIR}/PngLoader.cpp"
 "${CMAKE_CURRENT_SOURCE_DIR}/Random.cpp"
-"${CMAKE_CURRENT_SOURCE_DIR}/sgp.cpp"
 "${CMAKE_CURRENT_SOURCE_DIR}/sgp_logger.cpp"
 "${CMAKE_CURRENT_SOURCE_DIR}/shading.cpp"
 "${CMAKE_CURRENT_SOURCE_DIR}/soundman.cpp"


### PR DESCRIPTION
the Ja2.rc file needs to be in the add_executable target for the icon to appear, and that one requires WinMain.

so get rid of dummy.cpp and put sgp/sgp.cpp in there