### PR TITLE
Revert CI changes, wrong approach

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,29 +34,25 @@ jobs:
         name: Set global variables
         run: |
           set -eux
-
-          all_languages="${{ inputs.build_all_languages }}"
-          assemble_release="${{ inputs.assemble_release }}"
-          repo="${{ github.repository }}"
-          is_tag="${{ startsWith(github.ref, 'refs/tags/v') }}"
-
-          if [ "$assemble_release" = "true" ] || { [ "$repo" = "1dot13/source" ] && [ "$is_tag" = "true" ]; }
+          
+          full_release='${{ ( github.repository == '1dot13/source' && github.ref_name == 'master' ) || startsWith(github.ref, 'refs/tags/v') }}'
+          
+          if [[ '${{ inputs.build_all_languages }}' == 'true' || ( '${{ inputs.build_all_languages }}' == '' && "$full_release" == 'true' ) ]]
           then
-            full_release="true"
-          else
-            full_release="false"
-          fi
-
-          if [ "$all_languages" = "true" ] || [ "$full_release" = "true" ]
-          then
-            languages_json_array='["Chinese", "German", "English", "French", "Polish", "Italian", "Dutch", "Russian"]'
+            languages_json_array='["Chinese", "German", "English", "French", "Polish", "Italian", "Dutch", "Russian"]';
           else
             # English + some other language for compilation testing
             languages_json_array='["German", "English"]'
           fi
-
-          echo "languages_json_array=$languages_json_array" >> "$GITHUB_OUTPUT"
-          echo "assemble_release=$full_release" >> "$GITHUB_OUTPUT"
+          echo "languages_json_array=$languages_json_array" >> $GITHUB_OUTPUT
+          
+          if [[ '${{ inputs.assemble_release }}' == 'true' || ( '${{ inputs.assemble_release }}' == '' && "$full_release" == 'true' ) ]]
+          then
+            assemble_release='true'
+          else
+            assemble_release='false'
+          fi
+          echo "assemble_release=$assemble_release" >> $GITHUB_OUTPUT
 
       - name: Clone repos metadata
         run: |
@@ -190,12 +186,14 @@ jobs:
         merge-multiple: true
 
     - name: Checkout Repo
+      if: github.ref == 'refs/heads/master'
       uses: actions/checkout@v4
       with:
         path: source
         fetch-depth: 1
         sparse-checkout: 'README.md'
     - name: Create latest pre-release
+      if: github.ref == 'refs/heads/master'
       working-directory: source
       run: |
         gh release delete latest --cleanup-tag || true

--- a/.github/workflows/build_language.yml
+++ b/.github/workflows/build_language.yml
@@ -11,7 +11,7 @@ on:
       assemble:
         description: 'assemble full package'
         required: true
-        default: false
+        default: true
         type: boolean
       continue-on-error:
         description: 'allows a language to fail, used when building all languages'


### PR DESCRIPTION
This reverts commit 1976dee738bcbcaf707cfb4c2e356a75862b71ec.

Revert "yet another fix for the github actions"

This reverts commit 552951795cf12687457cfa29ec644986cdf7a96b.

Revert "make sure CI to assemble release on 'v*' tag push or manually"

This reverts commit 8897769f0de672149107494bad6f62382c3fd7d9.