### PR TITLE
Revert "use link-time optimization when creating a release"

### DIFF
--- a/.github/workflows/build_language.yml
+++ b/.github/workflows/build_language.yml
@@ -54,16 +54,6 @@ jobs:
           sed -i "s|@Build@|${GAME_BUILD:0:255}|" Ja2/GameVersion.cpp
           cat Ja2/GameVersion.cpp
 
-      - name: Turn on link-time optimization?
-        if: fromJSON(inputs.assemble)
-        shell: bash
-        run: |
-          set -eux
-
-          echo "
-          LTO=ON
-          " >> $GITHUB_ENV
-
       - name: Prepare build properties
         shell: bash
         run: |
@@ -87,7 +77,7 @@ jobs:
           arch: x86
       - name: Prepare build
         run: |
-          cmake -S . -B build -GNinja -DCMAKE_BUILD_TYPE=Release -DLanguages="$Env:JA2Language" -DApplications="$Env:JA2Application" -DLTO_OPTION="$Env:LTO"
+          cmake -S . -B build -GNinja -DCMAKE_BUILD_TYPE=Release -DLanguages="$Env:JA2Language" -DApplications="$Env:JA2Application"
       - name: Build
         run: |
           cmake --build build/ -- -v


### PR DESCRIPTION
If this is ever the default, it should be set in the CMakeLists.txt file, not in the CI alone. My bad.

This reverts commit a7b0091a27a1942a5ed5521b86df9393dbf5bdcd.