### PR TITLE
Fix Rebel Command capping town loyalty at 0%

### DIFF
--- a/Strategic/Rebel Command.cpp
+++ b/Strategic/Rebel Command.cpp
@@ -3389,7 +3389,12 @@ FLOAT GetLoyaltyGainModifier()
 UINT8 GetMaxTownLoyalty(INT8 townId)
 {
 	if (gGameExternalOptions.fRebelCommandEnabled)
-		return rebelCommandSaveInfo.regions[townId].ubMaxLoyalty;
+	{
+		// A cap of 0 means this region was never seeded (see SeedRegionMaxLoyalty). Treat it as
+		// "no cap" rather than pinning town loyalty to 0% - legitimate caps are always >= 20.
+		const UINT8 ubMaxLoyalty = rebelCommandSaveInfo.regions[townId].ubMaxLoyalty;
+		return ubMaxLoyalty != 0 ? ubMaxLoyalty : MAX_LOYALTY_VALUE;
+	}
 
 	return MAX_LOYALTY_VALUE;
 }
@@ -3970,32 +3975,51 @@ void HourlyUpdate()
 	}
 }
 
+// Difficulty-based starting loyalty cap for a non-HQ town. The underlying settings are clamped
+// to [20,100] at load time (see LoadRebelCommandSettings), so this is never 0.
+INT8 GetStartingMaxLoyalty()
+{
+	switch (gGameOptions.ubDifficultyLevel)
+	{
+	case DIF_LEVEL_EASY:   return gRebelCommandSettings.iMaxLoyaltyNovice;
+	case DIF_LEVEL_HARD:   return gRebelCommandSettings.iMaxLoyaltyExpert;
+	case DIF_LEVEL_INSANE: return gRebelCommandSettings.iMaxLoyaltyInsane;
+	case DIF_LEVEL_MEDIUM:
+	default:               return gRebelCommandSettings.iMaxLoyaltyExperienced;
+	}
+}
+
+// Seeds every region's loyalty cap to its difficulty-based starting value (OMERTA = 100).
+// Idempotent: only writes regions still at the zero-init default, so it never clobbers an
+// in-progress ARC campaign (e.g. supply lines already bought) or a correctly loaded save. 0 is
+// never a legitimate cap (Init seeds >= 20, supply lines only add), so == 0 unambiguously means
+// "not yet seeded". Safe to call in any order (new game, load, feature toggled on); inert while
+// ARC is disabled because GetMaxTownLoyalty only consults these values when it is enabled.
+void SeedRegionMaxLoyalty()
+{
+	const INT8 startingMaxLoyalty = GetStartingMaxLoyalty();
+
+	for (int a = FIRST_TOWN; a < NUM_TOWNS; ++a)
+	{
+		if (rebelCommandSaveInfo.regions[a].ubMaxLoyalty != 0)
+			continue; // already seeded / progressed - leave it alone
+
+		rebelCommandSaveInfo.regions[a].ubMaxLoyalty = (a == OMERTA) ? MAX_LOYALTY_VALUE : startingMaxLoyalty;
+	}
+}
+
 void Init()
 {
+	// Seed the loyalty caps unconditionally - even when ARC is currently disabled - so a later
+	// FALSE->TRUE feature-flag flip (Features screen, save reload, MP) can never read a stale 0
+	// cap that would pin town loyalty to 0%. This is the root-cause fix: Init() used to run
+	// before the feature flag was set and bail out here, leaving the caps at their zero default.
+	SeedRegionMaxLoyalty();
+
 	if (!gGameExternalOptions.fRebelCommandEnabled)
 		return;
 
-	INT8 startingMaxLoyalty;
-
-	switch (gGameOptions.ubDifficultyLevel)
-	{
-	case DIF_LEVEL_EASY:
-		startingMaxLoyalty = gRebelCommandSettings.iMaxLoyaltyNovice;
-		break;
-
-	case DIF_LEVEL_HARD:
-		startingMaxLoyalty = gRebelCommandSettings.iMaxLoyaltyExpert;
-		break;
-
-	case DIF_LEVEL_INSANE:
-		startingMaxLoyalty = gRebelCommandSettings.iMaxLoyaltyInsane;
-		break;
-
-	case DIF_LEVEL_MEDIUM:
-	default:
-		startingMaxLoyalty = gRebelCommandSettings.iMaxLoyaltyExperienced;
-		break;
-	}
+	const INT8 startingMaxLoyalty = GetStartingMaxLoyalty();
 
 	// set base values
 	iIncomingSuppliesPerDay = static_cast<INT32>(CurrentPlayerProgressPercentage() * gRebelCommandSettings.fIncomeModifier);
@@ -4036,18 +4060,16 @@ void Init()
 	// init regions
 	for (int a = FIRST_TOWN; a < NUM_TOWNS; ++a)
 	{
-		// init max loyalty
+		// max loyalty caps are seeded by SeedRegionMaxLoyalty() above
 		if (a == OMERTA)
 		{
-			// as rebel hq, omerta gets 100% max loyalty and an admin team
+			// as rebel hq, omerta gets an admin team
 			rebelCommandSaveInfo.regions[OMERTA].adminStatus = RAS_ACTIVE;
-			rebelCommandSaveInfo.regions[OMERTA].ubMaxLoyalty = MAX_LOYALTY_VALUE;
 		}
 		else
 		{
 			// init admins
 			rebelCommandSaveInfo.regions[a].adminStatus = RAS_NONE;
-			rebelCommandSaveInfo.regions[a].ubMaxLoyalty = startingMaxLoyalty;
 			gTownLoyalty[a].ubRating = min(gTownLoyalty[a].ubRating, startingMaxLoyalty);
 		}
 
@@ -4091,6 +4113,10 @@ BOOLEAN Load(HWFILE file)
 		UINT32 numBytesRead = 0;
 
 		numBytesRead = FileRead(file, &rebelCommandSaveInfo, sizeof(RebelCommand::SaveInfo), &numBytesRead);
+
+		// Saves made with ARC disabled (or a short/old read) leave region caps at the zero-init
+		// default; seed any still at 0 so loyalty isn't pinned to 0% once ARC is enabled.
+		SeedRegionMaxLoyalty();
 
 		SetupInfo();
 	}


### PR DESCRIPTION
## Problem

With **Arulco Rebel Command (ARC)** enabled, town loyalty can get stuck at **0%** — e.g. taking Drassen with no civilian casualties never raises loyalty, and players have reported a "sudden drop to 0%" mid-game.

## Root cause

ARC stores a per-region loyalty cap in `RegionSaveInfo::ubMaxLoyalty`. The backing global `rebelCommandSaveInfo` is a zero-initialised POD with no member initialiser, so every region's cap starts at **0**. The only code that seeds those caps to sane values (>= 20, OMERTA 100) is `RebelCommand::Init()`, which **early-returns while `gGameExternalOptions.fRebelCommandEnabled` is FALSE** (`Rebel Command.cpp:3975`) and only runs at new-game time (`Game Init.cpp:818`).

That feature flag is set **independently and later** in `UpdateFeatureFlags` (`GameSettings.cpp:247`, gated by `FF_FEATURES_SCREEN`). So whenever ARC is turned on *after* `Init()` ran with the flag FALSE — enabling it via the Features screen mid-game, loading a save whose regions are still 0, or in multiplayer where the flag is never synced — the caps stay 0, `GetMaxTownLoyalty()` returns 0, and `UpdateTownLoyaltyRating()` (`Strategic Town Loyalty.cpp:393,399`) pins town loyalty to `min(…, 0) = 0%`. (Omerta is unaffected — it's hard-set to 100.)

## Fix

Extract an **idempotent** `SeedRegionMaxLoyalty()` that seeds each region to its difficulty-based starting cap (OMERTA → 100), writing only regions still at the zero-init sentinel — so it never clobbers an in-progress campaign (e.g. supply lines already bought, which only *add* to the cap):

- `Init()` calls it **unconditionally, before the feature-flag guard** — regions are seeded every new game regardless of when the flag is set.
- `Load()` calls it **after reading the save** — repairs saves made with ARC off (or short/old reads).
- `GetMaxTownLoyalty()` treats a `0` cap as **"no cap"** as a final safety net (legitimate caps are always >= 20, so 0 is an unambiguous "never seeded" marker).

This makes ARC behave **as designed** (towns capped at `startingMaxLoyalty`, raised by supply lines) rather than merely masking the 0 — important because the additive supply-line math would otherwise turn a stale `0 += increase` into a wrong low cap, and the UI/maxed-label readers would show 0%.

## Edge cases covered

Fresh new game (ARC on/off); **mid-game enable** via Features screen; **save made while caps were 0 then reloaded**; **multiplayer** per-side enable; ARC fully disabled (unchanged vanilla path); OMERTA forced to 100; correct interaction with the additive supply-line purchase and the new-game `gTownLoyalty` clamp (kept new-game-only). **Save format and `sizeof(SaveInfo)` are unchanged**, so saves remain compatible.

Single file (`Strategic/Rebel Command.cpp`, +50/−24). Windows/MSVC project — verified by source inspection.