### PR TITLE
Remove useless lua variables, add lua externalized function to heal boxers

### DIFF
--- a/Strategic/Game Clock.cpp
+++ b/Strategic/Game Clock.cpp
@@ -249,10 +249,6 @@ void AdvanceClock( UINT8 ubWarpCode )
 	guiDay = ( guiGameClock / NUM_SEC_IN_DAY );
 	guiHour = ( guiGameClock - ( guiDay * NUM_SEC_IN_DAY ) ) / NUM_SEC_IN_HOUR;
 	guiMin	= ( guiGameClock - ( ( guiDay * NUM_SEC_IN_DAY ) + ( guiHour * NUM_SEC_IN_HOUR ) ) ) / NUM_SEC_IN_MIN;
-	
-	uiHourLua = guiHour;
-	uiDayLua = guiDay;
-	uiMinLua = guiMin;
 
 	swprintf( WORLDTIMESTR, L"%s %d, %02d:%02d", gpGameClockString[ STR_GAMECLOCK_DAY_NAME ], guiDay, guiHour, guiMin );
 

--- a/Strategic/LuaInitNPCs.cpp
+++ b/Strategic/LuaInitNPCs.cpp
@@ -859,6 +859,7 @@ static int l_PlayerTeamFull(lua_State* L);
 
 static int l_ProfilesStrategicInsertionData(lua_State* L);
 
+static int l_HealBoxers(lua_State* L);
 static int l_ResetBoxers(lua_State* L);
 
 static int l_AddVolunteers(lua_State* L);
@@ -912,9 +913,6 @@ static int l_SetIntelAndQuestMapDataForSector(lua_State* L);
 using namespace std;
 
 UINT16 idProfil;
-UINT32 uiHourLua;
-UINT32 uiDayLua;
-UINT32 uiMinLua;
 
 UINT16 PROFILLUA_sSectorX;
 UINT16 PROFILLUA_sSectorY;
@@ -1189,6 +1187,7 @@ static void IniFunction(lua_State* L, BOOLEAN bQuests)
 	lua_register(L, "TacticalCharacterDialogueWithSpecialEvent", l_TacticalCharacterDialogueWithSpecialEvent);
 	lua_register(L, "SetSalary", l_MercSalary);
 	lua_register(L, "SetProfileStrategicInsertionData", l_ProfilesStrategicInsertionData);
+	lua_register(L, "HealBoxers", l_HealBoxers);
 
 	//Get  merc
 	lua_register(L, "GetDirection", l_GetDirection); //new
@@ -9314,6 +9313,27 @@ static int l_ResetBoxers(lua_State* L)
 
 	return 0;
 }
+
+// heal boxers back to max health in case the player stays in sector while the boxers are resting
+static int l_HealBoxers(lua_State* L)
+{
+	for (UINT8 i = 0; i < NUM_BOXERS; ++i)
+	{
+		// Get breath back
+		gubBoxerID[i]->bBreath = gubBoxerID[i]->bBreathMax;
+		gubBoxerID[i]->sBreathRed = 0;
+		// Get life back
+		gubBoxerID[i]->stats.bLife = gubBoxerID[i]->stats.bLifeMax;
+		gubBoxerID[i]->bBleeding = 0;
+		// erase insta-healable injury 
+		gubBoxerID[i]->iHealableInjury = 0;
+
+		DebugQuestInfo(String("Lua: healed gubBoxerID[%d] %d back to full health", i, gubBoxerID[i]));
+	}
+
+	return 0;
+}
+
 
 //Set character to sector Y
 static int l_SetCharacterSectorY(lua_State* L)

--- a/Strategic/LuaInitNPCs.h
+++ b/Strategic/LuaInitNPCs.h
@@ -26,9 +26,6 @@ typedef struct
 
 extern ACTION_ITEM_VALUES ActionItemsValues[500];
 
-extern UINT32 uiHourLua;
-extern UINT32 uiDayLua;
-extern UINT32 uiMinLua;
 extern UINT16 PROFILLUA_sSectorX;
 extern UINT16 PROFILLUA_sSectorY;
 extern UINT8 PROFILLUA_bSectorZ;

--- a/Strategic/Luaglobal.cpp
+++ b/Strategic/Luaglobal.cpp
@@ -510,15 +510,6 @@ void IniGlobalGameSetting(lua_State *L)
 	lua_pushinteger(L, gubBoxingMatchesWon);
 	lua_setglobal(L, "gubBoxingMatchesWon");
 	
-	lua_pushinteger(L, uiHourLua);
-	lua_setglobal(L, "cHour");
-	
-	lua_pushinteger(L, uiDayLua);
-	lua_setglobal(L, "cDay");
-	
-	lua_pushinteger(L, uiMinLua);
-	lua_setglobal(L, "cMin");
-	
 	lua_pushinteger(L, gbPlayerNum);
 	lua_setglobal(L, "gbPlayerNum");
 	


### PR DESCRIPTION
- These gameclock variables were not updated properly so it created a discrepancy between it and the proper gameclock variables, and it was causing issues with the lua hourly update script which are updated to use the correct variable [here](https://github.com/1dot13/gamedir/pull/222)

- Function that heals boxers after they finish resting

Must be merged in conjunction with https://github.com/1dot13/gamedir/pull/222 gamedir or it will break because the new script would be missing the new heal boxer function and an old gamedir would be missing the useless variable I removed