### PR TITLE
Use SoldierID instead of pSoldier

### DIFF
--- a/Strategic/mapscreen.cpp
+++ b/Strategic/mapscreen.cpp
@@ -863,7 +863,7 @@ extern BOOLEAN CanPlayerUseSectorInventory( SOLDIERTYPE *pSelectedSoldier );
 
 // handle talking
 void HandleSpontanousTalking( void );
-BOOLEAN ContinueDialogue(SOLDIERTYPE *pSoldier, BOOLEAN fDone );
+BOOLEAN ContinueDialogue(SoldierID id, BOOLEAN fDone );
 extern void CreateDestroyMilitiaSectorButtons( void );
 extern void CreateDestroySupplySectorButtons();
 
@@ -13098,16 +13098,12 @@ void UpdatePausedStatesDueToTimeCompression( void )
 }
 
 
-BOOLEAN ContinueDialogue(SOLDIERTYPE *pSoldier, BOOLEAN fDone )
+BOOLEAN ContinueDialogue(SoldierID id, BOOLEAN fDone )
 {
 	// continue this grunts dialogue, restore when done
 	static INT16 bOldSelectedInfoChar = -1;
 	static BOOLEAN fTalkingingGuy = FALSE;
-
 	UINT16 bCounter = 0;
-
-
-
 
 	if( fDone == TRUE )
 	{
@@ -13131,7 +13127,7 @@ BOOLEAN ContinueDialogue(SOLDIERTYPE *pSoldier, BOOLEAN fDone )
 	}
 
 	// check if valid character talking?
-	if( pSoldier == NULL )
+	if( id >= NOBODY )
 	{
 		return FALSE;
 	}
@@ -13141,7 +13137,7 @@ BOOLEAN ContinueDialogue(SOLDIERTYPE *pSoldier, BOOLEAN fDone )
 	{
 		if( gCharactersList[bCounter].fValid == TRUE )
 		{
-			if( gCharactersList[bCounter].usSolID == pSoldier->ubID )
+			if( gCharactersList[bCounter].usSolID == id )
 			{
 				if( bSelectedInfoChar != bCounter )
 				{

--- a/Tactical/Dialogue Control.cpp
+++ b/Tactical/Dialogue Control.cpp
@@ -203,7 +203,7 @@ void RenderSubtitleBoxOverlay( VIDEO_OVERLAY *pBlitter );
 void RenderFaceOverlay( VIDEO_OVERLAY *pBlitter );
 
 
-extern BOOLEAN ContinueDialogue(SOLDIERTYPE *pSoldier, BOOLEAN fDone );
+extern BOOLEAN ContinueDialogue(SoldierID id, BOOLEAN fDone );
 extern void HandlePendingInitConv( );
 extern BOOLEAN WillMercRenew( SOLDIERTYPE *pSoldier, BOOLEAN fSayQuote );
 extern void DrawFace( INT16 sCharNumber );
@@ -253,7 +253,7 @@ void HandleExternNPCSpeechFace( INT32 iIndex );
 
 
 
-extern BOOLEAN ContinueDialogue(SOLDIERTYPE *pSoldier, BOOLEAN fDone );
+extern BOOLEAN ContinueDialogue(SoldierID id, BOOLEAN fDone );
 extern	BOOLEAN		DoSkiMessageBox( UINT8 ubStyle, STR16 zString, UINT32 uiExitScreen, UINT8 ubFlags, MSGBOX_CALLBACK ReturnCallback );
 
 
@@ -3005,10 +3005,9 @@ void HandleTacticalSpeechUI( UINT8 ubCharacterNum, INT32 iFaceIndex	)
 		// If so, set current guy active to talk.....
 		if ( pSoldier != NULL )
 		{
-			ContinueDialogue( pSoldier, FALSE );
+			ContinueDialogue( pSoldier->ubID, FALSE );
 		}
 	}
-
 }
 
 


### PR DESCRIPTION
ContinueDialogue was possible to be called with pSoldier that isn't null but is not valid pointer to MercPtrs array resulting in debugger catching an illegal memory access.