### PR TITLE
Stop weapon in gunsling pocket from contributing worn camo value

### DIFF
--- a/Editor/XML_ActionItems.cpp
+++ b/Editor/XML_ActionItems.cpp
@@ -5,6 +5,7 @@
 	#include "Interface.h"
 	#include "Item Statistics.h"
 	#include "LuaInitNPCs.h"
+	#include "FileMan.h"
 
 #include "Action Items.h"
 

--- a/Tactical/Item Types.cpp
+++ b/Tactical/Item Types.cpp
@@ -648,6 +648,10 @@ bool OBJECTTYPE::CanStack(OBJECTTYPE& sourceObject, int& numToStack)
 	//stacking control, restrict certain things here
 	if (numToStack > 0) {
 		if (exists() == true) {
+			if (sourceObject.usItem != usItem) {
+				return false;
+			}
+
 			if (Item[usItem].usItemClass == IC_MONEY) {
 				//money doesn't stack, it merges
 				// average out the status values using a weighted average...

--- a/Tactical/Items.cpp
+++ b/Tactical/Items.cpp
@@ -12792,9 +12792,7 @@ INT16 GetWornCamo( SOLDIERTYPE * pSoldier )
 				ttl += GetCamoBonus(&pSoldier->inv[HANDPOS]);
 			if (pSoldier->inv[SECONDHANDPOS].exists() == true && Item[pSoldier->inv[SECONDHANDPOS].usItem].usItemClass & IC_WEAPON)
 				ttl += GetCamoBonus(&pSoldier->inv[SECONDHANDPOS]);
-			if (pSoldier->inv[GUNSLINGPOCKPOS].exists() == true && Item[pSoldier->inv[GUNSLINGPOCKPOS].usItem].usItemClass & IC_WEAPON)
-				ttl += GetCamoBonus(&pSoldier->inv[GUNSLINGPOCKPOS]);
-		}
+			}
 	}
 
 	return __max(0, __min( ttl, ( 100 - gGameExternalOptions.bCamoKitArea ) ) );
@@ -12851,9 +12849,7 @@ INT16 GetWornUrbanCamo( SOLDIERTYPE * pSoldier )
 				ttl += GetUrbanCamoBonus(&pSoldier->inv[HANDPOS]);
 			if (pSoldier->inv[SECONDHANDPOS].exists() == true && Item[pSoldier->inv[SECONDHANDPOS].usItem].usItemClass & IC_WEAPON)
 				ttl += GetUrbanCamoBonus(&pSoldier->inv[SECONDHANDPOS]);
-			if (pSoldier->inv[GUNSLINGPOCKPOS].exists() == true && Item[pSoldier->inv[GUNSLINGPOCKPOS].usItem].usItemClass & IC_WEAPON)
-				ttl += GetUrbanCamoBonus(&pSoldier->inv[GUNSLINGPOCKPOS]);
-		}
+			}
 	}
 
 	return __max(0, __min( ttl, ( 100 - gGameExternalOptions.bCamoKitArea ) ) );
@@ -12910,9 +12906,7 @@ INT16 GetWornDesertCamo( SOLDIERTYPE * pSoldier )
 				ttl += GetDesertCamoBonus(&pSoldier->inv[HANDPOS]);
 			if (pSoldier->inv[SECONDHANDPOS].exists() == true && Item[pSoldier->inv[SECONDHANDPOS].usItem].usItemClass & IC_WEAPON)
 				ttl += GetDesertCamoBonus(&pSoldier->inv[SECONDHANDPOS]);
-			if (pSoldier->inv[GUNSLINGPOCKPOS].exists() == true && Item[pSoldier->inv[GUNSLINGPOCKPOS].usItem].usItemClass & IC_WEAPON)
-				ttl += GetDesertCamoBonus(&pSoldier->inv[GUNSLINGPOCKPOS]);
-		}
+			}
 	}
 	return __max(0, __min( ttl, ( 100 - gGameExternalOptions.bCamoKitArea ) ) );
 }
@@ -12968,9 +12962,7 @@ INT16 GetWornSnowCamo( SOLDIERTYPE * pSoldier )
 				ttl += GetSnowCamoBonus(&pSoldier->inv[HANDPOS]);
 			if (pSoldier->inv[SECONDHANDPOS].exists() == true && Item[pSoldier->inv[SECONDHANDPOS].usItem].usItemClass & IC_WEAPON)
 				ttl += GetSnowCamoBonus(&pSoldier->inv[SECONDHANDPOS]);
-			if (pSoldier->inv[GUNSLINGPOCKPOS].exists() == true && Item[pSoldier->inv[GUNSLINGPOCKPOS].usItem].usItemClass & IC_WEAPON)
-				ttl += GetSnowCamoBonus(&pSoldier->inv[GUNSLINGPOCKPOS]);
-		}
+			}
 	}
 	return __max(0, __min( ttl, ( 100 - gGameExternalOptions.bCamoKitArea ) ) );
 }

--- a/Tactical/Items.cpp
+++ b/Tactical/Items.cpp
@@ -10792,6 +10792,20 @@ INT32 GetObjectModifier( SOLDIERTYPE* pSoldier, OBJECTTYPE *pObj, UINT8 ubStance
 						iModifier += GetItemModifier(ObjList[pSoldier->bScopeMode], ubRef, usType);
 			}
 		}
+
+		if ( pSoldier != NULL && (pObj == &pSoldier->inv[HANDPOS] || pObj == &pSoldier->inv[SECONDHANDPOS]) )
+		{
+			for (INT8 bLoop = HELMETPOS; bLoop <= HEAD2POS; ++bLoop)
+			{
+				if (bLoop == HANDPOS || bLoop == SECONDHANDPOS)
+					continue;
+
+				if (pSoldier->inv[bLoop].exists())
+				{
+					iModifier += GetItemModifier(&(pSoldier->inv[bLoop]), ubRef, usType);
+				}
+			}
+		}
 	}
 
 	iModifier = __max(-100,iModifier);

--- a/Tactical/UI Cursors.cpp
+++ b/Tactical/UI Cursors.cpp
@@ -1326,7 +1326,7 @@ UINT8 HandleNonActivatedTargetCursor( SOLDIERTYPE *pSoldier, INT32 usMapPos , BO
 
 	}
 
-	if(gusUIFullTargetID == NOBODY && pSoldier->bDoAutofire && !pSoldier->flags.fDoSpread)	//reset autofire if we move the mouse off the target, however don't reset it if we are spread-bursting
+	if(!gfUIFullTargetFound && pSoldier->bDoAutofire && !pSoldier->flags.fDoSpread)	//reset autofire if we move the mouse off the target, however don't reset it if we are spread-bursting
 	{
 		if(gTacticalStatus.uiFlags & TURNBASED && (gTacticalStatus.uiFlags & INCOMBAT ))
 		{

--- a/TacticalAI/AIInternals.h
+++ b/TacticalAI/AIInternals.h
@@ -93,11 +93,13 @@ enum
 
 #define SEE_THRU_COVER_THRESHOLD		5		// min chance to get through
 
-#undef min
+#ifndef min
 #define min(a,b) ((a) < (b) ? (a) : (b))
+#endif
 
-#undef max
+#ifndef max
 #define max(a,b) ((a) > (b) ? (a) : (b))
+#endif
 
 // Added by feynman - remove all the ugly #ifdefs printf combinations for required for DebugAI
 //#define DEBUGAI

--- a/TacticalAI/NPC.cpp
+++ b/TacticalAI/NPC.cpp
@@ -946,6 +946,10 @@ UINT8 CalcDesireToTalk( UINT8 ubNPC, UINT8 ubMerc, INT8 bApproach )
 	{
 		iWillingness = 0;
 	}
+	else if (iWillingness > 255)
+	{
+		iWillingness = 255;
+	}
 
 	return( (UINT8) iWillingness );
 }


### PR DESCRIPTION
A weapon placed in the gunsling pocket (SHIFT+K) with attachments that have camo modifiers incorrectly contributes those modifiers to the overall worn camo value. A slung weapon should not be visible enough to affect camo.

Fix: Removed the GUNSLINGPOCKPOS camo check from all four GetWorn*Camo functions (woodland, urban, desert, snow).

Fixes #465.