### PR TITLE
Make 3rd party corpses invisible till they in fov

### DIFF
--- a/Tactical/Rotting Corpses.cpp
+++ b/Tactical/Rotting Corpses.cpp
@@ -2527,7 +2527,6 @@ void LookForAndMayCommentOnSeeingCorpse( SOLDIERTYPE *pSoldier, INT32 sGridNo, U
 	INT8			bToleranceThreshold = 0;
 	SOLDIERTYPE		*pTeamSoldier;
 
-
 	if ( QuoteExp[ pSoldier->ubProfile ].QuoteExpHeadShotOnly == 1 )
 	{
 		return;


### PR DESCRIPTION
when non player soldier dies the corpse is rendered even if we can't see it. For example when you, soldiers, and blood cats are in the same sector and goon got killed the corpse is rendered even if your team can't see it at all. With this change such corpses won't be rendered right away, but they become visible when you come over them 