### PR TITLE
ASD/ARC: Fix Error by One in gasCan Vector

### DIFF
--- a/Strategic/Rebel Command.cpp
+++ b/Strategic/Rebel Command.cpp
@@ -4772,8 +4772,10 @@ void ApplyAdditionalASDEffects()
 		{
 		case MissionHelpers::DISRUPT_ASD_STEAL_FUEL:
 		{
-			// spawn a gas can
-			CreateItemAtAirport(ItemIdCache::gasCans.at(ItemIdCache::gasCans.size() - 1), 75 + Random(26));
+			// only spawn a gas can if at least one gas can is known by the game (ItemIsGascan)
+			if (ItemIdCache::gasCans.size() > 0)
+				// The gas can is spawned like a Bobby Ray delivery (you need to open the crate)
+				CreateItemAtAirport(ItemIdCache::gasCans.at(ItemIdCache::gasCans.size() -1), 75 + Random(26));
 
 			// say it came from the ASD's reserves
 			AddStrategicAIResources(ASD_FUEL, -(gGameExternalOptions.gASDResource_Fuel_Jeep + Random(gGameExternalOptions.gASDResource_Fuel_Jeep)));

--- a/Strategic/Rebel Command.cpp
+++ b/Strategic/Rebel Command.cpp
@@ -4773,7 +4773,7 @@ void ApplyAdditionalASDEffects()
 		case MissionHelpers::DISRUPT_ASD_STEAL_FUEL:
 		{
 			// spawn a gas can
-			CreateItemAtAirport(ItemIdCache::gasCans.at(ItemIdCache::gasCans.size()), 75 + Random(26));
+			CreateItemAtAirport(ItemIdCache::gasCans.at(ItemIdCache::gasCans.size() - 1), 75 + Random(26));
 
 			// say it came from the ASD's reserves
 			AddStrategicAIResources(ASD_FUEL, -(gGameExternalOptions.gASDResource_Fuel_Jeep + Random(gGameExternalOptions.gASDResource_Fuel_Jeep)));

--- a/Strategic/Rebel Command.cpp
+++ b/Strategic/Rebel Command.cpp
@@ -129,21 +129,10 @@ namespace ItemIdCache
 {
 	// cache these values on load so that we don't need to search for them every time something happens
 	std::vector<UINT16> gasCans;
-	std::vector<UINT16> firstAidKits;
-	std::vector<UINT16> medKits;
-	std::vector<UINT16> toolKits;
-	std::vector<UINT16> ammo[10]; // coolness
 
 	void Clear()
 	{
 		gasCans.clear();
-		firstAidKits.clear();
-		medKits.clear();
-		toolKits.clear();
-		for (int i = 0; i < 10; ++i)
-		{
-			ammo[i].clear();
-		}
 	}
 }
 
@@ -4418,23 +4407,6 @@ void SetupInfo()
 	for (UINT16 i = 0; i < MAXITEMS; ++i)
 	{
 		if (ItemIsGascan(i)) ItemIdCache::gasCans.push_back(i);
-		else if (ItemIsFirstAidKit(i)) ItemIdCache::firstAidKits.push_back(i);
-		else if (ItemIsMedicalKit(i)) ItemIdCache::medKits.push_back(i);
-		else if (ItemIsToolkit(i)) ItemIdCache::toolKits.push_back(i);
-		else if (Item[i].usItemClass & IC_AMMO)
-		{
-			if (Magazine[Item[i].ubClassIndex].ubMagType == AMMO_BOX)
-			{
-				if ((gGameOptions.fGunNut || !ItemIsOnlyInTonsOfGuns(i))
-				&& (gGameOptions.ubGameStyle == STYLE_SCIFI || !ItemIsOnlyInScifi(i)))
-				{
-					// coolness runs from 1-10, so apply offset
-					const UINT8 coolness = min(max(1, Item[i].ubCoolness), 10);
-					ItemIdCache::ammo[coolness-1].push_back(i);
-				}
-			}
-		}
-		
 	}
 }
 


### PR DESCRIPTION
The ARC mission `DISRUPT_ASD_STEAL_FUEL` crashes the game at 00:00. Inside `ApplyAdditionalASDEffects` the vector `ItemIdCache::gasCans` is indexed by .size() which returns the size of 1. But since indexes start at 0 the game tries to access memory that isn't reserved for this vector.