### PR TITLE
Load sector heightdata and use it when placing items and corpses into an unloaded sector

### DIFF
--- a/Strategic/Auto Resolve.cpp
+++ b/Strategic/Auto Resolve.cpp
@@ -2481,6 +2481,12 @@ DebugMsg (TOPIC_JA2,DBG_LEVEL_3,"Autoresolve2");
 	DeleteVideoObjectFromIndex( gpAR->iIndent );
 	DeleteVideoSurfaceFromIndex( gpAR->iInterfaceBuffer );
 
+	// Load necessary mapinfo to place corpses
+	CHAR8 bFilename[50];
+	INT32 worldRows, worldCols;
+	GetMapFileName(gpAR->ubSectorX, gpAR->ubSectorY, 0, bFilename, TRUE, TRUE);
+	LoadWorldInfoForAutoResolve(bFilename, worldRows, worldCols);
+
 	if( fDeleteForGood )
 	{ //Delete the soldier instances -- done when we are completely finished.
 
@@ -2519,7 +2525,7 @@ DebugMsg (TOPIC_JA2,DBG_LEVEL_3,"Autoresolve2");
 					RemoveCharacterFromSquads( gpMercs[ i ].pSoldier );
 					ChangeSoldiersAssignment( gpMercs[ i ].pSoldier, ASSIGNMENT_DEAD );
 
-					AddDeadSoldierToUnLoadedSector( gpAR->ubSectorX, gpAR->ubSectorY, 0, gpMercs[ i ].pSoldier, RandomGridNo(), ADD_DEAD_SOLDIER_TO_SWEETSPOT );
+					AddDeadSoldierToUnLoadedSector( gpAR->ubSectorX, gpAR->ubSectorY, 0, gpMercs[ i ].pSoldier, RandomGridNoUnloadedSector(worldRows, worldCols), ADD_DEAD_SOLDIER_TO_SWEETSPOT );
 				}
 				else if( gpAR->ubBattleStatus == BATTLE_SURRENDERED || gpAR->ubBattleStatus == BATTLE_CAPTURED )
 				{
@@ -2624,7 +2630,8 @@ DebugMsg (TOPIC_JA2,DBG_LEVEL_3,"Autoresolve2");
 			}
 
 			// Flugente: drop sector equipment
-			gpCivs[ i ].pSoldier->DropSectorEquipment();
+			const auto gridno = RandomGridNoUnloadedSector(worldRows, worldCols);
+			gpCivs[ i ].pSoldier->DropSectorEquipment(gridno);
 
 			if( fDeleteForGood && gpCivs[ i ].pSoldier->stats.bLife < OKLIFE/2 )
 			{
@@ -2649,7 +2656,7 @@ DebugMsg (TOPIC_JA2,DBG_LEVEL_3,"Autoresolve2");
 					UpdateMilitia( militia );
 				}
 
-				AddDeadSoldierToUnLoadedSector( gpAR->ubSectorX, gpAR->ubSectorY, 0, gpCivs[ i ].pSoldier, RandomGridNo(), ADD_DEAD_SOLDIER_TO_SWEETSPOT );
+				AddDeadSoldierToUnLoadedSector( gpAR->ubSectorX, gpAR->ubSectorY, 0, gpCivs[ i ].pSoldier, gridno, ADD_DEAD_SOLDIER_TO_SWEETSPOT );
 				StrategicRemoveMilitiaFromSector( gpCivs[ i ].pSoldier->sSectorX, gpCivs[ i ].pSoldier->sSectorY, ubCurrentRank, 1 );
 
 				if( ProcessLoyalty() )
@@ -2681,7 +2688,8 @@ DebugMsg (TOPIC_JA2,DBG_LEVEL_3,"Autoresolve2");
 				TrackEnemiesKilled( ENEMY_KILLED_IN_AUTO_RESOLVE, gpEnemies[ i ].pSoldier->ubSoldierClass );	//add casualty to some statistic
 				if( ProcessLoyalty() )HandleGlobalLoyaltyEvent( GLOBAL_LOYALTY_ENEMY_KILLED, gpAR->ubSectorX, gpAR->ubSectorY, 0 );
 				ProcessQueenCmdImplicationsOfDeath( gpEnemies[ i ].pSoldier );
-				AddDeadSoldierToUnLoadedSector( gpAR->ubSectorX, gpAR->ubSectorY, 0, gpEnemies[ i ].pSoldier, RandomGridNo(), ADD_DEAD_SOLDIER_TO_SWEETSPOT );
+				const auto gridno = RandomGridNoUnloadedSector(worldRows, worldCols);
+				AddDeadSoldierToUnLoadedSector( gpAR->ubSectorX, gpAR->ubSectorY, 0, gpEnemies[ i ].pSoldier, gridno, ADD_DEAD_SOLDIER_TO_SWEETSPOT);
 			}
 		}
 	}
@@ -6007,7 +6015,7 @@ void AutoResolveMilitiaDropAndPromote()
 			}
 
 			// Flugente: drop sector equipment
-			gpCivs[i].pSoldier->DropSectorEquipment( );
+			gpCivs[i].pSoldier->DropSectorEquipment( NOWHERE );
 						
 			if ( gpCivs[i].pSoldier->stats.bLife < OKLIFE / 2 )
 			{

--- a/Tactical/Map Information.cpp
+++ b/Tactical/Map Information.cpp
@@ -20,6 +20,7 @@ FLOAT gdMajorMapVersion = MAJOR_MAP_VERSION;
 BOOLEAN gfWorldLoaded;
 
 MAPCREATE_STRUCT gMapInformation;
+MAPCREATE_STRUCT gMapInformationAutoResolve;
 
 //CHRISL: MINOR_MAP_VERSION information moved to worlddef.h by ADB.  We're using these values elsewhere and need them
 //	in the header file

--- a/Tactical/Map Information.h
+++ b/Tactical/Map Information.h
@@ -57,6 +57,7 @@ public:
 };
 
 extern MAPCREATE_STRUCT gMapInformation;
+extern MAPCREATE_STRUCT gMapInformationAutoResolve;
 
 void LoadMapInformation(INT8** hBuffer, FLOAT dMajorMapVersion);
 void SaveMapInformation(HWFILE hFile, FLOAT dMajorMapVersion, UINT8 ubMinorMapVersion);

--- a/Tactical/Overhead.cpp
+++ b/Tactical/Overhead.cpp
@@ -11403,7 +11403,7 @@ void TeamDropAll(UINT8 bTeam, BOOLEAN fForce)
         // if soldier is in the current sector, drop all equipment (that has the TAKEN_BY_MILITIA-flag set)
         if( pSoldier->bActive && ( pSoldier->sSectorX == gWorldSectorX ) && ( pSoldier->sSectorY == gWorldSectorY ) && ( pSoldier->bSectorZ == gbWorldSectorZ) )
         {
-            pSoldier->DropSectorEquipment();
+            pSoldier->DropSectorEquipment( NOWHERE );
         }
     }
 }

--- a/Tactical/Rotting Corpses.cpp
+++ b/Tactical/Rotting Corpses.cpp
@@ -1066,7 +1066,7 @@ BOOLEAN TurnSoldierIntoCorpse( SOLDIERTYPE *pSoldier, BOOLEAN fRemoveMerc, BOOLE
 		DropKeysInKeyRing( pSoldier, pSoldier->sGridNo, pSoldier->pathing.bLevel, bVisible, FALSE, 0, FALSE );
 
 		// Flugente: even if we forbid militia from dropping their equipment, they will still drop what they took via sector inventory (this functions only drops what they took)
-		pSoldier->DropSectorEquipment();
+		pSoldier->DropSectorEquipment( NOWHERE );
 	}
 
 	// Make team look for items

--- a/Tactical/Soldier Control.cpp
+++ b/Tactical/Soldier Control.cpp
@@ -16818,7 +16818,7 @@ BOOLEAN	SOLDIERTYPE::UpdateMultiTurnAction( )
 	return TRUE;
 }
 
-void	SOLDIERTYPE::DropSectorEquipment( )
+void	 SOLDIERTYPE::DropSectorEquipment( INT32 UnloadedSectorGridNo)
 {
 	// not if we already dropped the gear
 	if ( this->usSoldierFlagMask & SOLDIER_EQUIPMENT_DROPPED )
@@ -16887,7 +16887,7 @@ void	SOLDIERTYPE::DropSectorEquipment( )
 			}
 		}
 
-		AddItemsToUnLoadedSector( this->sSectorX, this->sSectorY, this->bSectorZ, RandomGridNo( ), counter, pObject, 0, WORLD_ITEM_REACHABLE, 0, 1, FALSE );
+		AddItemsToUnLoadedSector( this->sSectorX, this->sSectorY, this->bSectorZ, UnloadedSectorGridNo, counter, pObject, 0, WORLD_ITEM_REACHABLE, 0, 1, FALSE );
 	}
 }
 

--- a/Tactical/Soldier Control.h
+++ b/Tactical/Soldier Control.h
@@ -1916,7 +1916,7 @@ public:
 	void		CancelMultiTurnAction(BOOLEAN fFinished);
 	BOOLEAN		UpdateMultiTurnAction();
 
-	void		DropSectorEquipment();
+	void		DropSectorEquipment( INT32 UnloadedSectorGridNo);
 
 	// sevenfm: Take new bomb with id = usItem from iventory to HANDPOS
 	void 		TakeNewBombFromInventory(UINT16 usItem);

--- a/TileEngine/Isometric Utils.cpp
+++ b/TileEngine/Isometric Utils.cpp
@@ -1319,7 +1319,7 @@ BOOLEAN FindFenceJumpDirection( SOLDIERTYPE *pSoldier, INT32 sGridNo, INT8 bStar
 	return( FALSE );
 }
 
-//Simply chooses a random gridno within valid boundaries (for dropping things in unloaded sectors)
+//Simply chooses a random gridno within valid boundaries (for dropping things in loaded sectors)
 INT32 RandomGridNo()
 {
 	INT32 iMapXPos, iMapYPos, iMapIndex;
@@ -1329,6 +1329,69 @@ INT32 RandomGridNo()
 		iMapYPos = Random( WORLD_ROWS );
 		iMapIndex = iMapYPos * WORLD_COLS + iMapXPos;
 	}while( !GridNoOnVisibleWorldTile( iMapIndex ) );
+	return iMapIndex;
+}
+
+
+static bool pointLeftOfEdge(INT32 xp, INT32 yp, INT32 x1, INT32 y1, INT32 x2, INT32 y2)
+{
+	//Test whether the point(xp, yp) lies on the left-hand side of the edge(x1, y1) - (x2, y2)
+	const auto D = (x2 - x1) * (yp - y1) - (xp - x1) * (y2 - y1);
+	return (D > 0);
+}
+
+INT32 RandomGridNoUnloadedSector(INT32 worldRows, INT32 worldCols)
+{
+	INT32 iMapIndex;
+	const auto centerHeight = gpWorldLevelDataAutoResolve[gMapInformationAutoResolve.sCenterGridNo].sHeight;
+
+	const auto CenterWorldX = (WORLD_ROWS) / 2 * CELL_X_SIZE;
+	const auto CenterWorldY = (WORLD_COLS) / 2 * CELL_Y_SIZE;
+
+	// Sector corners are shifted inwards a bit to limit the area to be slightly smaller than actual sector.
+	// It fixed a few annyoing edge cases where a tile would evaluate to being inside the map, but it was juuust out of reach in actual gameplay
+	const auto TLX = 2*CELL_X_SIZE; // Shift X-coordinate by one tile inwards from actual edge.
+	const auto TLY = (WORLD_ROWS / 2) * CELL_X_SIZE;
+
+	const auto TRX = (WORLD_COLS / 2) * CELL_Y_SIZE;
+	const auto TRY = 2*CELL_X_SIZE; // Shift Y-coordinate by one tile inwards from actual edge
+
+	const auto BLX = ((WORLD_COLS / 2) * CELL_Y_SIZE);
+	const auto BLY = ((WORLD_ROWS-1) * CELL_Y_SIZE); // Shift Y-coordinate by one row inwards from actual edge
+
+	const auto BRX = ((WORLD_COLS-1) * CELL_Y_SIZE); // Shift X-coordinate by one row inwards from actual edge
+	const auto BRY = ((WORLD_ROWS / 2) * CELL_X_SIZE);
+
+	UINT8 randomGridHeight = 255;
+	do
+	{
+		randomGridHeight = 255; // Reset height to be tested
+		INT32 iMapXPos = Random(worldCols);
+		INT32 iMapYPos = Random(worldRows);
+		iMapIndex = iMapYPos * worldCols + iMapXPos;
+
+		// Discard gridno that is not within map bounds.
+		// Check point against world area's edges. If any edge test fails, it means point is not inside.
+		// Edge traverals goes counterclockwise, Top Right -> Top Left -> Bottom Left -> Bottom Right -> Top Right
+		const auto pX = iMapXPos * CELL_X_SIZE;
+		const auto pY = iMapYPos * CELL_Y_SIZE;
+		
+		//TR->TL
+		if ( !pointLeftOfEdge(pX, pY, TLX, TLY, TRX, TRY) )
+			continue;
+		//TL->BL
+		if ( !pointLeftOfEdge(pX, pY, BLX, BLY, TLX, TLY) )
+			continue;
+		//BL->BR
+		if ( !pointLeftOfEdge(pX, pY, BRX, BRY, BLX, BLY) )
+			continue;
+		//BR->TR
+		if ( !pointLeftOfEdge(pX, pY, TRX, TRY, BRX, BRY) )
+			continue;
+
+		// Compare randomGridHeight with height of the center grid of the map, as long as the center of the map is on walkable height it will work properly
+		randomGridHeight = gpWorldLevelDataAutoResolve[iMapIndex].sHeight; 
+	} while ( !(randomGridHeight == centerHeight) ); 
 	return iMapIndex;
 }
 

--- a/TileEngine/Isometric Utils.h
+++ b/TileEngine/Isometric Utils.h
@@ -113,6 +113,7 @@ BOOLEAN FindFenceJumpDirection( SOLDIERTYPE *pSoldier, INT32 sGridNo, INT8 bStar
 
 //Simply chooses a random gridno within valid boundaries (for dropping things in unloaded sectors)
 INT32 RandomGridNo();
+INT32 RandomGridNoUnloadedSector(INT32 worldRows, INT32 worldCols);
 
 extern UINT32 guiForceRefreshMousePositionCalculation;
 

--- a/TileEngine/worlddef.cpp
+++ b/TileEngine/worlddef.cpp
@@ -138,7 +138,8 @@ void SaveMapLights( HWFILE hfile );
 void LoadMapLights( INT8 **hBuffer );
 
 // Global Variables
-MAP_ELEMENT			*gpWorldLevelData;
+MAP_ELEMENT* gpWorldLevelData;
+MAP_ELEMENT *gpWorldLevelDataAutoResolve;
 INT32						*gpDirtyData;
 UINT32					gSurfaceMemUsage;
 //UINT8						gubWorldMovementCosts[ WORLD_MAX ][MAXDIR][2];
@@ -3311,6 +3312,296 @@ BOOLEAN LoadWorld(const STR8 puiFilename, FLOAT* pMajorMapVersion, UINT8* pMinor
 	MemFree(bCounts);
 	return(TRUE);
 }
+
+// A stub LoadWorld function so we can read a sector's tile height values into gpWorldLevelDataAutoResolve[].sHeight and entrypoint gridnos into gMapInformationAutoResolve
+// They are needed when placing corpses and dropped items into a random gridno in an unloaded sector when we're finished with autoresolve battle.
+BOOLEAN LoadWorldInfoForAutoResolve(const STR8 puiFilename, INT32& iRowSize, INT32& iColSize)
+{
+	HWFILE hfile;
+	FLOAT dMajorMapVersion;
+	UINT8 ubMinorMapVersion;
+	UINT32 uiFlags;
+	UINT32 uiBytesRead;
+	UINT32 uiFileSize;
+	INT32 i, cnt, cnt2;
+	UINT8 ubType;
+	CHAR8 aFilename[2 * FILENAME_BUFLEN];
+	UINT8 ubCombine;
+	UINT8(*bCounts)[8] = NULL;
+	INT8* pBuffer;
+	INT8* pBufferHead;
+
+
+	// Append exension to filename!
+	if ( gfForceLoad )
+		sprintf(aFilename, "MAPS\\%s", gzForceLoadFile);
+	else
+		sprintf(aFilename, "MAPS\\%s", puiFilename);
+
+	// Open file
+	hfile = FileOpen(aFilename, FILE_ACCESS_READ);
+
+	if ( !hfile )
+	{
+#ifndef JA2EDITOR
+		SET_ERROR("Could not load map file %S", aFilename);
+#endif
+		return(FALSE);
+	}
+
+
+	// Get the file size and alloc one huge buffer for it. We will use this buffer to transfer all of the data from.
+	uiFileSize = FileGetSize(hfile);
+	pBuffer = (INT8*)MemAlloc(uiFileSize);
+	pBufferHead = pBuffer;
+	FileRead(hfile, pBuffer, uiFileSize, &uiBytesRead);
+	FileClose(hfile);
+
+
+	// Read JA2 Version ID
+	LOADDATA(&dMajorMapVersion, pBuffer, sizeof(FLOAT));
+	LOADDATA(&ubMinorMapVersion, pBuffer, sizeof(UINT8));
+
+	iRowSize = OLD_WORLD_ROWS;
+	iColSize = OLD_WORLD_COLS;
+	if ( dMajorMapVersion >= 7.00 )
+	{
+		LOADDATA(&iRowSize, pBuffer, sizeof(INT32));
+		LOADDATA(&iColSize, pBuffer, sizeof(INT32));
+	}
+
+	// Actual world size of the map we loaded!
+	INT32 iWorldSize = iRowSize * iColSize;
+	gMapTrn.ResizeTrnCfg(WORLD_ROWS, WORLD_COLS, iRowSize, iColSize);
+
+
+	// Initialize world data
+	if ( gpWorldLevelDataAutoResolve != NULL )
+		MemFree(gpWorldLevelDataAutoResolve);
+	gpWorldLevelDataAutoResolve = (MAP_ELEMENT*)MemAlloc(sizeof(MAP_ELEMENT) * WORLD_MAX);
+	memset(gpWorldLevelDataAutoResolve, 0, sizeof(MAP_ELEMENT) * WORLD_MAX);
+
+	bCounts = (UINT8(*)[8])MemAlloc(WORLD_MAX * 8);
+	memset(bCounts, 0, sizeof(UINT8) * WORLD_MAX * 8);
+
+
+	// Read FLAGS FOR WORLD
+	LOADDATA(&uiFlags, pBuffer, sizeof(INT32));
+	SKIPDATA(pBuffer, pBuffer, sizeof(INT32)); // TilesetID
+
+	// Load soldier size
+	SKIPDATA(pBuffer, pBuffer, sizeof(INT32));
+
+	// NOTE! We need this!
+	// Read height values
+	for ( i = 0; i < iWorldSize; i++ )
+	{
+		gMapTrn.GetTrnCnt(cnt = i);
+		LOADDATA(&gpWorldLevelDataAutoResolve[cnt].sHeight, pBuffer, sizeof(INT16));
+	}
+
+	// Read layer counts
+	for ( i = 0; i < iWorldSize; i++ )
+	{
+		gMapTrn.GetTrnCnt(cnt = i);
+		// Read combination of land/world flags
+		LOADDATA(&ubCombine, pBuffer, sizeof(UINT8));
+		// Split
+		bCounts[cnt][0] = (UINT8)(ubCombine & 0x0F);
+		gpWorldLevelDataAutoResolve[cnt].uiFlags |= (UINT8)((ubCombine & 0xF0) >> 4);
+		// Read #objects, structs
+		LOADDATA(&ubCombine, pBuffer, sizeof(UINT8));
+		// Split
+		bCounts[cnt][1] = (UINT8)(ubCombine & 0x0F);
+		bCounts[cnt][2] = (UINT8)((ubCombine & 0xF0) >> 4);
+		// Read shadows, roof
+		LOADDATA(&ubCombine, pBuffer, sizeof(UINT8));
+		// Split
+		bCounts[cnt][3] = (UINT8)(ubCombine & 0x0F);
+		bCounts[cnt][4] = (UINT8)((ubCombine & 0xF0) >> 4);
+		// Read OnRoof, nothing
+		LOADDATA(&ubCombine, pBuffer, sizeof(UINT8));
+		// Split
+		bCounts[cnt][5] = (UINT8)(ubCombine & 0x0F);
+	}
+
+	for ( i = 0; i < iWorldSize; i++ )
+	{
+		gMapTrn.GetTrnCnt(cnt = i);
+		for ( cnt2 = 0; cnt2 < bCounts[cnt][0]; cnt2++ )
+		{
+			SKIPDATA(pBuffer, pBuffer, sizeof(UINT8));
+			SKIPDATA(pBuffer, pBuffer, sizeof(UINT8));
+		}
+	}
+
+	// New load require UINT16 for the type subindex due to the fact that ROADPIECES contain over 300 type subindices.
+	for ( i = 0; i < iWorldSize; i++ )
+	{
+		gMapTrn.GetTrnCnt(cnt = i);
+		// Set objects
+		for ( cnt2 = 0; cnt2 < bCounts[cnt][1]; cnt2++ )
+		{
+			LOADDATA(&ubType, pBuffer, sizeof(UINT8));
+			SKIPDATA(pBuffer, pBuffer, sizeof(UINT16));
+
+			if ( ubType >= FIRSTPOINTERS )
+				continue;
+		}
+	}
+
+	for ( i = 0; i < iWorldSize; i++ )
+	{
+		gMapTrn.GetTrnCnt(cnt = i);
+		// Set structs
+		for ( cnt2 = 0; cnt2 < bCounts[cnt][2]; cnt2++ )
+		{
+			SKIPDATA(pBuffer, pBuffer, sizeof(UINT8));
+			SKIPDATA(pBuffer, pBuffer, sizeof(UINT8));
+		}
+	}
+
+	for ( i = 0; i < iWorldSize; i++ )
+	{
+		gMapTrn.GetTrnCnt(cnt = i);
+		for ( cnt2 = 0; cnt2 < bCounts[cnt][3]; cnt2++ )
+		{
+			SKIPDATA(pBuffer, pBuffer, sizeof(UINT8));
+			SKIPDATA(pBuffer, pBuffer, sizeof(UINT8));
+		}
+	}
+
+	for ( i = 0; i < iWorldSize; i++ )
+	{
+		gMapTrn.GetTrnCnt(cnt = i);
+		for ( cnt2 = 0; cnt2 < bCounts[cnt][4]; cnt2++ )
+		{
+			SKIPDATA(pBuffer, pBuffer, sizeof(UINT8));
+			SKIPDATA(pBuffer, pBuffer, sizeof(UINT8));
+		}
+	}
+
+	for ( i = 0; i < iWorldSize; i++ )
+	{
+		gMapTrn.GetTrnCnt(cnt = i);
+		for ( cnt2 = 0; cnt2 < bCounts[cnt][5]; cnt2++ )
+		{
+			SKIPDATA(pBuffer, pBuffer, sizeof(UINT8));
+			SKIPDATA(pBuffer, pBuffer, sizeof(UINT8));
+		}
+	}
+
+	// For old Russian Maps which have version 6.0
+	if ( dMajorMapVersion == 6.00 && ubMinorMapVersion < 27 )
+	{
+		UINT32 uiNums[37];
+		LOADDATA(uiNums, pBuffer, sizeof(INT32) * 37);
+		dMajorMapVersion = 5.00;
+	}
+	// For new maps
+	else if ( dMajorMapVersion == 6.00 && ubMinorMapVersion < 27 && MAJOR_MAP_VERSION == 6.00 )
+	{
+		UINT32 uiNums[37];
+		LOADDATA(uiNums, pBuffer, sizeof(UINT32) * 37);
+	}
+	//now the data is discarded and when saved, as 6.27, you won't have this problem!
+
+
+	for ( i = 0; i < iWorldSize; i++ ) {
+		// Read room information, 2 byte for new files
+		if ( ubMinorMapVersion < 29 ) {
+			SKIPDATA(pBuffer, pBuffer, sizeof(INT8));
+		}
+		else {
+			SKIPDATA(pBuffer, pBuffer, sizeof(UINT16));
+		}
+	}
+
+	// Load out item information
+	if ( uiFlags & MAP_WORLDITEMS_SAVED )
+	{
+		WORLDITEM dummyItem;
+		UINT32 uiNumWorldItems;
+
+		//Read the number of items that were saved in the map.
+		LOADDATA(&uiNumWorldItems, pBuffer, 4);
+
+		if ( gTacticalStatus.uiFlags & LOADING_SAVED_GAME && !gfEditMode )
+		{ //The sector has already been visited.	The items are saved in a different format that will be
+			//loaded later on.	So, all we need to do is skip the data entirely.
+			if ( dMajorMapVersion >= 6.0 && ubMinorMapVersion > 26 ) {
+				for ( unsigned int x = 0; x < uiNumWorldItems; ++x )
+				{
+					//ADB WORLDITEM's size on disk is unknown
+					dummyItem.Load(&pBuffer, dMajorMapVersion, ubMinorMapVersion);
+				}
+			}
+			else
+			{
+				pBuffer += sizeof(OLD_WORLDITEM_101) * uiNumWorldItems;
+			}
+		}
+		else for ( i = 0; i < uiNumWorldItems; i++ )
+		{
+			dummyItem.Load(&pBuffer, dMajorMapVersion, ubMinorMapVersion);
+		}
+	}
+
+	if ( uiFlags & MAP_AMBIENTLIGHTLEVEL_SAVED )
+	{
+		//Ambient light levels are only saved in underground levels
+		SKIPDATA(pBuffer, pBuffer, sizeof(BOOLEAN));
+		SKIPDATA(pBuffer, pBuffer, sizeof(BOOLEAN));
+		SKIPDATA(pBuffer, pBuffer, sizeof(UINT8));
+
+	}
+
+	if ( uiFlags & MAP_WORLDLIGHTS_SAVED )
+	{
+		SGPPaletteEntry	LColors[3];
+		UINT8 ubNumColors;
+		UINT16 usNumLights;
+		CHAR8	str[30];
+		UINT8 ubStrLen;
+		LIGHT_SPRITE	TmpLight;
+
+		// read in the light colors!
+		LOADDATA(&ubNumColors, pBuffer, 1);
+		LOADDATA(LColors, pBuffer, sizeof(SGPPaletteEntry) * ubNumColors);
+
+		LOADDATA(&usNumLights, pBuffer, 2);
+
+
+		for ( cnt = 0; cnt < usNumLights; cnt++ )
+		{
+			LOADDATA(&TmpLight, pBuffer, sizeof(LIGHT_SPRITE));
+			LOADDATA(&ubStrLen, pBuffer, 1);
+
+			if ( ubStrLen )
+			{
+				LOADDATA(str, pBuffer, ubStrLen);
+			}
+		}
+	}
+
+	gMapInformationAutoResolve.Load(&pBuffer, dMajorMapVersion);
+
+
+	// NOTE! We need these!
+	// Translation routine for map grid numbers
+	gMapTrn.GetTrnCnt(gMapInformationAutoResolve.sCenterGridNo);
+	gMapTrn.GetTrnCnt(gMapInformationAutoResolve.sIsolatedGridNo);
+	gMapTrn.GetTrnCnt(gMapInformationAutoResolve.sNorthGridNo);
+	gMapTrn.GetTrnCnt(gMapInformationAutoResolve.sEastGridNo);
+	gMapTrn.GetTrnCnt(gMapInformationAutoResolve.sWestGridNo);
+	gMapTrn.GetTrnCnt(gMapInformationAutoResolve.sSouthGridNo);
+
+	// Remove this rather large chunk of memory from the system now!
+	MemFree(pBufferHead);
+	MemFree(bCounts);
+	return(TRUE);
+}
+
 
 //****************************************************************************************
 //

--- a/TileEngine/worlddef.h
+++ b/TileEngine/worlddef.h
@@ -281,6 +281,7 @@ typedef struct
 
 // World Data
 extern MAP_ELEMENT			*gpWorldLevelData;
+extern MAP_ELEMENT* gpWorldLevelDataAutoResolve;
 extern UINT8 (*gubWorldMovementCosts)[MAXDIR][2];//dnl ch43 260909
 
 //dnl ch44 290909 Translation routine
@@ -339,6 +340,7 @@ BOOLEAN NewWorld( INT32 nMapRows,  INT32 nMapCols );
 
 BOOLEAN SaveWorld(const STR8 puiFilename, FLOAT dMajorMapVersion=MAJOR_MAP_VERSION, UINT8 ubMinorMapVersion=MINOR_MAP_VERSION);//dnl ch33 150909
 BOOLEAN LoadWorld(const STR8 puiFilename, FLOAT* pMajorMapVersion=NULL, UINT8* pMinorMapVersion=NULL);//dnl ch44 290909
+BOOLEAN LoadWorldInfoForAutoResolve(const STR8 puiFilename, INT32& iRowSize, INT32& iColSize);
 
 void CompileWorldMovementCosts(void);//dnl ch56 151009
 void RecompileLocalMovementCosts( INT32 sCentreGridNo );


### PR DESCRIPTION
Fixes #319 

Militia dropping used equipment and any corpses to be spawned after autoresolve were using function RandomGridNo() for determining a tile where they could be placed, but its checks would always return true for any gridno no matter what. That resulted in both items and corpses being spawned in unreachable locations such as cliffs.

We now load just enough of the sector's data to be able to properly determine whether a random gridno is valid or not.
