### PR TITLE
Fix assertion failure crash when stacking different item types

### DIFF
--- a/Tactical/Item Types.cpp
+++ b/Tactical/Item Types.cpp
@@ -648,6 +648,10 @@ bool OBJECTTYPE::CanStack(OBJECTTYPE& sourceObject, int& numToStack)
 	//stacking control, restrict certain things here
 	if (numToStack > 0) {
 		if (exists() == true) {
+			if (sourceObject.usItem != usItem) {
+				return false;
+			}
+
 			if (Item[usItem].usItemClass == IC_MONEY) {
 				//money doesn't stack, it merges
 				// average out the status values using a weighted average...


### PR DESCRIPTION
When OBJECTTYPE::CanStack is called, it does not check if the item types are the same, falling through and returning true. This results in OBJECTTYPE::ForceAddObjectsToStack triggering an assertion crash when attempting to stack different items. Checking usItem mismatch in CanStack prevents this crash (fixes #502).