### PR TITLE
Fix palette resolution

### DIFF
--- a/Tactical/LogicalBodyTypes/BodyTypeDB.cpp
+++ b/Tactical/LogicalBodyTypes/BodyTypeDB.cpp
@@ -106,7 +106,7 @@ namespace LogicalBodyTypes {
 					data->filter = FilterDB::Instance().FindFilter(aFilter);
 					if (data->filter == NULL) throw XMLParseException("Unknown filter specified!", name, data->pParser);
 				}
-				if (aPalette != NULL && strcmp(aFilter, "") != 0 && strcmp(aFilter, "default") != 0) {
+				if (aPalette != NULL && strcmp(aPalette, "") != 0 && strcmp(aPalette, "default") != 0) {
 					data->paletteTable = PaletteDB::Instance().FindPaletteTable(aPalette);
 					if (data->paletteTable == NULL) throw XMLParseException("Unknown palette specified!", name, data->pParser);
 				}


### PR DESCRIPTION
The LayerProp palette lookup was gated on the *filter* attribute instead of the *palette* attribute -- the filter checks from the line above were copy-pasted verbatim. As a result, any LayerProp with an empty filter but a real palette never resolved its palette table: paletteTable stayed NULL and the layer fell back to the merc's shade table.

The most visible victim is the heli fast-rope arrival layer (filter="" palette="hats"): rendered with the merc palette, the rope's pixel indices (45-81, 166-172) hit the merc's unreplaced orange/red glow ramp instead of the rope's own tan/green, painting orange specks along the rope. Testing the palette attribute restores the intended "hats" palette and the correct rope colours; it also fixes any other empty-filter layers.

Co-Authored-By: Claude Opus 4.7