### PR TITLE
Supply ProfileID to LUA scripts instead of SoldierID

### DIFF
--- a/Strategic/LuaInitNPCs.cpp
+++ b/Strategic/LuaInitNPCs.cpp
@@ -8657,7 +8657,7 @@ static int l_TileIsOutOfBoundsClosestPC(lua_State* L)
 static int l_FindSoldierByProfileID(lua_State* L)
 {
 	SOLDIERTYPE* pSoldier;
-	UINT16 id = NOBODY;
+	UINT8 foundProfileID = -1;
 	UINT16 ubLoop = 0, ubLoopLimit = MAX_NUM_SOLDIERS;
 
 	if (lua_gettop(L))
@@ -8668,11 +8668,12 @@ static int l_FindSoldierByProfileID(lua_State* L)
 		{
 			if (pSoldier->bActive && pSoldier->ubProfile == ubTargetNPC)
 			{
-				id = pSoldier->ubID;
+				foundProfileID = pSoldier->ubProfile;
+				break;
 			}
 		}
 
-		lua_pushinteger(L, id);
+		lua_pushinteger(L, foundProfileID);
 	}
 
 	return 1;
@@ -8695,6 +8696,7 @@ static int l_FindSoldierByProfileIDBool(lua_State* L)
 			if (pSoldier->bActive && pSoldier->ubProfile == ubTargetNPC)
 			{
 				ProfBool = TRUE;
+				break;
 			}
 		}
 


### PR DESCRIPTION
Fixes broken NPC quests among probably other things.

Lua scripts expect to receive the same profileID value back from l_FindSolderByProfileID() that is supplied to it on the script side. This is a bit suboptimal as we constantly keep searching for the correct soldier on different calls to C++ side with the way it works now.

A better solution in the future would be to change the other l_ side functions that depend on l_FindSolderByProfileID() to use SoldierID instead so we would need to search for the merc only once. As an example, ActionStopMerc() / l_EVENT_StopMerc() that gets called in lua side HandleMaryArrival() function.