### PR TITLE
Fix items duplication in prev sector on entering new sector

### DIFF
--- a/Ja2/SaveLoadGame.cpp
+++ b/Ja2/SaveLoadGame.cpp
@@ -3587,7 +3587,7 @@ BOOLEAN SaveGame( int ubSaveGameID, STR16 pGameDesc )
 	
 	DebugMsg( TOPIC_JA2, DBG_LEVEL_3, String("starting SaveCurrentSectorsInformationToTempItemFile" ) );
 	//Save the current sectors open temp files to the disk
-	if( !SaveCurrentSectorsInformationToTempItemFile() )
+	if( !SaveCurrentSectorsInformationToTempItemFile( TRUE ) )
 	{
 		ScreenMsg( FONT_MCOLOR_WHITE, MSG_ERROR, L"ERROR in SaveCurrentSectorsInformationToTempItemFile()");
 		goto FAILED_TO_SAVE;

--- a/Strategic/strategicmap.cpp
+++ b/Strategic/strategicmap.cpp
@@ -6476,7 +6476,7 @@ BOOLEAN HandleDefiniteUnloadingOfWorld( UINT8 ubUnloadCode )
 			TeamDropAll( MILITIA_TEAM );
 
 			// Save the current sectors Item list to a temporary file, if its not the first time in
-			SaveCurrentSectorsInformationToTempItemFile( );
+			SaveCurrentSectorsInformationToTempItemFile( FALSE );
 
 			// Update any mercs currently in sector, their profile info...
 			UpdateSoldierPointerDataIntoProfile( FALSE );
@@ -6492,7 +6492,7 @@ BOOLEAN HandleDefiniteUnloadingOfWorld( UINT8 ubUnloadCode )
 		}
 
 		//Save the current sectors open temp files to the disk
-		if ( !SaveCurrentSectorsInformationToTempItemFile( ) )
+		if ( !SaveCurrentSectorsInformationToTempItemFile( FALSE ) )
 		{
 			ScreenMsg( FONT_MCOLOR_WHITE, MSG_TESTVERSION, L"ERROR in SaveCurrentSectorsInformationToTempItemFile()" );
 			return FALSE;
@@ -6639,7 +6639,7 @@ BOOLEAN CheckAndHandleUnloadingOfCurrentWorld( )
 			TeamDropAll( MILITIA_TEAM, TRUE );
 
 			// Save the current sectors Item list to a temporary file, if its not the first time in
-			SaveCurrentSectorsInformationToTempItemFile( );
+			SaveCurrentSectorsInformationToTempItemFile( FALSE );
 
 			return FALSE;
 		}

--- a/Tactical/Tactical Save.cpp
+++ b/Tactical/Tactical Save.cpp
@@ -1027,7 +1027,6 @@ BOOLEAN SaveCurrentSectorsInformationToTempItemFile( )
 	// handle all reachable before save
 	HandleAllReachAbleItemsInTheSector( gWorldSectorX, gWorldSectorY, gbWorldSectorZ );
 	UpdateWorldItems(gWorldSectorX, gWorldSectorY, gbWorldSectorZ, guiNumWorldItems, gWorldItems);
-	PruneWorldItems();
 
 	std::vector<ROTTING_CORPSE_DEFINITION> corpsedefvector;
 

--- a/Tactical/Tactical Save.cpp
+++ b/Tactical/Tactical Save.cpp
@@ -993,7 +993,7 @@ BOOLEAN AddItemsToUnLoadedSector(INT16 sMapX, INT16 sMapY, INT8 bMapZ, INT32 sGr
 extern BOOLEAN gfInMeanwhile;
 extern BOOLEAN EnableModifiedFileSetCache(BOOLEAN value);
 
-BOOLEAN SaveCurrentSectorsInformationToTempItemFile( )
+BOOLEAN SaveCurrentSectorsInformationToTempItemFile(BOOLEAN saveGame)
 {
 	BOOLEAN fShouldBeInMeanwhile = FALSE;
 	if( gfWasInMeanwhile )
@@ -1027,6 +1027,11 @@ BOOLEAN SaveCurrentSectorsInformationToTempItemFile( )
 	// handle all reachable before save
 	HandleAllReachAbleItemsInTheSector( gWorldSectorX, gWorldSectorY, gbWorldSectorZ );
 	UpdateWorldItems(gWorldSectorX, gWorldSectorY, gbWorldSectorZ, guiNumWorldItems, gWorldItems);
+
+	if (saveGame)
+	{
+		PruneWorldItems();
+	}
 
 	std::vector<ROTTING_CORPSE_DEFINITION> corpsedefvector;
 

--- a/Tactical/Tactical Save.h
+++ b/Tactical/Tactical Save.h
@@ -44,7 +44,7 @@ BOOLEAN GetNumberOfWorldItemsFromTempItemFile( INT16 sMapX, INT16 sMapY, INT8 bM
 UINT32 GetNumberOfMovableItems( INT16 sMapX, INT16 sMapY, INT8 bMapZ );
 
 //Saves the Current Sectors, ( world Items, rotting corpses, ... )  to the temporary file used to store the sectors items
-BOOLEAN SaveCurrentSectorsInformationToTempItemFile( );
+BOOLEAN SaveCurrentSectorsInformationToTempItemFile( BOOLEAN saveGame );
 
 //Loads the Currents Sectors information ( world Items, rotting corpses, ... ) from the temporary file used to store the sectores items
 BOOLEAN LoadCurrentSectorsInformationFromTempItemsFile();


### PR DESCRIPTION
It should fix a rather annoying bug with items duplication when you reorder items in one sector and then you enter a non selected sector. It was introduced in f88b07b99bbf28b26df8be9f22fb2b65c17b57f1 and I found it using bisect so what ever was fixed there could potential come up. My limited testing shows no duplications so far. If there is more to it you have you're starting point I guess.
UPD: Had an opportunity to play a bit. Dups are still there but steps to reproduces are now different... I'll try to revert the whole f88b07b99bbf28b26df8be9f22fb2b65c17b57f1 and test how it goes
UPD2: Since debugging world inventory is an absolute pain this is a quick and dirty way to make it work. No dups so far. Game can be saved and loaded