### PR TITLE
make preprocessor definitions consistent in every single lib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,5 +163,5 @@ foreach(app IN LISTS ApplicationTargets)
   # for SGP only
   target_link_libraries(${app}_sgp PRIVATE "ddraw.lib" "${PROJECT_SOURCE_DIR}/fmodvc.lib")
   target_link_libraries(${app}_sgp PRIVATE libpng)
-  target_compile_definitions(${app}_sgp PRIVATE NO_ZLIB_COMPRESSION)
+  target_compile_definitions(${app}_sgp PRIVATE ${compilationFlags} ${debugFlags} NO_ZLIB_COMPRESSION)
 endforeach()


### PR DESCRIPTION
SGP did not seem to make any use of compilationFlags or debugFlags when translating from msbuild to cmake, but there could be a thrice removed transitive include I've missed.

there's a small probability this fixes some obscure UB or one-definition rule violation that's causing the mystery crashes people have reported