### PR TITLE
Fix PBI when enemy attacks starting sector in tactical view

### DIFF
--- a/Strategic/Map Screen Interface Bottom.cpp
+++ b/Strategic/Map Screen Interface Bottom.cpp
@@ -2070,7 +2070,14 @@ void HandleExitsFromMapScreen( void )
 #ifdef JA2UB
 				//JA25 ub
 				case MAP_EXIT_TO_INTRO_SCREEN:
-				//	SetPendingNewScreen( INTRO_SCREEN );
+					//	SetPendingNewScreen( INTRO_SCREEN );
+					// Set the PBI sector locator to initial arrival sector.
+					// UB skips the call to HandleTimeCompressWithTeamJackedInAndGearedToGo() that would normally set it upon game start
+					// When it's not set, the MapscreenHandle() will error on assert when trying to draw the glowing red box around the sector under attack
+					gubPBSectorX = gGameExternalOptions.ubDefaultArrivalSectorX;
+					gubPBSectorY = gGameExternalOptions.ubDefaultArrivalSectorY;
+					gubPBSectorZ = 0;
+
 					BeginLoadScreen();
 					break;
 #endif


### PR DESCRIPTION
Closes #518 

When enemy attacks the starting sector and player is in tactical view. We go from tactical to strategic screen to show the prebattle interface instead of staying in tactical. The game errors on the sector assert in HandleBlitOfSectorLocatorIcon() when trying to draw the glowing red locator around the sector just before displaying the prebattle interface.

Normally the locator sector gets set properly when compressing time for the first time in a new game start but due to UB going into playing the intro video, it skips the call to HandleTimeCompressWithTeamJackedInAndGearedToGo() that would eventually set it. Neither can we rely on setting the sector when initiating the prebattle interface since MapScreenHandle() tries to display the locator before the PBI gets initialized.