### PR TITLE
Fix helicopter airspace view when switching to travel mode

### DIFF
--- a/Strategic/mapscreen.cpp
+++ b/Strategic/mapscreen.cpp
@@ -11735,7 +11735,6 @@ void TeamListDestinationRegionBtnCallBack(MOUSE_REGION *pRegion, INT32 iReason )
 					// if he's in the helicopter
 					if( gCharactersList[ iValue + FIRSTmercTOdisplay ].usSolID->iVehicleId == iHelicopterVehicleId )
 					{
-						TurnOnAirSpaceMode( );
 						if( RequestGiveSkyriderNewDestination( ) == FALSE )
 						{
 							// not allowed to change destination of the helicopter
@@ -16025,8 +16024,14 @@ void MakeMapModesSuitableForDestPlotting( INT8 bCharNumber )
 		{
 			if ( gusMapDisplayColourMode == MAP_DISPLAY_AIRSPACE || gusMapDisplayColourMode == MAP_DISPLAY_AIRSPACE_COLOURED_SAMS )
 			{
-				// turn off airspace mode automatically
-				ToggleAirspaceMode();
+				// turn airspace OFF	
+				gusMapDisplayColourMode = MAP_DISPLAY_NORMAL;
+				MapBorderButtonOff(MAP_BORDER_AIRSPACE_BTN);
+				// dirty regions
+				fMapPanelDirty = TRUE;
+				fTeamPanelDirty = TRUE;
+				fCharacterInfoPanelDirty = TRUE;
+				fMapScreenBottomDirty = TRUE;
 			}
 		}
 


### PR DESCRIPTION
* Clicking destination column in teamlist for a squad in a helicopter will switch to first airspace view that shows safe / unsafe air sectors instead of the second sector.

* Clicking destination column in teamlist for a squad not in a helicopter while in either airspace view will now correctly turn it off