### PR TITLE
Fix the issue of garbled UTF-8 text in the szTileSetDisplayName field…

### DIFF
--- a/Tactical/SkillMenu.cpp
+++ b/Tactical/SkillMenu.cpp
@@ -909,15 +909,6 @@ DragSelection::Setup( UINT32 aVal )
 
 				if ( xmlentry >= 0 )
 				{
-<<<<<<< HEAD
-<<<<<<< HEAD
-					//swprintf( pStr, L"%hs (%s)", gStructureMovePossible[xmlentry].szTileSetDisplayName, FaceDirs[gOneCDirection[ubDirection]] );
-
-					// zwwooooo: Fix the issue of UTF-8 text garbling. (Method provided by @Learner)
-=======
->>>>>>> PR2
-=======
->>>>>>> 11caa6529cd9652ac71b4e69d508e2accb166500
 					WCHAR buf[256];
 					MultiByteToWideChar(CP_UTF8, 0, gStructureMovePossible[xmlentry].szTileSetDisplayName, -1, buf, 256);
 					swprintf(pStr, L"%s (%s)", buf, FaceDirs[gOneCDirection[ubDirection]]);

--- a/Tactical/SkillMenu.cpp
+++ b/Tactical/SkillMenu.cpp
@@ -909,9 +909,12 @@ DragSelection::Setup( UINT32 aVal )
 
 				if ( xmlentry >= 0 )
 				{
+<<<<<<< HEAD
 					//swprintf( pStr, L"%hs (%s)", gStructureMovePossible[xmlentry].szTileSetDisplayName, FaceDirs[gOneCDirection[ubDirection]] );
 
 					// zwwooooo: Fix the issue of UTF-8 text garbling. (Method provided by @Learner)
+=======
+>>>>>>> PR2
 					WCHAR buf[256];
 					MultiByteToWideChar(CP_UTF8, 0, gStructureMovePossible[xmlentry].szTileSetDisplayName, -1, buf, 256);
 					swprintf(pStr, L"%s (%s)", buf, FaceDirs[gOneCDirection[ubDirection]]);

--- a/Tactical/SkillMenu.cpp
+++ b/Tactical/SkillMenu.cpp
@@ -909,7 +909,12 @@ DragSelection::Setup( UINT32 aVal )
 
 				if ( xmlentry >= 0 )
 				{
-					swprintf( pStr, L"%hs (%s)", gStructureMovePossible[xmlentry].szTileSetDisplayName, FaceDirs[gOneCDirection[ubDirection]] );
+					//swprintf( pStr, L"%hs (%s)", gStructureMovePossible[xmlentry].szTileSetDisplayName, FaceDirs[gOneCDirection[ubDirection]] );
+
+					// zwwooooo: Fix the issue of UTF-8 text garbling. (Method provided by @Learner)
+					WCHAR buf[256];
+					MultiByteToWideChar(CP_UTF8, 0, gStructureMovePossible[xmlentry].szTileSetDisplayName, -1, buf, 256);
+					swprintf(pStr, L"%s (%s)", buf, FaceDirs[gOneCDirection[ubDirection]]);
 
 					// we have to use an offset of NOBODY in order to differentiate between person and corpse
 					pOption = new POPUP_OPTION( &std::wstring( pStr ), new popupCallbackFunction<void, UINT32>( &Wrapper_Function_DragSelection_GridNo, sTempGridNo ) );

--- a/i18n/_ChineseText.cpp
+++ b/i18n/_ChineseText.cpp
@@ -5478,7 +5478,7 @@ STR16			MercInfo[] =
 	L"未结账单", //L"Unsettled Bills",
 	L"生平", //L"Bio",
 	L"物品", //L"Inv",
-	L"特别优惠！",
+	L"Special Offer!",
 };
 
 

--- a/i18n/_ChineseText.cpp
+++ b/i18n/_ChineseText.cpp
@@ -5478,7 +5478,7 @@ STR16			MercInfo[] =
 	L"未结账单", //L"Unsettled Bills",
 	L"生平", //L"Bio",
 	L"物品", //L"Inv",
-	L"Special Offer!",
+	L"特别优惠！",
 };
 
 


### PR DESCRIPTION
… of the StructureMove.xml file in the game's "Drag" menu.(Method provided by @Learner)

Chinese translation update.