### PR TITLE
Load old ObjectData correctly

### DIFF
--- a/Ja2/SaveLoadGame.cpp
+++ b/Ja2/SaveLoadGame.cpp
@@ -3036,15 +3036,13 @@ BOOLEAN StackedObjectData::Load( INT8** hBuffer, float dMajorMapVersion, UINT8 u
 		else if (dMajorMapVersion >= 7 && ubMinorMapVersion >= MINOR_MAP_VERSION)
 		{
 			// Flugente: changed this, otherwise game would crash when reading WF maps if class ObjectData was different. this is a rough fix and by no means perfect
-			//LOADDATA(&(this->data), *hBuffer, sizeof(ObjectData));
-			ObjectData_PRE_ITS oldData;
+			ObjectData_PRE_ITS oldData{};
 			LOADDATA(&(oldData), *hBuffer, sizeof(ObjectData_PRE_ITS));
 			this->data = oldData;
 		}
 		else if (dMajorMapVersion >= 7 && ubMinorMapVersion >= MINOR_MAP_REPAIR_SYSTEM)
 		{
 			// sObjectFlag'  size changed			
-			//LOADDATA(&(this->data), *hBuffer, sizeof(ObjectData) - sizeof(this->data.sObjectFlag) );
 			ObjectData_PRE_ITS oldData;
 			LOADDATA(&(oldData), *hBuffer, sizeof(ObjectData_PRE_ITS) - sizeof(oldData.sObjectFlag));
 			this->data = oldData;
@@ -3058,8 +3056,7 @@ BOOLEAN StackedObjectData::Load( INT8** hBuffer, float dMajorMapVersion, UINT8 u
 			// But of course, we now 'read' the values for sRepairThreshold, but there weren't any in older map versions, resulting in garbage values - we therefore set that manually to 100
 			// Of course, once the ObjectData-Class is altered, this has to be altered as well!
 			//dnl ch74 241013 We cannot change past so hardcode 32 simply because that was sizeof(ObjectData) before current and all future changes ;-)
-			//LOADDATA(&(this->data), *hBuffer, /*sizeof(ObjectData) - (sizeof(this->data.bDirtLevel) + sizeof(this->data.sObjectFlag) )*/32);
-			ObjectData_PRE_ITS oldData;
+			ObjectData_PRE_ITS oldData{};
 			LOADDATA(&(oldData), *hBuffer, 32);
 			this->data = oldData;
 			this->data.sRepairThreshold = 100;
@@ -3068,8 +3065,7 @@ BOOLEAN StackedObjectData::Load( INT8** hBuffer, float dMajorMapVersion, UINT8 u
 		{
 			// WF Maps have old format
 			// +1 because we have to account for endOfPOD itself
-			//LOADDATA(&(this->data), *hBuffer, SIZEOF_OBJECTDATA_POD+1 );
-			ObjectData_PRE_ITS oldData;
+			ObjectData_PRE_ITS oldData{};
 			LOADDATA(&(oldData), *hBuffer, SIZEOF_OBJECTDATA_POD_PRE_ITS + 1);
 			this->data = oldData;
 		}

--- a/Tactical/Item Types.cpp
+++ b/Tactical/Item Types.cpp
@@ -1181,10 +1181,8 @@ ObjectData& ObjectData::operator =(const ObjectData& src)
 
 ObjectData& ObjectData::operator =(const ObjectData_PRE_ITS& src)
 {
-	if ((void*)this != (void*)&src) {
-		//first get rid of any LBE this might have
-		//DeleteLBE();
-
+	if ((void*)this != (void*)&src)
+	{
 		//copy over the data
 		this->bTrap = src.bTrap;
 		this->fUsed = src.fUsed;
@@ -1198,16 +1196,13 @@ ObjectData& ObjectData::operator =(const ObjectData_PRE_ITS& src)
 		this->sObjectFlag = src.sObjectFlag;
 
 		//copy over the union
-		this->misc.bBombStatus = src.misc.bBombStatus;		// % status
-		this->misc.bDetonatorType = src.misc.bDetonatorType;		// timed, remote, or pressure-activated
-		this->misc.usBombItem = src.misc.usBombItem;			// the usItem of the bomb.
-		this->misc.bDelay = src.misc.bDelay;			// >=0 values used only
-		this->misc.ubBombOwner = static_cast<UINT16>(src.misc.ubBombOwner);			// side which placed the bomb
-		this->misc.bActionValue = src.misc.bActionValue;			// this is used by the ACTION_ITEM fake item
-		this->misc.ubTolerance = src.misc.ubTolerance;			// tolerance value for panic triggers
-
-		//duplicate the LBE data
-		//DuplicateLBE();
+		this->misc.bBombStatus = src.misc.bBombStatus;
+		this->misc.bDetonatorType = src.misc.bDetonatorType;
+		this->misc.usBombItem = src.misc.usBombItem;
+		this->misc.bDelay = src.misc.bDelay;
+		this->misc.ubBombOwner = static_cast<UINT16>(src.misc.ubBombOwner);
+		this->misc.bActionValue = src.misc.bActionValue;
+		this->misc.ubTolerance = src.misc.ubTolerance;
 	}
 	return *this;
 }

--- a/Tactical/Item Types.h
+++ b/Tactical/Item Types.h
@@ -441,7 +441,7 @@ namespace ObjectDataStructs {
 		int		uniqueID;			// how the LBENODE is accessed
 	};
 
-	// For map load compatibility
+	// Used to maintain compatibility with major map versions older than 8.0
 	struct OBJECT_BOMBS_AND_OTHER_PRE_ITS
 	{
 		INT16		bBombStatus;
@@ -463,14 +463,8 @@ namespace ObjectDataStructs {
 };
 
 
-class ObjectData_PRE_ITS
+struct ObjectData_PRE_ITS
 {
-public:
-	ObjectData_PRE_ITS() { initialize(); };
-	// Assignment operator
-	ObjectData_PRE_ITS& operator=(const ObjectData_PRE_ITS&);
-	void	 initialize() { memset(this, 0, sizeof(ObjectData_PRE_ITS)); };
-
 	union {
 		INT16												objectStatus;//holds the same value as bStatus[0]
 		UINT16												ubShotsLeft;//holds the same value as ubShotsLeft[0]
@@ -481,14 +475,14 @@ public:
 		ObjectDataStructs::OBJECT_OWNER						owner;
 		ObjectDataStructs::OBJECT_LBE						lbe;
 	};
-	INT8		bTrap;			// 1-10 exp_lvl to detect
+	INT8			bTrap;			// 1-10 exp_lvl to detect
 	UINT8		fUsed;			// flags for whether the item is used or not
-	UINT8		ubImprintID;	// ID of merc that item is imprinted on
-	char		endOfPOD;		// For WF maps
+	UINT8		ubImprintID;		// ID of merc that item is imprinted on
+	char			endOfPOD;		// For WF maps
 	FLOAT		bTemperature;	// Flugente FTW 1.2: temperature of gun
 	UINT8		ubDirection;		// direction the bomb faces (for directional explosives)
 	UINT32		ubWireNetworkFlag;	// flags for the tripwire network
-	INT8		bDefuseFrequency;	// frequency for defusing, >=0 values used only
+	INT8			bDefuseFrequency;	// frequency for defusing, >=0 values used only
 	INT16		sRepairThreshold;	// repair only possible up to this value
 	FLOAT		bFiller;			// unused for now
 	UINT64		sObjectFlag;		// used to notify of various states that apply to this object, but not the item in general


### PR DESCRIPTION
ITS changed ObjectDataStructs::OBJECT_BOMBS_AND_OTHER::ubBombOwner data size from 1 byte to 2 bytes, and it was not taken into account when loading ObjectData