### PR TITLE
Fix helicopter for UB

### DIFF
--- a/Strategic/Map Screen Helicopter.cpp
+++ b/Strategic/Map Screen Helicopter.cpp
@@ -1278,8 +1278,7 @@ void LandHelicopter( void )
 	else
 	{
 #ifdef JA2UB
-		Assert( 0 );
-//No meanwhiles
+		//No meanwhiles in UB
 #else
 		// play meanwhile scene if it hasn't been used yet
 		HandleKillChopperMeanwhileScene();


### PR DESCRIPTION
No need to force an assert error here. We can simply ignore the meanwhile scene just like all the others.