### PR TITLE
Fix the issue of UTF-8 text garbling.

### DIFF
--- a/Tactical/SkillMenu.cpp
+++ b/Tactical/SkillMenu.cpp
@@ -909,7 +909,9 @@ DragSelection::Setup( UINT32 aVal )
 
 				if ( xmlentry >= 0 )
 				{
-					swprintf( pStr, L"%hs (%s)", gStructureMovePossible[xmlentry].szTileSetDisplayName, FaceDirs[gOneCDirection[ubDirection]] );
+					WCHAR buf[256];
+					MultiByteToWideChar(CP_UTF8, 0, gStructureMovePossible[xmlentry].szTileSetDisplayName, -1, buf, 256);
+					swprintf(pStr, L"%s (%s)", buf, FaceDirs[gOneCDirection[ubDirection]]);
 
 					// we have to use an offset of NOBODY in order to differentiate between person and corpse
 					pOption = new POPUP_OPTION( &std::wstring( pStr ), new popupCallbackFunction<void, UINT32>( &Wrapper_Function_DragSelection_GridNo, sTempGridNo ) );


### PR DESCRIPTION
Fix the issue of garbled UTF-8 text in the szTileSetDisplayName field of the StructureMove.xml file in the game's "Drag" menu.(Method provided by @Learner)