### PR TITLE
Revert PR544

### DIFF
--- a/Tactical/Rotting Corpses.cpp
+++ b/Tactical/Rotting Corpses.cpp
@@ -1112,7 +1112,8 @@ BOOLEAN TurnSoldierIntoCorpse( SOLDIERTYPE *pSoldier, BOOLEAN fRemoveMerc, BOOLE
 	iCorpseID = AddRottingCorpse( &Corpse );
 
 	// If this is our guy......make visible...
-	if ( iCorpseID != -1 && pSoldier->bTeam == OUR_TEAM || gbPublicOpplist[OUR_TEAM][pSoldier->ubID] == SEEN_CURRENTLY )
+	//if ( pSoldier->bTeam == gbPlayerNum )
+	if ( iCorpseID != -1 )
 	{
 		MakeCorpseVisible( pSoldier, &( gRottingCorpse[ iCorpseID ] ) );
 	}
@@ -2538,9 +2539,6 @@ void LookForAndMayCommentOnSeeingCorpse( SOLDIERTYPE *pSoldier, INT32 sGridNo, U
 	{
 		return;
 	}
-
-	if (pCorpse->fActivated && pCorpse->def.bVisible != 1)
-		pCorpse->def.bVisible = 1;
 
 	if ( pCorpse->def.ubType != ROTTING_STAGE2 )
 	{


### PR DESCRIPTION
"Corpses are not properly shown even if within mercs' vision due to the check only running intermittently since we're not constantly running the reveal roofs and items function. In addition, mercs such as Raven who have the quoteexpheadshotonly set to true, will NEVER reveal any corpses"

Revert "Remove extra line"

This reverts commit 1e1eb8886416f73b5ae868463de85b416109ce9b.

Revert "Move visibility check after already included pCorpse check"

This reverts commit 72e586a37897a729620de84ccc18efd21bb79551.

Revert "Make 3rd party corpses invisible till they in fov"

This reverts commit 07dbf9c848aeae6fbffc5e6e12369a9780148c71.