### PR TITLE
Fix dialogue approach score UINT8 overflow under high Leadership

### DIFF
--- a/TacticalAI/NPC.cpp
+++ b/TacticalAI/NPC.cpp
@@ -946,6 +946,10 @@ UINT8 CalcDesireToTalk( UINT8 ubNPC, UINT8 ubMerc, INT8 bApproach )
 	{
 		iWillingness = 0;
 	}
+	else if (iWillingness > 255)
+	{
+		iWillingness = 255;
+	}
 
 	return( (UINT8) iWillingness );
 }


### PR DESCRIPTION
Under high Leadership (LDR) values and high loyalty, CalcDesireToTalk can return a value greater than 255. Casting it directly to (UINT8) wraps the value to a tiny number, causing recruitment of NPCs like Vince to fail. Capping the score at 255 before casting resolves the issue (fixes #506).