### PR TITLE
Stop put pelt to bc inv

### DIFF
--- a/Tactical/Inventory Choosing.cpp
+++ b/Tactical/Inventory Choosing.cpp
@@ -3129,7 +3129,8 @@ void AssignCreatureInventory( SOLDIERTYPE *pSoldier )
 
 	if (Random(100) < uiChanceToDrop)
 	{
-		CreateItem( (UINT16)(fBloodcat ? BLOODCAT_PELT : CREATURE_PART_ORGAN), (INT8) (80 + Random(21)), &(pSoldier->inv[BIGPOCK3POS]) );
+		if (!fBloodcat)
+			CreateItem((UINT16)CREATURE_PART_ORGAN, (INT8)(80 + Random(21)), &(pSoldier->inv[BIGPOCK3POS]));
 	}
 }
 


### PR DESCRIPTION
Since now we can use a knife to 'take' blood cat's pelt let's prevent them from dropping it by not putting them into inventory Otherwise it's possible to get 2 pelts of the same tiger... The only problem is that it's probably not a very well documented fact that take clothes means 'skin the tiger'