### PR TITLE
Let 'w' allow to look with no extra click

### DIFF
--- a/Tactical/Turn Based Input.cpp
+++ b/Tactical/Turn Based Input.cpp
@@ -4612,7 +4612,7 @@ void GetKeyboardInput( UINT32 *puiNewEvent )
 					if ( ( gpItemPointer == NULL ) &&
 						( ( gsCurInterfacePanel != SM_PANEL ) || ( ButtonList[ iSMPanelButtons[ LOOK_BUTTON ] ]->uiFlags & BUTTON_ENABLED ) ) )
 					{
-						*puiNewEvent = LC_CHANGE_TO_LOOK;
+						*puiNewEvent = LC_LOOK;
 					}
 				}
 				break;


### PR DESCRIPTION
Since we have at least 3 options to 'look' let's change the way one of the works. So we this change you don't need to confirm a look with extra mouse click both in real time and in tb. All you need is to move cursor in the direction you want to look/raise weapon and press 'w'