### PR TITLE
Add visual muzzle flash for invisible soldiers

### DIFF
--- a/Tactical/Soldier Ani.cpp
+++ b/Tactical/Soldier Ani.cpp
@@ -615,11 +615,6 @@ BOOLEAN AdjustToNextAnimationFrame( SOLDIERTYPE *pSoldier )
 
 			case 441:
 				// CODE: Show muzzle flash
-				if ( pSoldier->bVisible == -1 )
-				{
-					break;
-				}
-
 				{
 					OBJECTTYPE* pObjAttHand = pSoldier->GetUsedWeapon(&pSoldier->inv[pSoldier->ubAttackingHand]);
 					if (IsFlashSuppressor(pObjAttHand, pSoldier) || (*pObjAttHand)[0]->data.gun.bGunAmmoStatus < 0)


### PR DESCRIPTION
For some reason we don't draw muzzle flashes for currently unseen soldiers which makes them absolutely useless.