### PR TITLE
Fix/drag unconscious softlock

### DIFF
--- a/Tactical/PATHAI.cpp
+++ b/Tactical/PATHAI.cpp
@@ -1380,7 +1380,7 @@ INT16 AStarPathfinder::CalcAP(int const terrainCost, UINT8 const direction)
 	}
 
 	// Flugente: dragging someone
-	if ( pSoldier->IsDragging( false ) )
+	if ( pSoldier->IsDragging() )
 	{
 		movementAPCost *= gItemSettings.fDragAPCostModifier;
 	}

--- a/Tactical/Soldier Control.cpp
+++ b/Tactical/Soldier Control.cpp
@@ -9046,7 +9046,7 @@ void CalculateSoldierAniSpeed( SOLDIERTYPE *pSoldier, SOLDIERTYPE *pStatsSoldier
 	}
 
 	// Flugente: drag people
-	if ( pSoldier->IsDragging( false ) )
+	if ( pSoldier->IsDragging() )
 	{
 		pSoldier->sAniDelay = gItemSettings.fDragAPCostModifier * pSoldier->sAniDelay;
 	}
@@ -11516,7 +11516,7 @@ void SOLDIERTYPE::MoveMerc( FLOAT dMovementChange, FLOAT dAngle, BOOLEAN fCheckR
 
 	// Flugente: as we move a tile, we would now be too far away to drag someone.
 	// So remember whether we were dragging (we have to set our position now, otherwise the person we drag woul soon occupy our gridno).
-	BOOLEAN currentlydragging = this->IsDragging();
+	BOOLEAN currentlydragging = this->IsDragging(true);
 	INT32 sOldGridNo = this->sGridNo;
 
 	// OK, set new position
@@ -24226,7 +24226,7 @@ BOOLEAN SOLDIERTYPE::CanBreakWindow(void)
 
 BOOLEAN SOLDIERTYPE::CanStartDrag(void)
 {
-	if (!this->IsDragging(false) && this->CanDragInPrinciple())
+	if (!this->IsDragging() && this->CanDragInPrinciple())
 	{
 		INT32 sNewGridNo = NewGridNo(this->sGridNo, DirectionInc(this->ubDirection));
 

--- a/Tactical/Soldier Control.h
+++ b/Tactical/Soldier Control.h
@@ -2056,7 +2056,7 @@ public:
 	BOOLEAN		CanDragPerson(SoldierID usID, BOOLEAN fCheckStance = FALSE);
 	BOOLEAN		CanDragCorpse(UINT16 usCorpseNum, BOOLEAN fCheckStance = FALSE);
 	BOOLEAN		CanDragStructure(INT32 sGridNo, BOOLEAN fCheckStance = FALSE);
-	BOOLEAN		IsDragging(bool aStopIfConditionNotSatisfied = true);
+	BOOLEAN		IsDragging(bool aStopIfConditionNotSatisfied = false);
 	void		SetDragOrderPerson( SoldierID usID );
 	void		SetDragOrderCorpse( UINT32 uiCorpseID );
 	void		SetDragOrderStructure( INT32 sGridNo );

--- a/Tactical/Turn Based Input.cpp
+++ b/Tactical/Turn Based Input.cpp
@@ -2221,7 +2221,7 @@ void GetKeyboardInput( UINT32 *puiNewEvent )
 			// sevenfm: also stop dragging
 			if (gusSelectedSoldier != NOBODY &&
 				gusSelectedSoldier &&
-				gusSelectedSoldier->IsDragging(false))
+				gusSelectedSoldier->IsDragging())
 			{
 				gusSelectedSoldier->CancelDrag();
 				DirtyMercPanelInterface(gusSelectedSoldier, DIRTYLEVEL2);


### PR DESCRIPTION
Same logic but cleaned up version of https://github.com/1dot13/source/pull/602 which @tais contributed with Claude Code's help

Most calls to `SOLDIERTYPE::IsDragging()` aren't supposed to have a side effect of cancelling a drag, being simple queries. Changing the default to reflect that is right move.

Assisted-by: Claude: