### PR TITLE
Rename 'Logical Bodytypes' to 'Use New Merc Graphics' in options menu

### DIFF
--- a/Editor/XML_ActionItems.cpp
+++ b/Editor/XML_ActionItems.cpp
@@ -5,6 +5,7 @@
 	#include "Interface.h"
 	#include "Item Statistics.h"
 	#include "LuaInitNPCs.h"
+	#include "FileMan.h"
 
 #include "Action Items.h"
 

--- a/Tactical/Item Types.cpp
+++ b/Tactical/Item Types.cpp
@@ -648,6 +648,10 @@ bool OBJECTTYPE::CanStack(OBJECTTYPE& sourceObject, int& numToStack)
 	//stacking control, restrict certain things here
 	if (numToStack > 0) {
 		if (exists() == true) {
+			if (sourceObject.usItem != usItem) {
+				return false;
+			}
+
 			if (Item[usItem].usItemClass == IC_MONEY) {
 				//money doesn't stack, it merges
 				// average out the status values using a weighted average...

--- a/Tactical/Items.cpp
+++ b/Tactical/Items.cpp
@@ -10792,6 +10792,20 @@ INT32 GetObjectModifier( SOLDIERTYPE* pSoldier, OBJECTTYPE *pObj, UINT8 ubStance
 						iModifier += GetItemModifier(ObjList[pSoldier->bScopeMode], ubRef, usType);
 			}
 		}
+
+		if ( pSoldier != NULL && (pObj == &pSoldier->inv[HANDPOS] || pObj == &pSoldier->inv[SECONDHANDPOS]) )
+		{
+			for (INT8 bLoop = HELMETPOS; bLoop <= HEAD2POS; ++bLoop)
+			{
+				if (bLoop == HANDPOS || bLoop == SECONDHANDPOS)
+					continue;
+
+				if (pSoldier->inv[bLoop].exists())
+				{
+					iModifier += GetItemModifier(&(pSoldier->inv[bLoop]), ubRef, usType);
+				}
+			}
+		}
 	}
 
 	iModifier = __max(-100,iModifier);

--- a/Tactical/UI Cursors.cpp
+++ b/Tactical/UI Cursors.cpp
@@ -1326,7 +1326,7 @@ UINT8 HandleNonActivatedTargetCursor( SOLDIERTYPE *pSoldier, INT32 usMapPos , BO
 
 	}
 
-	if(gusUIFullTargetID == NOBODY && pSoldier->bDoAutofire && !pSoldier->flags.fDoSpread)	//reset autofire if we move the mouse off the target, however don't reset it if we are spread-bursting
+	if(!gfUIFullTargetFound && pSoldier->bDoAutofire && !pSoldier->flags.fDoSpread)	//reset autofire if we move the mouse off the target, however don't reset it if we are spread-bursting
 	{
 		if(gTacticalStatus.uiFlags & TURNBASED && (gTacticalStatus.uiFlags & INCOMBAT ))
 		{

--- a/TacticalAI/AIInternals.h
+++ b/TacticalAI/AIInternals.h
@@ -93,11 +93,13 @@ enum
 
 #define SEE_THRU_COVER_THRESHOLD		5		// min chance to get through
 
-#undef min
+#ifndef min
 #define min(a,b) ((a) < (b) ? (a) : (b))
+#endif
 
-#undef max
+#ifndef max
 #define max(a,b) ((a) > (b) ? (a) : (b))
+#endif
 
 // Added by feynman - remove all the ugly #ifdefs printf combinations for required for DebugAI
 //#define DEBUGAI

--- a/TacticalAI/NPC.cpp
+++ b/TacticalAI/NPC.cpp
@@ -946,6 +946,10 @@ UINT8 CalcDesireToTalk( UINT8 ubNPC, UINT8 ubMerc, INT8 bApproach )
 	{
 		iWillingness = 0;
 	}
+	else if (iWillingness > 255)
+	{
+		iWillingness = 255;
+	}
 
 	return( (UINT8) iWillingness );
 }

--- a/i18n/_ChineseText.cpp
+++ b/i18n/_ChineseText.cpp
@@ -6628,7 +6628,7 @@ STR16		zOptionsToggleText[] =
 	L"强制回合制模式",						// add forced turn mode
 	L"替代战略地图颜色", // Change color scheme of Strategic Map
 	L"替代子弹图像", // Show alternate bullet graphics (tracers)
-	L"佣兵外观造型", //L"Use Logical Bodytypes",
+	L"佣兵外观造型", //L"Use New Merc Graphics",
 	L"显示佣兵军衔",	// shows mercs ranks
 	L"显示脸部装备图",				
 	L"显示脸部装备图标",

--- a/i18n/_DutchText.cpp
+++ b/i18n/_DutchText.cpp
@@ -6630,7 +6630,7 @@ STR16		zOptionsToggleText[] =
 	L"Forced Turn Mode",					// add forced turn mode
 	L"Alternate Strategy-Map Colors",		// Change color scheme of Strategic Map
 	L"Alternate bullet graphics",			// Show alternate bullet graphics (tracers) // TODO.Translate
-	L"Logical Bodytypes",
+	L"Use New Merc Graphics",
 	L"Show Merc Ranks",						// shows mercs ranks		// TODO.Translate
 	L"Show Face gear graphics",				// TODO.Translate
 	L"Show Face gear icons",

--- a/i18n/_EnglishText.cpp
+++ b/i18n/_EnglishText.cpp
@@ -6628,7 +6628,7 @@ STR16		zOptionsToggleText[] =
 	L"Forced Turn Mode",					// add forced turn mode
 	L"Alternate Strategy Map Colors",		// Change color scheme of Strategic Map
 	L"Alternate Bullet Graphics",			// Show alternate bullet graphics (tracers)
-	L"Logical Bodytypes",
+	L"Use New Merc Graphics",
 	L"Show Merc Ranks",						// shows mercs ranks
 	L"Show Face Gear Graphics",
 	L"Show Face Gear Icons",

--- a/i18n/_FrenchText.cpp
+++ b/i18n/_FrenchText.cpp
@@ -6635,7 +6635,7 @@ STR16		zOptionsToggleText[] =
 	L"Mode tour par tour forcé",			// add forced turn mode
 	L"Couleur alternative carte",		// Change color scheme of Strategic Map
 	L"Montrer tirs alternatifs",			// Show alternate bullet graphics (tracers)
-	L"Logical Bodytypes",
+	L"Use New Merc Graphics",
 	L"Afficher grade du mercenaire",						// shows mercs ranks
 	L"Afficher équip. sur portrait",
 	L"Afficher icônes sur portrait",

--- a/i18n/_GermanText.cpp
+++ b/i18n/_GermanText.cpp
@@ -6502,7 +6502,7 @@ STR16 zOptionsToggleText[] =
 	L"Erzwungener Runden-Modus",			// add forced turn mode
 	L"Alternatives Kartenfarbschema",		// Change color scheme of Strategic Map
 	L"Alternative Projektil-Grafik",			// Show alternate bullet graphics (tracers)
-	L"Logical Bodytypes",
+	L"Use New Merc Graphics",
 	L"Söldnerrang anzeigen.",					// shows mercs ranks
 	L"Gesichtsequipment-Grafiken",			
 	L"Gesichtsequipment-Icons",

--- a/i18n/_ItalianText.cpp
+++ b/i18n/_ItalianText.cpp
@@ -6613,7 +6613,7 @@ STR16		zOptionsToggleText[] =
 	L"Forced Turn Mode",					// add forced turn mode
 	L"Alternate Strategy-Map Colors",		// Change color scheme of Strategic Map
 	L"Alternate bullet graphics",			// Show alternate bullet graphics (tracers) // TODO.Translate
-	L"Logical Bodytypes (WIP)",
+	L"Use New Merc Graphics",
 	L"Show Merc Ranks",						// shows mercs ranks	// TODO.Translate
 	L"Show Face gear graphics",				// TODO.Translate
 	L"Show Face gear icons",

--- a/i18n/_PolishText.cpp
+++ b/i18n/_PolishText.cpp
@@ -6631,7 +6631,7 @@ STR16		zOptionsToggleText[] =
 	L"Wymuś tryb turowy",					// add forced turn mode
 	L"Alternate Strategy-Map Colors",		// Change color scheme of Strategic Map
 	L"Alternate bullet graphics",			// Show alternate bullet graphics (tracers) // TODO.Translate
-	L"Logical Bodytypes",
+	L"Use New Merc Graphics",
 	L"Show Merc Ranks",				// shows mercs ranks		// TODO.Translate	
 	L"Show Face gear graphics",			// TODO.Translate
 	L"Show Face gear icons",


### PR DESCRIPTION
The option name "Logical Bodytypes" (LOBOT) is obscure for new players exploring the options screen. Renamed to "Use New Merc Graphics" across all language files to be more descriptive of what the feature actually does.

Fixes #449.