### PR TITLE
Improve Displaycover() performance

### DIFF
--- a/Tactical/DisplayCover.cpp
+++ b/Tactical/DisplayCover.cpp
@@ -81,7 +81,7 @@ void	GetGridNoForViewPort( const INT32& ubX, const INT32& ubY, INT32& sGridNo );
 BOOLEAN GridNoOnScreenAndAround( const INT32& sGridNo, const UINT8& ubRadius=2 );
 
 BOOLEAN IsTheRoofVisible( const INT32& sGridNo );
-BOOLEAN HasAdjTile(const INT32 startIndex, const INT32 onRoof);
+BOOLEAN HasAdjTile(const INT32 startIndex, const bool onRoof);
 
 
 static TileDefines GetOverlayIndex( INT8 bOverlayType )
@@ -330,7 +330,7 @@ void RemoveCoverObjectFromWorld( INT32 sGridNo, UINT16 usGraphic, BOOLEAN fRoof 
 }
 
 
-static BOOLEAN HasAdjTile(const INT32 startIndex, const INT32 onRoof)
+static BOOLEAN HasAdjTile(const INT32 startIndex, const bool onRoof)
 {
 	const auto rowLength = 1 + gsMaxCellX - gsMinCellX;
 
@@ -1440,7 +1440,7 @@ void AddTraitObjectsToViewArea()
 	}
 }
 
-static BOOLEAN TraitTileHasAdjTile(const INT32 startIndex, const INT32 onRoof)
+static BOOLEAN TraitTileHasAdjTile(const INT32 startIndex, const bool onRoof)
 {
 	const auto rowLength = 1 + gsMaxCellX - gsMinCellX;
 


### PR DESCRIPTION
* Replaced gCoverViewArea[2000][2000][2] with std::vector that is adjusted to the actual viewport size. Size difference for example in 720p resolution is 8 000 000 vs 3969 elements

* FPS improved in merc view mode 6-8 frames and in enemy view mode 10-20 frames