### PR TITLE
fix POWs in LOS keeps you in tb mode

### DIFF
--- a/Tactical/Overhead.cpp
+++ b/Tactical/Overhead.cpp
@@ -6945,7 +6945,7 @@ BOOLEAN CheckForEndOfCombatMode( BOOLEAN fIncrementTurnsNotSeen )
         for ( cnt = 0; cnt < guiNumMercSlots; cnt++ )
         {
             pTeamSoldier = MercSlots[ cnt ];
-            if ( pTeamSoldier && pTeamSoldier->stats.bLife >= OKLIFE && !pTeamSoldier->aiData.bNeutral )
+            if ( pTeamSoldier && pTeamSoldier->stats.bLife >= OKLIFE && !pTeamSoldier->aiData.bNeutral && !(pTeamSoldier->usSoldierFlagMask & SOLDIER_POW) )
             {
                 if ( SoldierHasSeenEnemiesLastFewTurns( pTeamSoldier ) )
                 {


### PR DESCRIPTION
At the moment when pow is not collapsed and is in our LOS we can't leave TB. Let's fix it