### PR TITLE
QoL: Right Click to fast forward one hour

### DIFF
--- a/Strategic/Game Clock.cpp
+++ b/Strategic/Game Clock.cpp
@@ -45,6 +45,9 @@ BOOLEAN fClockMouseRegionCreated = FALSE;
 
 BOOLEAN fTimeCompressHasOccured = FALSE;
 
+// run time compression till next hour
+bool stopTimeCompressionNextHour = false;
+
 //This value represents the time that the sector was loaded.	If you are in sector A9, and leave
 //the game clock at that moment will get saved into the temp file associated with it.	The next time you
 //enter A9, this value will contain that time.	Used for scheduling purposes.
@@ -524,6 +527,9 @@ void DecreaseGameTimeCompressionRate()
 void SetGameTimeCompressionLevel( UINT32 uiCompressionRate )
 {
 	Assert( uiCompressionRate < NUM_TIME_COMPRESS_SPEEDS );
+
+	if( uiCompressionRate == TIME_COMPRESS_X0 )
+		stopTimeCompressionNextHour = false;
 
 	if( guiCurrentScreen == GAME_SCREEN )
 	{

--- a/Strategic/Game Clock.h
+++ b/Strategic/Game Clock.h
@@ -109,6 +109,9 @@ extern INT32 giTimeCompressSpeeds[ NUM_TIME_COMPRESS_SPEEDS ];
 // compress mode now in use
 extern INT32 giTimeCompressMode;
 
+// run time compression till next hour
+extern bool stopTimeCompressionNextHour;
+
 
 enum
 {

--- a/Strategic/Hourly Update.cpp
+++ b/Strategic/Hourly Update.cpp
@@ -86,6 +86,11 @@ CHAR16	zString[128];
 	if(is_networked)
 		return;
 
+	if (stopTimeCompressionNextHour)
+	{
+		SetGameTimeCompressionLevel( TIME_COMPRESS_X0);
+	}	
+
 	// hourly update of town loyalty
 	HandleTownLoyalty();
 

--- a/Strategic/Map Screen Interface Bottom.cpp
+++ b/Strategic/Map Screen Interface Bottom.cpp
@@ -713,6 +713,27 @@ void BtnTimeCompressMoreMapScreenCallback( GUI_BUTTON *btn,INT32 reason )
 	{
 		if ( CommonTimeCompressionChecks() == TRUE )
 			return;
+
+		// redraw region
+		if( btn->uiFlags & MSYS_HAS_BACKRECT )
+		{
+			fMapScreenBottomDirty = TRUE;
+		}
+
+		btn->uiFlags|=(BUTTON_CLICKED_ON);
+	}
+	// Start time compression which stops at the next hour
+	// Button down removes the pop up/tooltip, Button up calls the functionality
+	else if(reason & MSYS_CALLBACK_REASON_RBUTTON_UP )
+	{
+		if (btn->uiFlags & BUTTON_CLICKED_ON)
+		{
+			btn->uiFlags&=~(BUTTON_CLICKED_ON);
+			fMapScreenBottomDirty = TRUE;
+
+			stopTimeCompressionNextHour = true;
+			SetGameTimeCompressionLevel( TIME_COMPRESS_60MINS );
+		}
 	}
 }
 

--- a/i18n/_EnglishText.cpp
+++ b/i18n/_EnglishText.cpp
@@ -4453,7 +4453,7 @@ STR16 pMapScreenBottomFastHelp[] =
 	L"|Laptop",
 	L"Tactical (|E|s|c)",
 	L"|Options",
-	L"Time Compress (|+)", 	// time compress more
+	L"Time Compress (|+)\nRight Click to fast forward one hour", 	// time compress more
 	L"Time Compress (|-)", 	// time compress less
 	L"Previous Message (|U|p)\nPrevious Page (|P|g|U|p)", 	// previous message in scrollable list
 	L"Next Message (|D|o|w|n)\nNext Page (|P|g|D|n)", 	// next message in the scrollable list


### PR DESCRIPTION
This is a quality of life feature to auto stop time compression once `HandleHourlyUpdate` is called. By right clicking on the relevant button for `MAP_TIME_COMPRESS_MORE` (strategic screen bottom right), time compression is set to 60 minutes and is automatically reset once a full hour has passed. This doesn't affect the normal behaviour with left click.

By setting the new bool `stopTimeCompressionNextHour` in `SetGameTimeCompressionLevel`, it is also set to false when an event happens inside the hour (for example moving into a new sector)

~~Some minor reformatting was done in `BtnTimeCompressMoreMapScreenCallback` to indent lines with the expected amounts of whitespace.~~