### PR TITLE
Make gunsling pocket available only if you have gunsling attached

### DIFF
--- a/Tactical/Items.cpp
+++ b/Tactical/Items.cpp
@@ -6445,6 +6445,9 @@ BOOLEAN CanItemFitInPosition( SOLDIERTYPE *pSoldier, OBJECTTYPE *pObj, INT8 bPos
 			if(pObj->usItem == MONEY)
 				return( FALSE );
 
+			if (!HasAttachmentOfClass(pObj, AC_SLING))
+				return(FALSE);
+
 			if ( Item[pObj->usItem].usItemClass & (IC_AMMO | IC_GRENADE) )
 				return(CompatibleAmmoForGun(pObj, &pSoldier->inv[GUNSLINGPOCKPOS]) || ValidAttachment(pObj->usItem, &(pSoldier->inv[GUNSLINGPOCKPOS]) ) || ValidLaunchable(pObj->usItem, pSoldier->inv[GUNSLINGPOCKPOS].usItem));
 


### PR DESCRIPTION
Allow to use gunsling pocket only with weapon that has rifle sling attached. It's more realistic than to have a heavy mg without a sling to being somehow magically attached to merc's body.
You would need to carry a shovel, machete and crowbar somewhere else