### PR TITLE
use en_US locale instead of user's, fallback to C if not found

### DIFF
--- a/Utils/Text Utils.cpp
+++ b/Utils/Text Utils.cpp
@@ -9,7 +9,12 @@ auto FormatMoney(INT32 iNumber) -> std::wstring
 {
     static std::wstringstream wss([] {
         std::wstringstream ss;
-        ss.imbue(std::locale(""));
+        try {
+            ss.imbue(std::locale("en_US.UTF-8"));
+        }
+        catch (const std::exception&) {
+            ss.imbue(std::locale::classic());
+        }
         return ss;
         }());
     wss.str(L"");


### PR DESCRIPTION
most likely every windows install has en_US available, even if in other languages. if not, bring back the insertcommas function from history, no biggie