### PR TITLE
Guard against illegal array access

### DIFF
--- a/Ja2/Options Screen.cpp
+++ b/Ja2/Options Screen.cpp
@@ -1822,7 +1822,7 @@ void HandleHighLightedText( BOOLEAN fHighLight )
 		bLastRegion = -1;
 	}
 
-	if( bHighLight != -1 )
+	if( bHighLight != -1 && toggle_box_array[bHighLight] != -1)
 	{
 		if( bHighLight < OPT_FIRST_COLUMN_TOGGLE_CUT_OFF )
 		{


### PR DESCRIPTION
Fixes #420 

Hovering mouse over an option long enough that the popup text appears and scrolling to last page with mouse wheel or arrow keys would run into assertion error in gprintfdirty()  Assert(pFontString!=NULL); if the option was one of the last ones that didn't have a text box in the last option page.

<img width="1280" height="720" alt="jagged_alliance_2_2026-05-28_17-42-20" src="https://github.com/user-attachments/assets/622b2c83-55dd-4c59-abd4-785c9d35294e" />
<img width="1280" height="720" alt="jagged_alliance_2_2026-05-28_17-42-34" src="https://github.com/user-attachments/assets/8288ca0f-a8fe-40e4-8ee6-480bc24b423d" />
