### PR TITLE
IniOption Food items can show without using Food

### DIFF
--- a/Ja2/GameSettings.cpp
+++ b/Ja2/GameSettings.cpp
@@ -1998,6 +1998,7 @@ void LoadGameExternalOptions()
 	gGameExternalOptions.fFoodDecayInSectors							= iniReader.ReadBoolean("Tactical Food Settings", "FOOD_DECAY_IN_SECTORS", TRUE);
 	gGameExternalOptions.sFoodDecayModificator							= iniReader.ReadFloat("Tactical Food Settings", "FOOD_DECAY_MODIFICATOR",			1.0f, 0.1f, 10.0f);
 	gGameExternalOptions.fFoodEatingSounds								= iniReader.ReadBoolean("Tactical Food Settings", "FOOD_EATING_SOUNDS", TRUE);
+	gGameExternalOptions.fAlwaysFood                                    = iniReader.ReadBoolean("Tactical Food Settings", "ALWAYS_FOOD", FALSE);
 	
 	//################# Disease Settings ##################
 	gGameExternalOptions.fDisease										= iniReader.ReadBoolean( "Disease Settings", "DISEASE", FALSE );

--- a/Ja2/GameSettings.h
+++ b/Ja2/GameSettings.h
@@ -506,6 +506,7 @@ typedef struct
 	FLOAT	sFoodDecayModificator;
 	
 	BOOLEAN fFoodEatingSounds;
+	BOOLEAN fAlwaysFood;
 
 	// Flugente: disease settings
 	BOOLEAN fDisease;

--- a/Tactical/Items.cpp
+++ b/Tactical/Items.cpp
@@ -1271,14 +1271,21 @@ BOOLEAN ItemIsLegal( UINT16 usItemIndex, BOOLEAN fIgnoreCoolness )
 	if ( Item[usItemIndex].ubCoolness == 0 && !fIgnoreCoolness )
 		return FALSE;
 
-	// silversurfer: no food items if the food system is off
-	if (!UsingFoodSystem() && Item[usItemIndex].foodtype > 0)
-	{ 
-		// silversurfer: Only restrict food for now. Water can be used to replenish lost energy so it is useful even without the food system.
-		// kitty: and only if food isn't a drug at the same time, to make sure using those drugs without food system is possible
-			if (Food[Item[usItemIndex].foodtype].bFoodPoints > 0 && Item[usItemIndex].drugtype == 0 )
-				return FALSE;
-	}
+	// kitty: players might want food items in game for roleplay reasons, i.e. when interacting with npc-dealer in restaurant, no food might seems odd
+	// with the option "ALWAYS_FOOD" set TRUE, food items will show even without using the foodsystem
+	// should it be set to FALSE, no food items will be shown without using the foodsystem
+	if (!gGameExternalOptions.fAlwaysFood)
+	{
+		  // silversurfer: no food items if the food system is off
+	      if (!UsingFoodSystem() && Item[usItemIndex].foodtype > 0 )
+		  {
+		      // silversurfer: Only restrict food for now. Water can be used to replenish lost energy so it is useful even without the food system.
+		      // kitty: and only if food isn't a drug at the same time, to make sure using those drugs without food system is possible
+			  if (Food[Item[usItemIndex].foodtype].bFoodPoints > 0 && Item[usItemIndex].drugtype == 0 )
+
+				   return FALSE;
+	      }
+    }
 
 	// kitty: no disease items if the disease system is off
 	// whether the item is exclusive is defined by tag


### PR DESCRIPTION
- food items are usualy not shown in game without using Food
- option ALWAYS_FOOD allows them to be shown even without
- default is false, no food items without Food