### PR TITLE
Fix: mapscreen drop-all hotkey strips robot's armour/components

### DIFF
--- a/Strategic/mapscreen.cpp
+++ b/Strategic/mapscreen.cpp
@@ -8472,6 +8472,12 @@ void GetMapKeyboardInput( UINT32 *puiNewEvent )
 											if ( HandleNailsVestFetish( pSoldier, i, NOTHING ) )
 												continue;
 
+											// tais: never strip Madlab's robot of its installed components (ammo,
+											// targeting, chassis/armour, utility) - the player can't re-install them
+											// and the robot would be left defenceless. Only its cargo slot may be emptied.
+											if ( AM_A_ROBOT( pSoldier ) && i != ROBOT_INVENTORY_SLOT )
+												continue;
+
 											AutoPlaceObjectInInventoryStash(&pSoldier->inv[i], pSoldier->sGridNo, pSoldier->pathing.bLevel);
 											DeleteObj(&pSoldier->inv[i]);
 										}


### PR DESCRIPTION
## Problem

A user reported that using the mapscreen "drop everything" hotkey (**Shift+W**) on Madlab's robot empties its **armour** along with the rest of its inventory. Because the player can't re-install the robot's components through normal inventory (only Madlab can), the robot is left permanently defenceless.

## Cause

The drop-all loop in `GetMapKeyboardInput()` (`Strategic/mapscreen.cpp`, the `case 'W'` handler) iterates **every** slot from `HELMETPOS` to `NUM_INV_SLOTS` and dumps each one to the ground:

```cpp
for ( int i = HELMETPOS; i<NUM_INV_SLOTS; ++i ) { ... AutoPlaceObjectInInventoryStash(...); DeleteObj(...); }
```

The robot keeps its installed gear in those same slots: `ROBOT_AMMO_SLOT` (14), `ROBOT_TARGETING_SLOT` (15), `ROBOT_CHASSIS_SLOT` (16, the armour) and `ROBOT_UTILITY_SLOT` (17), plus `ROBOT_INVENTORY_SLOT` (18) for general cargo. The loop stripped all of them.

## Fix

Skip the robot's installed-component slots in the drop loop. Only its general cargo slot (`ROBOT_INVENTORY_SLOT`) may still be emptied:

```cpp
if ( AM_A_ROBOT( pSoldier ) && i != ROBOT_INVENTORY_SLOT )
    continue;
```

Regular mercs are unaffected. `AM_A_ROBOT` and `ROBOT_INVENTORY_SLOT` are both already used in this translation unit, so no new includes are needed.

> Note: the hotkey is **Shift+W** (Shift takes precedence in the key-translation table, and the handler ignores Ctrl), so the fix covers every modifier combination that actually reaches the drop loop. Not yet tested in-game - needs a Windows build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)