### PR TITLE
Set moved item old entry to not existing

### DIFF
--- a/Strategic/Map Screen Interface Map Inventory.cpp
+++ b/Strategic/Map Screen Interface Map Inventory.cpp
@@ -1133,8 +1133,12 @@ void SaveSeenAndUnseenItems( void )
 		if(pipl->fExists && pipl->object.ubNumberOfObjects)
 		{
 			uiTotalNumberOfVisibleItems += pipl->object.ubNumberOfObjects;
-			if(i > uiNumberOfSeenItems)
+			if (i > uiNumberOfSeenItems)
+			{
 				pInventoryPoolList[uiNumberOfSeenItems] = *pipl;
+				pipl->fExists = FALSE;
+			}
+
 			uiNumberOfSeenItems++;
 		}
 	}


### PR DESCRIPTION
Fixes item duplication bug that happened when placing an item to a different slot in unloaded sector. SaveSeenAndUnseenItems sorts seen and unseen items into pInventoryPoolList, but was not setting the moved item .fExists to false in its original slot effectively creating a copy of the item. If unseen items that were then added to pInventoryPoolList after the seen items were not long enough to overwrite all of the old entries for seen items, we would end up with duplicated items.