### PR TITLE
Expanded and sorted nationalities

### DIFF
--- a/Tactical/soldier profile type.h
+++ b/Tactical/soldier profile type.h
@@ -242,15 +242,15 @@ typedef enum
 {
 	// old Sirtech values
 	AMERICAN_NAT = 0,		// take that, Murica! Sirtech knew you have no value :-)
-	ARAB_NAT = 1,
+	ARAB_NAT = 1,          
 	AUSTRALIAN_NAT = 2,
 	BRITISH_NAT = 3,
 	CANADIAN_NAT = 4,
 	CUBAN_NAT = 5,
 	DANISH_NAT = 6,
 	FRENCH_NAT = 7,
-	RUSSIAN_NAT = 8,
-	NIGERIAN_NAT = 9,		// this was simply not defined in original data (I did not find any country), but we can't have any holes in here, so just invented soemthing
+	RUSSIAN_NAT = 8,       // kitty: changed 9 from nigerian (moved down) to traconian (UB takes place in Tracona)
+	TRACONIAN_NAT = 9,	   // this was simply not defined in original data (I did not find any country), but we can't have any holes in here, so just invented soemthing
 	SWISS_NAT = 10,
 	JAMAICAN_NAT = 11,
 	POLISH_NAT = 12,
@@ -261,64 +261,105 @@ typedef enum
 	SCOTTISH_NAT = 17,
 	ARULCAN_NAT = 18,
 	GERMAN_NAT = 19,
-	AFRICAN_NAT = 20,
+	AFRICAN_NAT = 20,   
 	ITALIAN_NAT = 21,
 	DUTCH_NAT = 22,
 	ROMANIAN_NAT = 23,
 	METAVIRAN_NAT = 24,
 
 	// new values, because why not
-	GREEK_NAT,		// 25
-	ESTONIAN_NAT,
-	VENEZUELAN_NAT ,
-	JAPANESE_NAT,
-	TURKISH_NAT,
-	INDIAN_NAT,		// 30
-	MEXICAN_NAT,
-	NORWEGIAN_NAT,
-	SPANISH_NAT,
-	BRASILIAN_NAT,
-	FINNISH_NAT,	// 35
-	IRANIAN_NAT,
-	ISRAELI_NAT,
-	BULGARIAN_NAT,
-	SWEDISH_NAT,
-	IRAQI_NAT,		// 40
-	SYRIAN_NAT,
-	BELGIAN_NAT,
-	PORTOGUESE_NAT,
-	BELARUSIAN_NAT,
-	SERBIAN_NAT,	// 45
-	PAKISTANI_NAT,
+	// kitty:
+	// added a few more and removed some, hoping to achieve a decent amount from every inhabited continent (plus one, in the 90's, relatively well-known fictional one)
+	// 0-24 original ja2 nationalities (except 9, see there)
+	// sorted non-original ones in (english) alphabetic order for some more ease of use during IMP creation
+	AFGHAN_NAT,       // 25 
 	ALBANIAN_NAT,
 	ARGENTINIAN_NAT,
 	ARMENIAN_NAT,
-	AZERBAIJANI_NAT, // 50
+	AZERBAIJANI_NAT,
+	BANGLADESHI_NAT,  // 30
+	BELARUSIAN_NAT,
+	BELGIAN_NAT,     
+	BENINESE_NAT,
 	BOLIVIAN_NAT,
-	CHILEAN_NAT,
-	CIRCASSIAN_NAT,
+	BOSNIAN_NAT,      // 35
+	BRASILIAN_NAT,
+	BULGARIAN_NAT,
+	CAMBODIAN_NAT,
+	CHADIAN_NAT,
+	CHILEAN_NAT,      // 40
 	COLUMBIAN_NAT,
-	EGYPTIAN_NAT, // 55
+	CONGOLESE_NAT,
+	CROATIAN_NAT,
+	ECUADORIAN_NAT,
+	EGYPTIAN_NAT,     // 45 
+	ENGLISH_NAT,    
+	ERITREAN_NAT,
+	ESTONIAN_NAT,
 	ETHIOPIAN_NAT,
+	FILIPINO_NAT,     // 50
+	FINNISH_NAT,  
 	GEORGIAN_NAT,
+	GREEK_NAT,
+	GUATEMALAN_NAT,
+	HAITIAN_NAT,      // 55
+	HONDURAN_NAT, 
+	INDIAN_NAT,
+	INDONESIAN_NAT,
+	IRANIAN_NAT,
+	IRAQI_NAT,        // 60
+	ISLANDIC_NAT, 
+	ISRAELI_NAT,
+	JAPANESE_NAT,
 	JORDANIAN_NAT,
-	KAZAKHSTANI_NAT,
-	KENYAN_NAT, // 60
-	KOREAN_NAT,
+	KAZAKHSTANI_NAT,  // 65
+	KOREAN_NAT,    
 	KYRGYZSTANI_NAT,
+	LAOTIAN_NAT,
+	LATVIAN_NAT,
+	LEBANESE_NAT,     // 70
+	LITHUANIAN_NAT, 
+	LYBIAN_NAT,
+	MACEDONIAN_NAT,
+	MALAYSIAN_NAT,
+	MEXICAN_NAT,      // 75
 	MONGOLIAN_NAT,
-	PALESTINIAN_NAT,
-	PANAMANIAN_NAT, // 65
-	RHODESIAN_NAT,
+	MOROCCAN_NAT,
+	MOZAMBICAN_NAT,
+	MYANMA_NAT,
+	NAMIBIAN_NAT,     // 80
+	NICARAGUAN_NAT,
+	NIGERIAN_NAT,      
+	NIGERIEN_NAT,     
+	NORWEGIAN_NAT,
+	PAKISTANI_NAT,    // 85
+	PANAMANIAN_NAT,
+	PORTOGUESE_NAT,
+	RWANDANESE_NAT,
 	SALVADORAN_NAT,
-	SAUDI_NAT,
+	SAUDI_NAT,        // 90
+	SERBIAN_NAT,
+	SLOVAKIAN_NAT,
+	SLOVENIAN_NAT,
 	SOMALI_NAT,
-	THAI_NAT, // 70
+	SPANISH_NAT,      // 95
+	SUDANESE_NAT,
+	SWEDISH_NAT,
+	SYRIAN_NAT,
+	THAI_NAT,
+	TOGOLESE_NAT,     // 100
+	TUNISIAN_NAT,
+	TURKISH_NAT,
+	UGANDAN_NAT,
 	UKRAINIAN_NAT,
+	URUGUAYAN_NAT,    // 105
 	UZBEKISTANI_NAT,
+	VENEZUELAN_NAT,
+	VIETNAMESE_NAT,
 	WELSH_NAT,
-	YAZIDI_NAT,
-	ZIMBABWEAN_NAT, // 75
+	YEMENI_NAT,       // 110
+	ZAMUNDAN_NAT,     // Zamunda 
+	ZIMBABWEAN_NAT,
 
 	NUM_NATIONALITIES
 } Nationalities;

--- a/i18n/_ChineseText.cpp
+++ b/i18n/_ChineseText.cpp
@@ -9424,13 +9424,13 @@ STR16		szNationalityText[]=
 	L"丹麦人",
 	L"法国人",
 	L"俄国人",
-	L"尼日利亚人",
+	L"Tracona人",      // (UB takes place in Tracona)
 	L"瑞士人",			// 10
 	L"牙买加人",
 	L"波兰人",
 	L"中国人",
 	L"爱尔兰人",
-	L"南非人",	// 15
+	L"南非人",	       // 15
 	L"匈牙利人",
 	L"苏格兰人",
 	L"Arulco人",
@@ -9442,57 +9442,94 @@ STR16		szNationalityText[]=
 	L"Metavira人",
 
 	// newly added from here on
-	L"希腊人",			// 25
-	L"爱沙尼亚人",
-	L"委内瑞拉人",
-	L"日本人",
-	L"土耳其人",
-	L"印度人",			// 30
-	L"墨西哥人",
-	L"挪威人",
-	L"西班牙人",
-	L"巴西人",
-	L"芬兰人",			// 35
-	L"伊朗人",
-	L"以色列人",
-	L"保加利亚人",
-	L"瑞典人",
-	L"伊拉克人",			// 40
-	L"叙利亚人",
-	L"比利时人",
-	L"葡萄牙人",
-	L"白俄罗斯人",
-	L"塞尔维亚人",			// 45
-	L"巴基斯坦人",
+	L"Afghan",       // 25 
 	L"Albanian",
 	L"Argentinian",
 	L"Armenian",
-	L"Azerbaijani", // 50
+	L"Azerbaijani",
+	L"Bangladeshi ", // 30
+    L"白俄罗斯人",
+    L"比利时人",
+	L"Beninese",
 	L"Bolivian",
-	L"Chilean",
-	L"Circassian",
+	L"Bosnian",     // 35
+    L"巴西人",
+    L"保加利亚人",
+	L"Cambodian",
+	L"Chadian",
+	L"Chilean",     // 40
 	L"Columbian",
-	L"Egyptian", // 55
+	L"Congolese",
+	L"Croatian",
+	L"Ecuadorian",
+	L"Egyptian",    // 45 
+	L"English",
+	L"Eritrean",
+	L"爱沙尼亚人",
 	L"Ethiopian",
+	L"Filipino",    // 50
+	L"芬兰人",
 	L"Georgian",
+	L"希腊人",
+	L"Guatemalan",
+	L"Haitian",      // 55
+	L"Honduran",
+	L"印度人",
+	L"Indonesian",
+	L"伊朗人",
+	L"伊拉克人",	     // 60
+	L"Islandic",
+	L"以色列人",
+	L"日本人",
 	L"Jordanian",
-	L"Kazakhstani",
-	L"Kenyan", // 60
+	L"Kazakhstani",  // 65
 	L"Korean",
 	L"Kyrgyzstani",
+	L"Laotian",
+	L"Latvian",
+	L"Lebanese",    // 70
+	L"Lithuanian",
+	L"Lybian",
+	L"Macedonian",
+	L"Malaysian",
+	L"墨西哥人",    // 75
 	L"Mongolian",
-	L"Palestinian",
-	L"Panamanian", // 65
-	L"Rhodesian",
+	L"Moroccan",
+	L"Mozambican",
+	L"Myanma",
+	L"Namibian",   // 80
+	L"Nicaraguan",
+	L"尼日利亚人",
+	L"Nigerien",
+	L"挪威人",
+	L"Pakistani",   // 85
+	L"Panamanian",
+	L"葡萄牙人",
+	L"Rwandanese",
 	L"Salvadoran",
-	L"Saudi",
+	L"Saudi",     // 90
+	L"塞尔维亚人",
+	L"Slovakian",
+	L"Slovenian",
 	L"Somali",
-	L"Thai", // 70
+	L"西班牙人",     // 95
+	L"Sudanese",
+	L"瑞典人",
+	L"叙利亚人",
+	L"Thai",
+	L"Togolese",    // 100
+	L"Tunisian",
+	L"土耳其人",
+	L"Ugandan",
 	L"Ukrainian",
+	L"Uruguayan",   // 105
 	L"Uzbekistani",
+	L"委内瑞拉人",
+	L"Vietnamese",
 	L"Welsh",
-	L"Yazidi",
-	L"Zimbabwean", // 75
+	L"Yemeni",     // 110
+	L"Zamundan",   // Zamunda 
+	L"Zimbabwean",
 };
 
 STR16		szNationalityTextAdjective[] =
@@ -9506,13 +9543,13 @@ STR16		szNationalityTextAdjective[] =
 	L"丹麦人",
 	L"法国人",
 	L"俄国人",
-	L"尼日利亚人",
+	L"traconia人"       // UB takes place in Tracona
 	L"瑞士人",			// 10
 	L"牙买加人",
 	L"波兰人",
 	L"中国人",
 	L"爱尔兰人",
-	L"南非人",	// 15
+	L"南非人",	       // 15
 	L"匈牙利人",
 	L"苏格兰人",
 	L"Arulco人",
@@ -9524,57 +9561,94 @@ STR16		szNationalityTextAdjective[] =
 	L"Metavira人",
 
 	// newly added from here on
-	L"希腊人",			// 25
-	L"爱沙尼亚人",
-	L"委内瑞拉人",
-	L"日本人",
-	L"土耳其人",
-	L"印度人",			// 30
-	L"墨西哥人",
-	L"挪威人",
-	L"西班牙人",
-	L"巴西人",
-	L"芬兰人",			// 35
-	L"伊朗人",
-	L"以色列人",
-	L"保加利亚人",
-	L"瑞典人",
-	L"伊拉克人",			// 40
-	L"叙利亚人",
-	L"比利时人",
-	L"葡萄牙人",
-	L"白俄罗斯人",
-	L"塞尔维亚人",		// 45
-	L"巴基斯坦人",
+	L"afghans",      // 25 
 	L"albanians",
 	L"argentinians",
 	L"armenians",
-	L"azerbaijani", // 50
+	L"azerbaijani",
+	L"bangladeshi", // 30
+	L"白俄罗斯人",
+	L"比利时人",
+	L"beninese",
 	L"bolivians",
-	L"chileans",
-	L"circassians",
+	L"bosnians",     // 35
+	L"巴西人",
+	L"保加利亚人",
+	L"cambodians",
+	L"chadians",
+	L"chileans",     // 40
 	L"columbians",
-	L"egyptians", // 55
+	L"congolese",
+	L"croatians",
+	L"ecuadorians",
+	L"egyptians",    // 45 
+	L"englishmen",
+	L"eritreans",
+	L"爱沙尼亚人",
 	L"ethiopians",
+	L"filipinos",    // 50
+	L"芬兰人",
 	L"georgians",
+	L"希腊人",
+	L"guatemalans",
+	L"haitians",      // 55
+	L"hondurans",
+	L"印度人",
+	L"indonesians",
+	L"伊朗人",
+	L"伊拉克人",     // 60
+	L"islandics",
+	L"以色列人",
+	L"日本人",
 	L"jordanians",
-	L"kazakhstani",
-	L"kenyans", // 60
+	L"kazakhstani",  // 65
 	L"koreans",
 	L"kyrgyzstani",
+	L"laotians",
+	L"latvians",
+	L"lebanese",    // 70
+	L"lithuanians",
+	L"lybians",
+	L"macedonians",
+	L"malaysians",
+	L"墨西哥人",   // 75
 	L"mongolians",
-	L"palestinians",
-	L"panamanians", // 65
-	L"rhodesians",
+	L"moroccans",
+	L"mozambicans",
+	L"myanmarians",
+	L"namibians",   // 80
+	L"nicaraguans",
+	L"尼日利亚人",
+	L"nigeriens",
+	L"挪威人",
+	L"巴基斯坦人",   // 85
+	L"panamanians",
+	L"葡萄牙人",
+	L"rwandanese",
 	L"salvadorans",
-	L"saudis",
-	L"somalis",
-	L"thais", // 70
+	L"saudis",     // 90
+	L"塞尔维亚人",
+	L"slovakians",
+	L"slovenians",
+	L"somali",
+	L"西班牙人",    // 95
+	L"sudanese",
+	L"瑞典人",
+	L"叙利亚人",
+	L"thais",
+	L"togolese",    // 100
+	L"tunisians",
+	L"土耳其人",
+	L"ugandans",
 	L"ukrainians",
+	L"uruguayans",   // 105
 	L"uzbekistani",
+	L"委内瑞拉人",
+	L"vietnamese",
 	L"welshs",
-	L"yazidis",
-	L"zimbabweans", // 75
+	L"yemenites",     // 110
+	L"zamundans",   // Zamunda 
+	L"zimbabweans",
 };
 
 // special text used if we do not hate any nation (value of -1)

--- a/i18n/_DutchText.cpp
+++ b/i18n/_DutchText.cpp
@@ -9436,7 +9436,7 @@ STR16		szNationalityText[]=
 	L"Danish",
 	L"French",
 	L"Russian",
-	L"Nigerian",
+	L"Traconian",
 	L"Swiss",			// 10
 	L"Jamaican",
 	L"Polish",
@@ -9454,57 +9454,94 @@ STR16		szNationalityText[]=
 	L"Metaviran",
 
 	// newly added from here on
-	L"Greek",			// 25
-	L"Estonian",
-	L"Venezuelan",
-	L"Japanese",
-	L"Turkish",
-	L"Indian",			// 30
-	L"Mexican",
-	L"Norwegian",
-	L"Spanish",
-	L"Brasilian",
-	L"Finnish",			// 35
-	L"Iranian",
-	L"Israeli",
-	L"Bulgarian",
-	L"Swedish",
-	L"Iraqi",			// 40
-	L"Syrian",
-	L"Belgian",
-	L"Portoguese",
-	L"Belarusian",		// TODO.Translate
-	L"Serbian",			// 45
-	L"Pakistani",
+	L"Afghan",       // 25 
 	L"Albanian",
 	L"Argentinian",
 	L"Armenian",
-	L"Azerbaijani", // 50
+	L"Azerbaijani",
+	L"Bangladeshi ", // 30
+	L"Belarusian",
+	L"Belgian",
+	L"Beninese",
 	L"Bolivian",
-	L"Chilean",
-	L"Circassian",
+	L"Bosnian",     // 35
+	L"Brasilian",
+	L"Bulgarian",
+	L"Cambodian",
+	L"Chadian",
+	L"Chilean",     // 40
 	L"Columbian",
-	L"Egyptian", // 55
+	L"Congolese",
+	L"Croatian",
+	L"Ecuadorian",
+	L"Egyptian",    // 45 
+	L"English",
+	L"Eritrean",
+	L"Estonian",
 	L"Ethiopian",
+	L"Filipino",    // 50
+	L"Finnish",
 	L"Georgian",
+	L"Greek",
+	L"Guatemalan",
+	L"Haitian",      // 55
+	L"Honduran",
+	L"Indian",
+	L"Indonesian",
+	L"Iranian",
+	L"Iraqi",      // 60
+	L"Islandic",
+	L"Israeli",
+	L"Japanese",
 	L"Jordanian",
-	L"Kazakhstani",
-	L"Kenyan", // 60
+	L"Kazakhstani",  // 65
 	L"Korean",
 	L"Kyrgyzstani",
+	L"Laotian",
+	L"Latvian",
+	L"Lebanese",    // 70
+	L"Lithuanian",
+	L"Lybian",
+	L"Macedonian",
+	L"Malaysian",
+	L"Mexican",    // 75
 	L"Mongolian",
-	L"Palestinian",
-	L"Panamanian", // 65
-	L"Rhodesian",
+	L"Moroccan",
+	L"Mozambican",
+	L"Myanma",
+	L"Namibian",   // 80
+	L"Nicaraguan",
+	L"Nigerian",
+	L"Nigerien",
+	L"Norwegian",
+	L"Pakistani",   // 85
+	L"Panamanian",
+	L"Portoguese",
+	L"Rwandanese",
 	L"Salvadoran",
-	L"Saudi",
+	L"Saudi",     // 90
+	L"Serbian",
+	L"Slovakian",
+	L"Slovenian",
 	L"Somali",
-	L"Thai", // 70
+	L"Spanish",     // 95
+	L"Sudanese",
+	L"Swedish",
+	L"Syrian",
+	L"Thai",
+	L"Togolese",    // 100
+	L"Tunisian",
+	L"Turkish",
+	L"Ugandan",
 	L"Ukrainian",
+	L"Uruguayan",   // 105
 	L"Uzbekistani",
+	L"Venezuelan",
+	L"Vietnamese",
 	L"Welsh",
-	L"Yazidi",
-	L"Zimbabwean", // 75
+	L"Yemeni",     // 110
+	L"Zamundan",   // Zamunda 
+	L"Zimbabwean",
 };
 
 STR16		szNationalityTextAdjective[] = // TODO.Translate
@@ -9518,7 +9555,7 @@ STR16		szNationalityTextAdjective[] = // TODO.Translate
 	L"danes",
 	L"frenchmen",
 	L"russians",
-	L"nigerians",
+	L"traconians",
 	L"swiss",			// 10
 	L"jamaicans",
 	L"poles",
@@ -9536,57 +9573,94 @@ STR16		szNationalityTextAdjective[] = // TODO.Translate
 	L"metavirans",
 
 	// newly added from here on
-	L"greek",			// 25
-	L"estonians",
-	L"venezuelans",
-	L"japanese",
-	L"turks",
-	L"indians",			// 30
-	L"mexicans",
-	L"norwegians",
-	L"spaniards",
-	L"brasilians",
-	L"finns",			// 35
-	L"iranians",
-	L"israelis",
-	L"bulgarians",
-	L"swedes",
-	L"iraqis",			// 40
-	L"syrians",
-	L"belgians",
-	L"portoguese",
-	L"belarusian",
-	L"serbians",		// 45
-	L"pakistanis",
+	L"afghans",       // 25 
 	L"albanians",
 	L"argentinians",
 	L"armenians",
-	L"azerbaijani", // 50
+	L"azerbaijani",
+	L"bangladeshi", // 30
+	L"belarusians",
+	L"belgians",
+	L"beninese",
 	L"bolivians",
-	L"chileans",
-	L"circassians",
+	L"bosnians",     // 35
+	L"brasilians",
+	L"bulgarians",
+	L"cambodians",
+	L"chadians",
+	L"chileans",     // 40
 	L"columbians",
-	L"egyptians", // 55
+	L"congolese",
+	L"croatians",
+	L"ecuadorians",
+	L"egyptians",    // 45 
+	L"englishmen",
+	L"eritreans",
+	L"estonians",
 	L"ethiopians",
+	L"filipinos",    // 50
+	L"finns",
 	L"georgians",
+	L"greek",
+	L"guatemalans",
+	L"haitians",      // 55
+	L"hondurans",
+	L"indians",
+	L"indonesians",
+	L"iranians",
+	L"iraqis",      // 60
+	L"islandics",
+	L"israelis",
+	L"japanese",
 	L"jordanians",
-	L"kazakhstani",
-	L"kenyans", // 60
+	L"kazakhstani",  // 65
 	L"koreans",
 	L"kyrgyzstani",
+	L"laotians",
+	L"latvians",
+	L"lebanese",    // 70
+	L"lithuanians",
+	L"lybians",
+	L"macedonians",
+	L"malaysians",
+	L"mexicans",    // 75
 	L"mongolians",
-	L"palestinians",
-	L"panamanians", // 65
-	L"rhodesians",
+	L"moroccans",
+	L"mozambicans",
+	L"myanmarians",
+	L"namibians",   // 80
+	L"nicaraguans",
+	L"nigerians",
+	L"nigeriens",
+	L"norwegians",
+	L"pakistanis",   // 85
+	L"panamanians",
+	L"portoguese",
+	L"rwandanese",
 	L"salvadorans",
-	L"saudis",
-	L"somalis",
-	L"thais", // 70
+	L"saudis",     // 90
+	L"serbians",
+	L"slovakians",
+	L"slovenians",
+	L"somali",
+	L"spaniards",     // 95
+	L"sudanese",
+	L"swedes",
+	L"syrians",
+	L"thais",
+	L"togolese",    // 100
+	L"tunisians",
+	L"turks",
+	L"ugandans",
 	L"ukrainians",
+	L"uruguayans",   // 105
 	L"uzbekistani",
+	L"venezuelans",
+	L"vietnamese",
 	L"welshs",
-	L"yazidis",
-	L"zimbabweans", // 75
+	L"yemenites",     // 110
+	L"zamundans",   // Zamunda 
+	L"zimbabweans",
 };
 
 // special text used if we do not hate any nation (value of -1)

--- a/i18n/_EnglishText.cpp
+++ b/i18n/_EnglishText.cpp
@@ -9424,7 +9424,7 @@ STR16		szNationalityText[]=
 	L"Danish",
 	L"French",
 	L"Russian",
-	L"Nigerian",
+	L"Traconian",        // UB takes place in Tracona
 	L"Swiss",			// 10
 	L"Jamaican",
 	L"Polish",
@@ -9442,57 +9442,94 @@ STR16		szNationalityText[]=
 	L"Metaviran",
 
 	// newly added from here on
-	L"Greek",			// 25
-	L"Estonian",
-	L"Venezuelan",
-	L"Japanese",
-	L"Turkish",
-	L"Indian",			// 30
-	L"Mexican",
-	L"Norwegian",
-	L"Spanish",
-	L"Brasilian",
-	L"Finnish",			// 35
-	L"Iranian",
-	L"Israeli",
-	L"Bulgarian",
-	L"Swedish",
-	L"Iraqi",			// 40
-	L"Syrian",
-	L"Belgian",
-	L"Portoguese",
-	L"Belarusian",
-	L"Serbian",			// 45
-	L"Pakistani",
+	L"Afghan",       // 25 
 	L"Albanian",
 	L"Argentinian",
 	L"Armenian",
-	L"Azerbaijani", // 50
+	L"Azerbaijani",
+	L"Bangladeshi ", // 30
+	L"Belarusian",
+	L"Belgian",
+	L"Beninese",
 	L"Bolivian",
-	L"Chilean",
-	L"Circassian",
+	L"Bosnian",     // 35
+	L"Brasilian",
+	L"Bulgarian",
+	L"Cambodian",
+	L"Chadian",
+	L"Chilean",     // 40
 	L"Columbian",
-	L"Egyptian", // 55
+	L"Congolese",
+	L"Croatian",
+	L"Ecuadorian",
+	L"Egyptian",    // 45 
+	L"English",
+	L"Eritrean",
+	L"Estonian",
 	L"Ethiopian",
+	L"Filipino",    // 50
+	L"Finnish",
 	L"Georgian",
+	L"Greek",
+	L"Guatemalan",
+	L"Haitian",      // 55
+	L"Honduran",
+	L"Indian",
+	L"Indonesian",
+	L"Iranian",
+	L"Iraqi",      // 60
+	L"Islandic",
+	L"Israeli",
+	L"Japanese",
 	L"Jordanian",
-	L"Kazakhstani",
-	L"Kenyan", // 60
+	L"Kazakhstani",  // 65
 	L"Korean",
 	L"Kyrgyzstani",
+	L"Laotian",
+	L"Latvian",
+	L"Lebanese",    // 70
+	L"Lithuanian",
+	L"Lybian",
+	L"Macedonian",
+	L"Malaysian",
+	L"Mexican",    // 75
 	L"Mongolian",
-	L"Palestinian",
-	L"Panamanian", // 65
-	L"Rhodesian",
+	L"Moroccan",
+	L"Mozambican",
+	L"Myanma",
+	L"Namibian",   // 80
+	L"Nicaraguan",
+	L"Nigerian",
+	L"Nigerien",
+	L"Norwegian",
+	L"Pakistani",   // 85
+	L"Panamanian",
+	L"Portoguese",
+	L"Rwandanese",
 	L"Salvadoran",
-	L"Saudi",
+	L"Saudi",     // 90
+	L"Serbian",
+	L"Slovakian",
+	L"Slovenian",
 	L"Somali",
-	L"Thai", // 70
+	L"Spanish",     // 95
+	L"Sudanese",
+	L"Swedish",
+	L"Syrian",
+	L"Thai",
+	L"Togolese",    // 100
+	L"Tunisian",
+	L"Turkish",
+	L"Ugandan",
 	L"Ukrainian",
+	L"Uruguayan",   // 105
 	L"Uzbekistani",
+	L"Venezuelan",
+	L"Vietnamese",
 	L"Welsh",
-	L"Yazidi",
-	L"Zimbabwean", // 75
+	L"Yemeni",     // 110
+	L"Zamundan",   // Zamunda 
+	L"Zimbabwean",
 };
 
 STR16		szNationalityTextAdjective[] =
@@ -9506,7 +9543,7 @@ STR16		szNationalityTextAdjective[] =
 	L"danes",
 	L"frenchmen",
 	L"russians",
-	L"nigerians",
+	L"traconians",
 	L"swiss",			// 10
 	L"jamaicans",
 	L"poles",
@@ -9524,57 +9561,94 @@ STR16		szNationalityTextAdjective[] =
 	L"metavirans",
 
 	// newly added from here on
-	L"greek",			// 25
-	L"estonians",
-	L"venezuelans",
-	L"japanese",
-	L"turks",
-	L"indians",			// 30
-	L"mexicans",
-	L"norwegians",
-	L"spaniards",
-	L"brasilians",
-	L"finns",			// 35
-	L"iranians",
-	L"israelis",
-	L"bulgarians",
-	L"swedes",
-	L"iraqis",			// 40
-	L"syrians",
-	L"belgians",
-	L"portoguese",
-	L"belarusians",
-	L"serbians",		// 45
-	L"pakistanis",
+	L"afghans",       // 25 
 	L"albanians",
 	L"argentinians",
 	L"armenians",
-	L"azerbaijani", // 50
+	L"azerbaijani",
+	L"bangladeshi", // 30
+	L"belarusians",
+	L"belgians",
+	L"beninese",
 	L"bolivians",
-	L"chileans",
-	L"circassians",
+	L"bosnians",     // 35
+	L"brasilians",
+	L"bulgarians",
+	L"cambodians",
+	L"chadians",
+	L"chileans",     // 40
 	L"columbians",
-	L"egyptians", // 55
+	L"congolese",
+	L"croatians",
+	L"ecuadorians",
+	L"egyptians",    // 45 
+	L"englishmen",
+	L"eritreans",
+	L"estonians",
 	L"ethiopians",
+	L"filipinos",    // 50
+	L"finns",
 	L"georgians",
+	L"greek",
+	L"guatemalans",
+	L"haitians",      // 55
+	L"hondurans",
+	L"indians",
+	L"indonesians",
+	L"iranians",
+	L"iraqis",      // 60
+	L"islandics",
+	L"israelis",
+	L"japanese",
 	L"jordanians",
-	L"kazakhstani",
-	L"kenyans", // 60
+	L"kazakhstani",  // 65
 	L"koreans",
 	L"kyrgyzstani",
+	L"laotians",
+	L"latvians",
+	L"lebanese",    // 70
+	L"lithuanians",
+	L"lybians",
+	L"macedonians",
+	L"malaysians",
+	L"mexicans",    // 75
 	L"mongolians",
-	L"palestinians",
-	L"panamanians", // 65
-	L"rhodesians",
+	L"moroccans",
+	L"mozambicans",
+	L"myanmarians",
+	L"namibians",   // 80
+	L"nicaraguans",
+	L"nigerians",
+	L"nigeriens",
+	L"norwegians",
+	L"pakistanis",   // 85
+	L"panamanians",
+	L"portoguese",
+	L"rwandanese",
 	L"salvadorans",
-	L"saudis",
-	L"somalis",
-	L"thais", // 70
+	L"saudis",     // 90
+	L"serbians",
+	L"slovakians",
+	L"slovenians",
+	L"somali",
+	L"spaniards",     // 95
+	L"sudanese",
+	L"swedes",
+	L"syrians",
+	L"thais",
+	L"togolese",    // 100
+	L"tunisians",
+	L"turks",
+	L"ugandans",
 	L"ukrainians",
+	L"uruguayans",   // 105
 	L"uzbekistani",
+	L"venezuelans",
+	L"vietnamese",
 	L"welshs",
-	L"yazidis",
-	L"zimbabweans", // 75
+	L"yemenites",     // 110
+	L"zamundans",   // Zamunda 
+	L"zimbabweans",
 };
 
 // special text used if we do not hate any nation (value of -1)

--- a/i18n/_FrenchText.cpp
+++ b/i18n/_FrenchText.cpp
@@ -9418,7 +9418,7 @@ STR16		szNationalityText[]=
 	L"Danois",
 	L"Français",
 	L"Russe",
-	L"Nigérian",
+	L"Traconian",
 	L"Suisse",			// 10
 	L"Jamaïcain",
 	L"Polonais",
@@ -9436,57 +9436,94 @@ STR16		szNationalityText[]=
 	L"Métavirien",
 
 	// newly added from here on
-	L"Grec",			// 25
-	L"Estonien",
-	L"Vénézuélien",
-	L"Japonais",
-	L"Turc",
-	L"Indien",			// 30
-	L"Mexicain",
-	L"Norvégien",
-	L"Espagnol",
-	L"Brésilien",
-	L"Finlandais",			// 35
-	L"Iranien",
-	L"Israélien",
-	L"Bulgare",
-	L"Suédois",
-	L"Irakien",			// 40
-	L"Syrien",
-	L"Belge",
-	L"Portugais",
-	L"Belarusian",		// TODO.Translate
-	L"Serbian",			// 45
-	L"Pakistani",
+	L"Afghan",       // 25 
 	L"Albanian",
 	L"Argentinian",
 	L"Armenian",
-	L"Azerbaijani", // 50
+	L"Azerbaijani",
+	L"Bangladeshi ", // 30
+	L"Belarusian",
+	L"Belge",
+	L"Beninese",
 	L"Bolivian",
-	L"Chilean",
-	L"Circassian",
+	L"Bosnian",     // 35
+	L"Brésilien",
+	L"Bulgare",
+	L"Cambodian",
+	L"Chadian",
+	L"Chilean",     // 40
 	L"Columbian",
-	L"Egyptian", // 55
+	L"Congolese",
+	L"Croatian",
+	L"Ecuadorian",
+	L"Egyptian",    // 45 
+	L"English",
+	L"Eritrean",
+	L"Estonien",
 	L"Ethiopian",
+	L"Filipino",    // 50
+	L"Finlandais",
 	L"Georgian",
+	L"Grec",
+	L"Guatemalan",
+	L"Haitian",      // 55
+	L"Honduran",
+	L"Indien",
+	L"Indonesian",
+	L"Iranien",
+	L"Irakien",	    // 60
+	L"Islandic",
+	L"Israélien",
+	L"Japonais",
 	L"Jordanian",
-	L"Kazakhstani",
-	L"Kenyan", // 60
+	L"Kazakhstani",  // 65
 	L"Korean",
 	L"Kyrgyzstani",
+	L"Laotian",
+	L"Latvian",
+	L"Lebanese",    // 70
+	L"Lithuanian",
+	L"Lybian",
+	L"Macedonian",
+	L"Malaysian",
+	L"Mexicain",    // 75
 	L"Mongolian",
-	L"Palestinian",
-	L"Panamanian", // 65
-	L"Rhodesian",
+	L"Moroccan",
+	L"Mozambican",
+	L"Myanma",
+	L"Namibian",   // 80
+	L"Nicaraguan",
+	L"Nigérian",
+	L"Nigerien",
+	L"Norvégien",
+	L"Pakistani",   // 85
+	L"Panamanian",
+	L"Portugais",
+	L"Rwandanese",
 	L"Salvadoran",
-	L"Saudi",
+	L"Saudi",     // 90
+	L"Serbian",
+	L"Slovakian",
+	L"Slovenian",
 	L"Somali",
-	L"Thai", // 70
+	L"Espagnol",     // 95
+	L"Sudanese",
+	L"Suédois",
+	L"Syrien",
+	L"Thai",
+	L"Togolese",    // 100
+	L"Tunisian",
+	L"Turc",
+	L"Ugandan",
 	L"Ukrainian",
+	L"Uruguayan",   // 105
 	L"Uzbekistani",
+	L"Vénézuélien",
+	L"Vietnamese",
 	L"Welsh",
-	L"Yazidi",
-	L"Zimbabwean", // 75
+	L"Yemeni",     // 110
+	L"Zamundan",   // Zamunda 
+	L"Zimbabwean",
 };
 
 STR16		szNationalityTextAdjective[] = // TODO.Translate
@@ -9500,7 +9537,7 @@ STR16		szNationalityTextAdjective[] = // TODO.Translate
 	L"danes",
 	L"frenchmen",
 	L"russians",
-	L"nigerians",
+	L"traconians",
 	L"swiss",			// 10
 	L"jamaicans",
 	L"poles",
@@ -9518,57 +9555,94 @@ STR16		szNationalityTextAdjective[] = // TODO.Translate
 	L"metavirans",
 
 	// newly added from here on
-	L"greek",			// 25
-	L"estonians",
-	L"venezuelans",
-	L"japanese",
-	L"turks",
-	L"indians",			// 30
-	L"mexicans",
-	L"norwegians",
-	L"spaniards",
-	L"brasilians",
-	L"finns",			// 35
-	L"iranians",
-	L"israelis",
-	L"bulgarians",
-	L"swedes",
-	L"iraqis",			// 40
-	L"syrians",
-	L"belgians",
-	L"portoguese",
-	L"belarusian",
-	L"serbians",		// 45
-	L"pakistanis",
+	L"afghans",       // 25 
 	L"albanians",
 	L"argentinians",
 	L"armenians",
-	L"azerbaijani", // 50
+	L"azerbaijani",
+	L"bangladeshi", // 30
+	L"belarusians",
+	L"belgians",
+	L"beninese",
 	L"bolivians",
-	L"chileans",
-	L"circassians",
+	L"bosnians",     // 35
+	L"brasilians",
+	L"bulgarians",
+	L"cambodians",
+	L"chadians",
+	L"chileans",     // 40
 	L"columbians",
-	L"egyptians", // 55
+	L"congolese",
+	L"croatians",
+	L"ecuadorians",
+	L"egyptians",    // 45 
+	L"englishmen",
+	L"eritreans",
+	L"estonians",
 	L"ethiopians",
+	L"filipinos",    // 50
+	L"finns",
 	L"georgians",
+	L"greek",
+	L"guatemalans",
+	L"haitians",      // 55
+	L"hondurans",
+	L"indians",
+	L"indonesians",
+	L"iranians",
+	L"iraqis",      // 60
+	L"islandics",
+	L"israelis",
+	L"japanese",
 	L"jordanians",
-	L"kazakhstani",
-	L"kenyans", // 60
+	L"kazakhstani",  // 65
 	L"koreans",
 	L"kyrgyzstani",
+	L"laotians",
+	L"latvians",
+	L"lebanese",    // 70
+	L"lithuanians",
+	L"lybians",
+	L"macedonians",
+	L"malaysians",
+	L"mexicans",    // 75
 	L"mongolians",
-	L"palestinians",
-	L"panamanians", // 65
-	L"rhodesians",
+	L"moroccans",
+	L"mozambicans",
+	L"myanmarians",
+	L"namibians",   // 80
+	L"nicaraguans",
+	L"nigerians",
+	L"nigeriens",
+	L"norwegians",
+	L"pakistanis",   // 85
+	L"panamanians",
+	L"portoguese",
+	L"rwandanese",
 	L"salvadorans",
-	L"saudis",
-	L"somalis",
-	L"thais", // 70
+	L"saudis",     // 90
+	L"serbians",
+	L"slovakians",
+	L"slovenians",
+	L"somali",
+	L"spaniards",     // 95
+	L"sudanese",
+	L"swedes",
+	L"syrians",
+	L"thais",
+	L"togolese",    // 100
+	L"tunisians",
+	L"turks",
+	L"ugandans",
 	L"ukrainians",
+	L"uruguayans",   // 105
 	L"uzbekistani",
+	L"venezuelans",
+	L"vietnamese",
 	L"welshs",
-	L"yazidis",
-	L"zimbabweans", // 75
+	L"yemenites",     // 110
+	L"zamundans",   // Zamunda 
+	L"zimbabweans",
 };
 
 // special text used if we do not hate any nation (value of -1)

--- a/i18n/_GermanText.cpp
+++ b/i18n/_GermanText.cpp
@@ -9287,7 +9287,7 @@ STR16		szNationalityText[]=
 	L"Danish",
 	L"French",
 	L"Russian",
-	L"Nigerian",
+	L"Traconian",
 	L"Swiss",			// 10
 	L"Jamaican",
 	L"Polish",
@@ -9305,57 +9305,94 @@ STR16		szNationalityText[]=
 	L"Metaviran",
 
 	// newly added from here on
-	L"Greek",			// 25
-	L"Estonian",
-	L"Venezuelan",
-	L"Japanese",
-	L"Turkish",
-	L"Indian",			// 30
-	L"Mexican",
-	L"Norwegian",
-	L"Spanish",
-	L"Brasilian",
-	L"Finnish",			// 35
-	L"Iranian",
-	L"Israeli",
-	L"Bulgarian",
-	L"Swedish",
-	L"Iraqi",			// 40
-	L"Syrian",
-	L"Belgian",
-	L"Portoguese",
-	L"Belarusian",		// TODO.Translate
-	L"Serbian",			// 45
-	L"Pakistani",
+	L"Afghan",       // 25 
 	L"Albanian",
 	L"Argentinian",
 	L"Armenian",
-	L"Azerbaijani", // 50
+	L"Azerbaijani",
+	L"Bangladeshi ", // 30
+	L"Belarusian",
+	L"Belgian",
+	L"Beninese",
 	L"Bolivian",
-	L"Chilean",
-	L"Circassian",
+	L"Bosnian",     // 35
+	L"Brasilian",
+	L"Bulgarian",
+	L"Cambodian",
+	L"Chadian",
+	L"Chilean",     // 40
 	L"Columbian",
-	L"Egyptian", // 55
+	L"Congolese",
+	L"Croatian",
+	L"Ecuadorian",
+	L"Egyptian",    // 45 
+	L"English",
+	L"Eritrean",
+	L"Estonian",
 	L"Ethiopian",
+	L"Filipino",    // 50
+	L"Finnish",
 	L"Georgian",
+	L"Greek",
+	L"Guatemalan",
+	L"Haitian",      // 55
+	L"Honduran",
+	L"Indian",
+	L"Indonesian",
+	L"Iranian",
+	L"Iraqi",      // 60
+	L"Islandic",
+	L"Israeli",
+	L"Japanese",
 	L"Jordanian",
-	L"Kazakhstani",
-	L"Kenyan", // 60
+	L"Kazakhstani",  // 65
 	L"Korean",
 	L"Kyrgyzstani",
+	L"Laotian",
+	L"Latvian",
+	L"Lebanese",    // 70
+	L"Lithuanian",
+	L"Lybian",
+	L"Macedonian",
+	L"Malaysian",
+	L"Mexican",    // 75
 	L"Mongolian",
-	L"Palestinian",
-	L"Panamanian", // 65
-	L"Rhodesian",
+	L"Moroccan",
+	L"Mozambican",
+	L"Myanma",
+	L"Namibian",   // 80
+	L"Nicaraguan",
+	L"Nigerian",
+	L"Nigerien",
+	L"Norwegian",
+	L"Pakistani",   // 85
+	L"Panamanian",
+	L"Portoguese",
+	L"Rwandanese",
 	L"Salvadoran",
-	L"Saudi",
+	L"Saudi",     // 90
+	L"Serbian",
+	L"Slovakian",
+	L"Slovenian",
 	L"Somali",
-	L"Thai", // 70
+	L"Spanish",     // 95
+	L"Sudanese",
+	L"Swedish",
+	L"Syrian",
+	L"Thai",
+	L"Togolese",    // 100
+	L"Tunisian",
+	L"Turkish",
+	L"Ugandan",
 	L"Ukrainian",
+	L"Uruguayan",   // 105
 	L"Uzbekistani",
+	L"Venezuelan",
+	L"Vietnamese",
 	L"Welsh",
-	L"Yazidi",
-	L"Zimbabwean", // 75
+	L"Yemeni",     // 110
+	L"Zamundan",   // Zamunda 
+	L"Zimbabwean",
 };
 
 // TODO.Translate
@@ -9370,7 +9407,7 @@ STR16		szNationalityTextAdjective[] =
 	L"danes",
 	L"frenchmen",
 	L"russians",
-	L"nigerians",
+	L"traconians",
 	L"swiss",			// 10
 	L"jamaicans",
 	L"poles",
@@ -9388,57 +9425,94 @@ STR16		szNationalityTextAdjective[] =
 	L"metavirans",
 
 	// newly added from here on
-	L"greek",			// 25
-	L"estonians",
-	L"venezuelans",
-	L"japanese",
-	L"turks",
-	L"indians",			// 30
-	L"mexicans",
-	L"norwegians",
-	L"spaniards",
-	L"brasilians",
-	L"finns",			// 35
-	L"iranians",
-	L"israelis",
-	L"bulgarians",
-	L"swedes",
-	L"iraqis",			// 40
-	L"syrians",
-	L"belgians",
-	L"portoguese",
-	L"belarusian",
-	L"serbians",		// 45
-	L"pakistanis",
+	L"afghans",       // 25 
 	L"albanians",
 	L"argentinians",
 	L"armenians",
-	L"azerbaijani", // 50
+	L"azerbaijani",
+	L"bangladeshi", // 30
+	L"belarusians",
+	L"belgians",
+	L"beninese",
 	L"bolivians",
-	L"chileans",
-	L"circassians",
+	L"bosnians",     // 35
+	L"brasilians",
+	L"bulgarians",
+	L"cambodians",
+	L"chadians",
+	L"chileans",     // 40
 	L"columbians",
-	L"egyptians", // 55
+	L"congolese",
+	L"croatians",
+	L"ecuadorians",
+	L"egyptians",    // 45 
+	L"englishmen",
+	L"eritreans",
+	L"estonians",
 	L"ethiopians",
+	L"filipinos",    // 50
+	L"finns",
 	L"georgians",
+	L"greek",
+	L"guatemalans",
+	L"haitians",      // 55
+	L"hondurans",
+	L"indians",
+	L"indonesians",
+	L"iranians",
+	L"iraqis",      // 60
+	L"islandics",
+	L"israelis",
+	L"japanese",
 	L"jordanians",
-	L"kazakhstani",
-	L"kenyans", // 60
+	L"kazakhstani",  // 65
 	L"koreans",
 	L"kyrgyzstani",
+	L"laotians",
+	L"latvians",
+	L"lebanese",    // 70
+	L"lithuanians",
+	L"lybians",
+	L"macedonians",
+	L"malaysians",
+	L"mexicans",    // 75
 	L"mongolians",
-	L"palestinians",
-	L"panamanians", // 65
-	L"rhodesians",
+	L"moroccans",
+	L"mozambicans",
+	L"myanmarians",
+	L"namibians",   // 80
+	L"nicaraguans",
+	L"nigerians",
+	L"nigeriens",
+	L"norwegians",
+	L"pakistanis",   // 85
+	L"panamanians",
+	L"portoguese",
+	L"rwandanese",
 	L"salvadorans",
-	L"saudis",
-	L"somalis",
-	L"thais", // 70
+	L"saudis",     // 90
+	L"serbians",
+	L"slovakians",
+	L"slovenians",
+	L"somali",
+	L"spaniards",     // 95
+	L"sudanese",
+	L"swedes",
+	L"syrians",
+	L"thais",
+	L"togolese",    // 100
+	L"tunisians",
+	L"turks",
+	L"ugandans",
 	L"ukrainians",
+	L"uruguayans",   // 105
 	L"uzbekistani",
+	L"venezuelans",
+	L"vietnamese",
 	L"welshs",
-	L"yazidis",
-	L"zimbabweans", // 75
+	L"yemenites",     // 110
+	L"zamundans",   // Zamunda 
+	L"zimbabweans",
 };
 
 // special text used if we do not hate any nation (value of -1)

--- a/i18n/_ItalianText.cpp
+++ b/i18n/_ItalianText.cpp
@@ -9427,7 +9427,7 @@ STR16		szNationalityText[]=
 	L"Danish",
 	L"French",
 	L"Russian",
-	L"Nigerian",
+	L"Traconian",
 	L"Swiss",			// 10
 	L"Jamaican",
 	L"Polish",
@@ -9445,57 +9445,94 @@ STR16		szNationalityText[]=
 	L"Metaviran",
 
 	// newly added from here on
-	L"Greek",			// 25
-	L"Estonian",
-	L"Venezuelan",
-	L"Japanese",
-	L"Turkish",
-	L"Indian",			// 30
-	L"Mexican",
-	L"Norwegian",
-	L"Spanish",
-	L"Brasilian",
-	L"Finnish",			// 35
-	L"Iranian",
-	L"Israeli",
-	L"Bulgarian",
-	L"Swedish",
-	L"Iraqi",			// 40
-	L"Syrian",
-	L"Belgian",
-	L"Portoguese",
-	L"Belarusian",		// TODO.Translate
-	L"Serbian",			// 45
-	L"Pakistani",
+	L"Afghan",       // 25 
 	L"Albanian",
 	L"Argentinian",
 	L"Armenian",
-	L"Azerbaijani", // 50
+	L"Azerbaijani",
+	L"Bangladeshi ", // 30
+	L"Belarusian",
+	L"Belgian",
+	L"Beninese",
 	L"Bolivian",
-	L"Chilean",
-	L"Circassian",
+	L"Bosnian",     // 35
+	L"Brasilian",
+	L"Bulgarian",
+	L"Cambodian",
+	L"Chadian",
+	L"Chilean",     // 40
 	L"Columbian",
-	L"Egyptian", // 55
+	L"Congolese",
+	L"Croatian",
+	L"Ecuadorian",
+	L"Egyptian",    // 45 
+	L"English",
+	L"Eritrean",
+	L"Estonian",
 	L"Ethiopian",
+	L"Filipino",    // 50
+	L"Finnish",
 	L"Georgian",
+	L"Greek",
+	L"Guatemalan",
+	L"Haitian",      // 55
+	L"Honduran",
+	L"Indian",
+	L"Indonesian",
+	L"Iranian",
+	L"Iraqi",      // 60
+	L"Islandic",
+	L"Israeli",
+	L"Japanese",
 	L"Jordanian",
-	L"Kazakhstani",
-	L"Kenyan", // 60
+	L"Kazakhstani",  // 65
 	L"Korean",
 	L"Kyrgyzstani",
+	L"Laotian",
+	L"Latvian",
+	L"Lebanese",    // 70
+	L"Lithuanian",
+	L"Lybian",
+	L"Macedonian",
+	L"Malaysian",
+	L"Mexican",    // 75
 	L"Mongolian",
-	L"Palestinian",
-	L"Panamanian", // 65
-	L"Rhodesian",
+	L"Moroccan",
+	L"Mozambican",
+	L"Myanma",
+	L"Namibian",   // 80
+	L"Nicaraguan",
+	L"Nigerian",
+	L"Nigerien",
+	L"Norwegian",
+	L"Pakistani",   // 85
+	L"Panamanian",
+	L"Portoguese",
+	L"Rwandanese",
 	L"Salvadoran",
-	L"Saudi",
+	L"Saudi",     // 90
+	L"Serbian",
+	L"Slovakian",
+	L"Slovenian",
 	L"Somali",
-	L"Thai", // 70
+	L"Spanish",     // 95
+	L"Sudanese",
+	L"Swedish",
+	L"Syrian",
+	L"Thai",
+	L"Togolese",    // 100
+	L"Tunisian",
+	L"Turkish",
+	L"Ugandan",
 	L"Ukrainian",
+	L"Uruguayan",   // 105
 	L"Uzbekistani",
+	L"Venezuelan",
+	L"Vietnamese",
 	L"Welsh",
-	L"Yazidi",
-	L"Zimbabwean", // 75
+	L"Yemeni",     // 110
+	L"Zamundan",   // Zamunda 
+	L"Zimbabwean",
 };
 
 STR16		szNationalityTextAdjective[] = // TODO.Translate
@@ -9509,7 +9546,7 @@ STR16		szNationalityTextAdjective[] = // TODO.Translate
 	L"danes",
 	L"frenchmen",
 	L"russians",
-	L"nigerians",
+	L"traconians",
 	L"swiss",			// 10
 	L"jamaicans",
 	L"poles",
@@ -9527,57 +9564,94 @@ STR16		szNationalityTextAdjective[] = // TODO.Translate
 	L"metavirans",
 
 	// newly added from here on
-	L"greek",			// 25
-	L"estonians",
-	L"venezuelans",
-	L"japanese",
-	L"turks",
-	L"indians",			// 30
-	L"mexicans",
-	L"norwegians",
-	L"spaniards",
-	L"brasilians",
-	L"finns",			// 35
-	L"iranians",
-	L"israelis",
-	L"bulgarians",
-	L"swedes",
-	L"iraqis",			// 40
-	L"syrians",
-	L"belgians",
-	L"portoguese",
-	L"belarusian",
-	L"serbians",		// 45
-	L"pakistanis",
+	L"afghans",       // 25 
 	L"albanians",
 	L"argentinians",
 	L"armenians",
-	L"azerbaijani", // 50
+	L"azerbaijani",
+	L"bangladeshi", // 30
+	L"belarusians",
+	L"belgians",
+	L"beninese",
 	L"bolivians",
-	L"chileans",
-	L"circassians",
+	L"bosnians",     // 35
+	L"brasilians",
+	L"bulgarians",
+	L"cambodians",
+	L"chadians",
+	L"chileans",     // 40
 	L"columbians",
-	L"egyptians", // 55
+	L"congolese",
+	L"croatians",
+	L"ecuadorians",
+	L"egyptians",    // 45 
+	L"englishmen",
+	L"eritreans",
+	L"estonians",
 	L"ethiopians",
+	L"filipinos",    // 50
+	L"finns",
 	L"georgians",
+	L"greek",
+	L"guatemalans",
+	L"haitians",      // 55
+	L"hondurans",
+	L"indians",
+	L"indonesians",
+	L"iranians",
+	L"iraqis",      // 60
+	L"islandics",
+	L"israelis",
+	L"japanese",
 	L"jordanians",
-	L"kazakhstani",
-	L"kenyans", // 60
+	L"kazakhstani",  // 65
 	L"koreans",
 	L"kyrgyzstani",
+	L"laotians",
+	L"latvians",
+	L"lebanese",    // 70
+	L"lithuanians",
+	L"lybians",
+	L"macedonians",
+	L"malaysians",
+	L"mexicans",    // 75
 	L"mongolians",
-	L"palestinians",
-	L"panamanians", // 65
-	L"rhodesians",
+	L"moroccans",
+	L"mozambicans",
+	L"myanmarians",
+	L"namibians",   // 80
+	L"nicaraguans",
+	L"nigerians",
+	L"nigeriens",
+	L"norwegians",
+	L"pakistanis",   // 85
+	L"panamanians",
+	L"portoguese",
+	L"rwandanese",
 	L"salvadorans",
-	L"saudis",
-	L"somalis",
-	L"thais", // 70
+	L"saudis",     // 90
+	L"serbians",
+	L"slovakians",
+	L"slovenians",
+	L"somali",
+	L"spaniards",     // 95
+	L"sudanese",
+	L"swedes",
+	L"syrians",
+	L"thais",
+	L"togolese",    // 100
+	L"tunisians",
+	L"turks",
+	L"ugandans",
 	L"ukrainians",
+	L"uruguayans",   // 105
 	L"uzbekistani",
+	L"venezuelans",
+	L"vietnamese",
 	L"welshs",
-	L"yazidis",
-	L"zimbabweans", // 75
+	L"yemenites",     // 110
+	L"zamundans",   // Zamunda 
+	L"zimbabweans",
 };
 
 // special text used if we do not hate any nation (value of -1)

--- a/i18n/_PolishText.cpp
+++ b/i18n/_PolishText.cpp
@@ -9440,7 +9440,7 @@ STR16		szNationalityText[]=
 	L"Danish",
 	L"French",
 	L"Russian",
-	L"Nigerian",
+	L"Traconian",
 	L"Swiss",			// 10
 	L"Jamaican",
 	L"Polish",
@@ -9458,57 +9458,94 @@ STR16		szNationalityText[]=
 	L"Metaviran",
 
 	// newly added from here on
-	L"Greek",			// 25
-	L"Estonian",
-	L"Venezuelan",
-	L"Japanese",
-	L"Turkish",
-	L"Indian",			// 30
-	L"Mexican",
-	L"Norwegian",
-	L"Spanish",
-	L"Brasilian",
-	L"Finnish",			// 35
-	L"Iranian",
-	L"Israeli",
-	L"Bulgarian",
-	L"Swedish",
-	L"Iraqi",			// 40
-	L"Syrian",
-	L"Belgian",
-	L"Portoguese",
-	L"Belarusian",		// TODO.Translate
-	L"Serbian",			// 45
-	L"Pakistani",
+	L"Afghan",       // 25 
 	L"Albanian",
 	L"Argentinian",
 	L"Armenian",
-	L"Azerbaijani", // 50
+	L"Azerbaijani",
+	L"Bangladeshi ", // 30
+	L"Belarusian",
+	L"Belgian",
+	L"Beninese",
 	L"Bolivian",
-	L"Chilean",
-	L"Circassian",
+	L"Bosnian",     // 35
+	L"Brasilian",
+	L"Bulgarian",
+	L"Cambodian",
+	L"Chadian",
+	L"Chilean",     // 40
 	L"Columbian",
-	L"Egyptian", // 55
+	L"Congolese",
+	L"Croatian",
+	L"Ecuadorian",
+	L"Egyptian",    // 45 
+	L"English",
+	L"Eritrean",
+	L"Estonian",
 	L"Ethiopian",
+	L"Filipino",    // 50
+	L"Finnish",
 	L"Georgian",
+	L"Greek",
+	L"Guatemalan",
+	L"Haitian",      // 55
+	L"Honduran",
+	L"Indian",
+	L"Indonesian",
+	L"Iranian",
+	L"Iraqi",      // 60
+	L"Islandic",
+	L"Israeli",
+	L"Japanese",
 	L"Jordanian",
-	L"Kazakhstani",
-	L"Kenyan", // 60
+	L"Kazakhstani",  // 65
 	L"Korean",
 	L"Kyrgyzstani",
+	L"Laotian",
+	L"Latvian",
+	L"Lebanese",    // 70
+	L"Lithuanian",
+	L"Lybian",
+	L"Macedonian",
+	L"Malaysian",
+	L"Mexican",    // 75
 	L"Mongolian",
-	L"Palestinian",
-	L"Panamanian", // 65
-	L"Rhodesian",
+	L"Moroccan",
+	L"Mozambican",
+	L"Myanma",
+	L"Namibian",   // 80
+	L"Nicaraguan",
+	L"Nigerian",
+	L"Nigerien",
+	L"Norwegian",
+	L"Pakistani",   // 85
+	L"Panamanian",
+	L"Portoguese",
+	L"Rwandanese",
 	L"Salvadoran",
-	L"Saudi",
+	L"Saudi",     // 90
+	L"Serbian",
+	L"Slovakian",
+	L"Slovenian",
 	L"Somali",
-	L"Thai", // 70
+	L"Spanish",     // 95
+	L"Sudanese",
+	L"Swedish",
+	L"Syrian",
+	L"Thai",
+	L"Togolese",    // 100
+	L"Tunisian",
+	L"Turkish",
+	L"Ugandan",
 	L"Ukrainian",
+	L"Uruguayan",   // 105
 	L"Uzbekistani",
+	L"Venezuelan",
+	L"Vietnamese",
 	L"Welsh",
-	L"Yazidi",
-	L"Zimbabwean", // 75
+	L"Yemeni",     // 110
+	L"Zamundan",   // Zamunda 
+	L"Zimbabwean",
 };
 
 STR16		szNationalityTextAdjective[] = // TODO.Translate
@@ -9522,7 +9559,7 @@ STR16		szNationalityTextAdjective[] = // TODO.Translate
 	L"danes",
 	L"frenchmen",
 	L"russians",
-	L"nigerians",
+	L"traconians",
 	L"swiss",			// 10
 	L"jamaicans",
 	L"poles",
@@ -9540,57 +9577,94 @@ STR16		szNationalityTextAdjective[] = // TODO.Translate
 	L"metavirans",
 
 	// newly added from here on
-	L"greek",			// 25
-	L"estonians",
-	L"venezuelans",
-	L"japanese",
-	L"turks",
-	L"indians",			// 30
-	L"mexicans",
-	L"norwegians",
-	L"spaniards",
-	L"brasilians",
-	L"finns",			// 35
-	L"iranians",
-	L"israelis",
-	L"bulgarians",
-	L"swedes",
-	L"iraqis",			// 40
-	L"syrians",
-	L"belgians",
-	L"portoguese",
-	L"belarusian",
-	L"serbians",		// 45
-	L"pakistanis",
+	L"afghans",       // 25 
 	L"albanians",
 	L"argentinians",
 	L"armenians",
-	L"azerbaijani", // 50
+	L"azerbaijani",
+	L"bangladeshi", // 30
+	L"belarusians",
+	L"belgians",
+	L"beninese",
 	L"bolivians",
-	L"chileans",
-	L"circassians",
+	L"bosnians",     // 35
+	L"brasilians",
+	L"bulgarians",
+	L"cambodians",
+	L"chadians",
+	L"chileans",     // 40
 	L"columbians",
-	L"egyptians", // 55
+	L"congolese",
+	L"croatians",
+	L"ecuadorians",
+	L"egyptians",    // 45 
+	L"englishmen",
+	L"eritreans",
+	L"estonians",
 	L"ethiopians",
+	L"filipinos",    // 50
+	L"finns",
 	L"georgians",
+	L"greek",
+	L"guatemalans",
+	L"haitians",      // 55
+	L"hondurans",
+	L"indians",
+	L"indonesians",
+	L"iranians",
+	L"iraqis",      // 60
+	L"islandics",
+	L"israelis",
+	L"japanese",
 	L"jordanians",
-	L"kazakhstani",
-	L"kenyans", // 60
+	L"kazakhstani",  // 65
 	L"koreans",
 	L"kyrgyzstani",
+	L"laotians",
+	L"latvians",
+	L"lebanese",    // 70
+	L"lithuanians",
+	L"lybians",
+	L"macedonians",
+	L"malaysians",
+	L"mexicans",    // 75
 	L"mongolians",
-	L"palestinians",
-	L"panamanians", // 65
-	L"rhodesians",
+	L"moroccans",
+	L"mozambicans",
+	L"myanmarians",
+	L"namibians",   // 80
+	L"nicaraguans",
+	L"nigerians",
+	L"nigeriens",
+	L"norwegians",
+	L"pakistanis",   // 85
+	L"panamanians",
+	L"portoguese",
+	L"rwandanese",
 	L"salvadorans",
-	L"saudis",
-	L"somalis",
-	L"thais", // 70
+	L"saudis",     // 90
+	L"serbians",
+	L"slovakians",
+	L"slovenians",
+	L"somali",
+	L"spaniards",     // 95
+	L"sudanese",
+	L"swedes",
+	L"syrians",
+	L"thais",
+	L"togolese",    // 100
+	L"tunisians",
+	L"turks",
+	L"ugandans",
 	L"ukrainians",
+	L"uruguayans",   // 105
 	L"uzbekistani",
+	L"venezuelans",
+	L"vietnamese",
 	L"welshs",
-	L"yazidis",
-	L"zimbabweans", // 75
+	L"yemenites",     // 110
+	L"zamundans",   // Zamunda 
+	L"zimbabweans",
 };
 
 // special text used if we do not hate any nation (value of -1)

--- a/i18n/_RussianText.cpp
+++ b/i18n/_RussianText.cpp
@@ -9419,7 +9419,7 @@ STR16		szNationalityText[]=
 	L"Датчанин",
 	L"Француз",
 	L"Русский",
-	L"Нигериец",
+	L"Traconian",           // UB takes place in Tracona
 	L"Швейцарец",			// 10
 	L"Ямаец",
 	L"Поляк",
@@ -9437,57 +9437,94 @@ STR16		szNationalityText[]=
 	L"Метавирец",
 
 	// newly added from here on
-	L"Грек",			// 25
-	L"Эстонец",
-	L"Венесуэлец",
-	L"Японец",
-	L"Турок",
-	L"Индиец",			// 30
-	L"Мексиканец",
-	L"Норвежец",
-	L"Испанец",
-	L"Бразилец",
-	L"Финн",			// 35
-	L"Иранец",
-	L"Израильтянин",
-	L"Болгарин",
-	L"Швед",
-	L"Иракец",			// 40
-	L"Сириец",
-	L"Бельгиец",
-	L"Португалец",
-	L"Белорус",
-	L"Серб",			// 45
-	L"Пакистанец",
+	L"Afghan",       // 25 
 	L"Албанец",
 	L"Аргентинец",
 	L"Армянин",
-	L"Азербайджанец", // 50
+	L"Азербайджанец",
+	L"Bangladeshi ", // 30
+	L"Белорус",
+	L"Бельгиец",
+	L"Beninese",
 	L"Боливиец",
-	L"Чилиец",
-	L"Черкес",
+	L"Bosnian",     // 35
+	L"Бразилец",
+	L"Болгарин",
+	L"Cambodian",
+	L"Chadian",
+	L"Чилиец",     // 40
 	L"Колумбиец",
-	L"Египтянин", // 55
+	L"Congolese",
+	L"Croatian",
+	L"Ecuadorian",
+	L"Египтянин",    // 45 
+	L"English",
+	L"Eritrean",
+	L"Эстонец",
 	L"Эфиоп",
+	L"Filipino",    // 50
+	L"Финн",
 	L"Грузин",
+	L"Грек",
+	L"Guatemalan",
+	L"Haitian",      // 55
+	L"Honduran",
+	L"Индиец",
+	L"Indonesian",
+	L"Иранец",
+	L"Иракец",     // 60
+	L"Islandic",
+	L"Израильтянин",
+	L"Японец",
 	L"Иорданец",
-	L"Казахстанец",
-	L"Кениец", // 60
+	L"Казахстанец",  // 65
 	L"Кореец",
 	L"Кыргызстанец",
+	L"Laotian",
+	L"Latvian",
+	L"Lebanese",    // 70
+	L"Lithuanian",
+	L"Lybian",
+	L"Macedonian",
+	L"Malaysian",
+	L"Мексиканец",    // 75
 	L"Монгол",
-	L"Палестинец",
-	L"Панамец", // 65
-	L"Родезиец",
+	L"Moroccan",
+	L"Mozambican",
+	L"Myanma",
+	L"Namibian",   // 80
+	L"Nicaraguan",
+	L"Нигериец",
+	L"Nigerien",
+	L"Норвежец",
+	L"Пакистанец",   // 85
+	L"Панамец",
+	L"Португалец",
+	L"Rwandanese",
 	L"Сальвадорец",
-	L"Саудовец",
+	L"Саудовец",     // 90
+	L"Серб",
+	L"Slovakian",
+	L"Slovenian",
 	L"Сомалиец",
-	L"Таец", // 70
+	L"Испанец",    // 95
+	L"Sudanese",
+	L"Швед",
+	L"Сириец",
+	L"Таец",
+	L"Togolese",    // 100
+	L"Tunisian",
+	L"Турок",
+	L"Ugandan",
 	L"Украинец",
+	L"Uruguayan",   // 105
 	L"Узбекистанец",
+	L"Венесуэлец",
+	L"Vietnamese",
 	L"Валлиец",
-	L"Езид",
-	L"Зимбабвиец", // 75
+	L"Yemeni",     // 110
+	L"Zamundan",   // Zamunda 
+	L"Зимбабвиец",
 };
 
 STR16		szNationalityTextAdjective[] =
@@ -9501,7 +9538,7 @@ STR16		szNationalityTextAdjective[] =
 	L"датчан",
 	L"французов",
 	L"русских",
-	L"нигерийцев",
+	L"traconians",
 	L"швейцарцев",			// 10
 	L"ямайцев",
 	L"поляков",
@@ -9519,57 +9556,94 @@ STR16		szNationalityTextAdjective[] =
 	L"метавирцев",
 
 	// newly added from here on
-	L"греков",			// 25
-	L"эстонцев",
-	L"венесуэльцев",
-	L"японцев",
-	L"турков",
-	L"индийцев",			// 30
-	L"мексиканцев",
-	L"норвежцев",
-	L"испанцев",
-	L"бразильцев",
-	L"финнов",			// 35
-	L"иранцев",
-	L"израильтянинов",
-	L"болгаров",
-	L"шведов",
-	L"иракцев",			// 40
-	L"сирийцев",
-	L"бельгийцев",
-	L"португальцев",
-	L"белорусов",
-	L"сербов",			// 45
-	L"пакистанцев",
+	L"afghans",       // 25 
 	L"албанцев",
 	L"аргентинцев",
 	L"армян",
-	L"азербайджанцев", // 50
+	L"азербайджанцев",
+	L"bangladeshi", // 30
+	L"белорусов",
+	L"бельгийцев",
+	L"beninese",
 	L"боливийцев",
-	L"чилийцев",
-	L"черкесов",
+	L"bosnians",     // 35
+	L"бразильцев",
+	L"болгаров",
+	L"cambodians",
+	L"chadians",
+	L"чилийцев",     // 40
 	L"колумбийцев",
-	L"египтян", // 55
+	L"congolese",
+	L"croatians",
+	L"ecuadorians",
+	L"египтян",    // 45 
+	L"englishmen",
+	L"eritreans",
+	L"эстонцев",
 	L"эфиопов",
+	L"filipinos",    // 50
+	L"финнов",
 	L"грузин",
+	L"греков",
+	L"guatemalans",
+	L"haitians",      // 55
+	L"hondurans",
+	L"индийцев",
+	L"indonesians",
+	L"иранцев",
+	L"иракцев",	      // 60
+	L"islandics",
+	L"израильтянинов",
+	L"японцев",
 	L"иорданцев",
-	L"казахстанцев",
-	L"кенийцев", // 60
+	L"казахстанцев",  // 65
 	L"корейцев",
 	L"кыргызстанцев",
+	L"laotians",
+	L"latvians",
+	L"lebanese",    // 70
+	L"lithuanians",
+	L"lybians",
+	L"macedonians",
+	L"malaysians",
+	L"мексиканцев",  // 75
 	L"монголов",
-	L"палестинцев",
-	L"панамцев", // 65
-	L"родезийцев",
+	L"moroccans",
+	L"mozambicans",
+	L"myanmarians",
+	L"namibians",   // 80
+	L"nicaraguans",
+	L"нигерийцев",
+	L"nigeriens",
+	L"норвежцев",
+	L"пакистанцев",   // 85
+	L"панамцев",
+	L"португальцев",
+	L"rwandanese",
 	L"сальвадорцев",
-	L"саудовцев",
+	L"саудовцев",     // 90
+	L"сербов",
+	L"slovakians",
+	L"slovenians",
 	L"сомалийцев",
-	L"тайцев", // 70
+	L"испанцев",     // 95
+	L"sudanese",
+	L"шведов",
+	L"сирийцев",
+	L"тайцев",
+	L"togolese",    // 100
+	L"tunisians",
+	L"турков",
+	L"ugandans",
 	L"украинцев",
+	L"uruguayans",   // 105
 	L"узбекистанцев",
+	L"венесуэльцев",
+	L"vietnamese",
 	L"валлийцев",
-	L"езидов",
-	L"зимбабвийцев", // 75
+	L"yemenites",     // 110
+	L"zamundans",   // Zamunda 
+	L"зимбабвийцев",
 };
 
 // special text used if we do not hate any nation (value of -1)


### PR DESCRIPTION
- added Tracona for use with UB, etc
- sorted alphabetical (english) for more ease of use during IMP creation
- that sorting starts only after original nationalities (from after Metaviran)
- expanded and adjusted the existing ones
- tried to achieve a decent amount from every continent
- while sorting the language specific files, preserved existing translations
- adjusted MercProfiles in related gamedir change