### PR TITLE
Apply aim and accuracy modifiers from equipped armor and face items

### DIFF
--- a/Tactical/Items.cpp
+++ b/Tactical/Items.cpp
@@ -10792,6 +10792,20 @@ INT32 GetObjectModifier( SOLDIERTYPE* pSoldier, OBJECTTYPE *pObj, UINT8 ubStance
 						iModifier += GetItemModifier(ObjList[pSoldier->bScopeMode], ubRef, usType);
 			}
 		}
+
+		if ( pSoldier != NULL && (pObj == &pSoldier->inv[HANDPOS] || pObj == &pSoldier->inv[SECONDHANDPOS]) )
+		{
+			for (INT8 bLoop = HELMETPOS; bLoop <= HEAD2POS; ++bLoop)
+			{
+				if (bLoop == HANDPOS || bLoop == SECONDHANDPOS)
+					continue;
+
+				if (pSoldier->inv[bLoop].exists())
+				{
+					iModifier += GetItemModifier(&(pSoldier->inv[bLoop]), ubRef, usType);
+				}
+			}
+		}
 	}
 
 	iModifier = __max(-100,iModifier);


### PR DESCRIPTION
GetObjectModifier previously only aggregated modifiers from the weapon in hand and its attachments, completely ignoring equipped armor (helmet, vest, leg armor) and face items (e.g., gas masks, NVGs). This resulted in XML aim/accuracy penalties on these items being ignored. Scanning slots HELMETPOS through HEAD2POS (excluding hands) and adding their modifiers to active weapons fixes the issue (fixes #508).