### PR TITLE
fix bug where combat doesn't end on team retreat

### DIFF
--- a/Strategic/strategicmap.cpp
+++ b/Strategic/strategicmap.cpp
@@ -6604,7 +6604,7 @@ BOOLEAN CheckAndHandleUnloadingOfCurrentWorld( )
 	{	//Check and see if we have any live mercs in the sector.
 		for ( i = gTacticalStatus.Team[OUR_TEAM].bFirstID; i <= gTacticalStatus.Team[OUR_TEAM].bLastID; i++ )
 		{ //If we have a live and valid soldier
-			if ( MercPtrs[i]->bActive && MercPtrs[i]->stats.bLife && !MercPtrs[i]->flags.fBetweenSectors && !(MercPtrs[i]->flags.uiStatusFlags & SOLDIER_VEHICLE) && !AM_A_ROBOT( MercPtrs[i] ) && !AM_AN_EPC( MercPtrs[i] ) )
+			if ( MercPtrs[i]->bActive && MercPtrs[i]->stats.bLife && !MercPtrs[i]->flags.fBetweenSectors && MercPtrs[i]->bInSector && !(MercPtrs[i]->flags.uiStatusFlags & SOLDIER_VEHICLE) && !AM_A_ROBOT( MercPtrs[i] ) && !AM_AN_EPC( MercPtrs[i] ) )
 			{
 				if ( MercPtrs[i]->sSectorX == gWorldSectorX &&
 					 MercPtrs[i]->sSectorY == gWorldSectorY &&


### PR DESCRIPTION
fixes issue #498 where retreating from combat in a sector that has a merc inbound via the airdrop marker causes combat not to end

the reason this fails is that a the inbound soldier counts as being in the sector being retreated from, even though he isn't

I add a check for `MercPtrs[i]->bInSector` so this doesn't happen

that way the function doesn't leave early and CheckForEndOfCombatMode is reached