### PR TITLE
Reverting Commit 9122d7a

### DIFF
--- a/Tactical/Weapons.cpp
+++ b/Tactical/Weapons.cpp
@@ -9957,10 +9957,6 @@ BOOLEAN IsGunBurstCapable(OBJECTTYPE* pObject, BOOLEAN fNotify, SOLDIERTYPE* pSo
 						fCapable = TRUE;
 					}
 				}
-				else if (Weapon[pObject->usItem].fBurstOnlyByFanTheHammer)
-				{
-					fCapable = FALSE;
-				}
 			}
 		}
 	}


### PR DESCRIPTION
- it made: CAN_FAN_THE_HAMMER = FALSE now disables the burst mode on pistols  
- which effectivly resulted in pistols burst mode only being avaialbale with can fan the hammer active 
- which further resulted in being required to fire from hip mode when using burst with pistols 
- that's not a desired behaviour for burst on pistols, their burst should not depend on fan the hammer 
- therefore reverted

commit 9122d7a