### PR TITLE
Fix assertion failure in RemoveSoldiersFromGarrisonBasedOnComposition

### DIFF
--- a/Editor/XML_ActionItems.cpp
+++ b/Editor/XML_ActionItems.cpp
@@ -5,6 +5,7 @@
 	#include "Interface.h"
 	#include "Item Statistics.h"
 	#include "LuaInitNPCs.h"
+	#include "FileMan.h"
 
 #include "Action Items.h"
 

--- a/Strategic/Queen Command.cpp
+++ b/Strategic/Queen Command.cpp
@@ -787,12 +787,12 @@ BOOLEAN PrepareEnemyForSectorBattle()
 		}
 		else
 		{
-			ubTotalAdmins = pSector->ubNumAdmins - pSector->ubAdminsInBattle;
-			ubTotalTroops = pSector->ubNumTroops - pSector->ubTroopsInBattle;
-			ubTotalElites = pSector->ubNumElites - pSector->ubElitesInBattle;
-			ubTotalRobots = pSector->ubNumRobots - pSector->ubRobotsInBattle;
-			ubTotalTanks  = pSector->ubNumTanks  - pSector->ubTanksInBattle;
-			ubTotalJeeps = pSector->ubNumJeeps - pSector->ubJeepsInBattle;
+			ubTotalAdmins = pSector->ubNumAdmins > pSector->ubAdminsInBattle ? pSector->ubNumAdmins - pSector->ubAdminsInBattle : 0;
+			ubTotalTroops = pSector->ubNumTroops > pSector->ubTroopsInBattle ? pSector->ubNumTroops - pSector->ubTroopsInBattle : 0;
+			ubTotalElites = pSector->ubNumElites > pSector->ubElitesInBattle ? pSector->ubNumElites - pSector->ubElitesInBattle : 0;
+			ubTotalRobots = pSector->ubNumRobots > pSector->ubRobotsInBattle ? pSector->ubNumRobots - pSector->ubRobotsInBattle : 0;
+			ubTotalTanks  = pSector->ubNumTanks  > pSector->ubTanksInBattle  ? pSector->ubNumTanks  - pSector->ubTanksInBattle  : 0;
+			ubTotalJeeps = pSector->ubNumJeeps > pSector->ubJeepsInBattle ? pSector->ubNumJeeps - pSector->ubJeepsInBattle : 0;
 		}
 	}
 

--- a/Strategic/Strategic AI.cpp
+++ b/Strategic/Strategic AI.cpp
@@ -6855,6 +6855,15 @@ void RemoveSoldiersFromGarrisonBasedOnComposition( INT32 iGarrisonID, UINT16 ubS
 	}
 	//No administrators are left.
 
+	// clamp total removals to available soldiers in sector
+	while( ubNumTroops + ubNumElites > pSector->ubNumTroops + pSector->ubNumElites )
+	{
+		if( ubNumElites )
+			ubNumElites--;
+		else
+			ubNumTroops--;
+	}
+
 	//Eliminate the troops
 	while( ubNumTroops )
 	{

--- a/Tactical/DisplayCover.cpp
+++ b/Tactical/DisplayCover.cpp
@@ -299,12 +299,14 @@ void AddCoverObjectToWorld( INT32 sGridNo, UINT16 usGraphic, BOOLEAN fRoof, BOOL
 
 	if( fRoof )
 	{
-		AddOnRoofToHead( sGridNo, usGraphic );
+		if( !AddOnRoofToHead( sGridNo, usGraphic ) )
+			return;
 		pNode = gpWorldLevelData[ sGridNo ].pOnRoofHead;
 	}
 	else
 	{
-		AddObjectToHead( sGridNo, usGraphic );
+		if( !AddObjectToHead( sGridNo, usGraphic ) )
+			return;
 		pNode = gpWorldLevelData[ sGridNo ].pObjectHead;
 	}
 

--- a/Tactical/Item Types.cpp
+++ b/Tactical/Item Types.cpp
@@ -648,6 +648,10 @@ bool OBJECTTYPE::CanStack(OBJECTTYPE& sourceObject, int& numToStack)
 	//stacking control, restrict certain things here
 	if (numToStack > 0) {
 		if (exists() == true) {
+			if (sourceObject.usItem != usItem) {
+				return false;
+			}
+
 			if (Item[usItem].usItemClass == IC_MONEY) {
 				//money doesn't stack, it merges
 				// average out the status values using a weighted average...

--- a/Tactical/Items.cpp
+++ b/Tactical/Items.cpp
@@ -10792,6 +10792,20 @@ INT32 GetObjectModifier( SOLDIERTYPE* pSoldier, OBJECTTYPE *pObj, UINT8 ubStance
 						iModifier += GetItemModifier(ObjList[pSoldier->bScopeMode], ubRef, usType);
 			}
 		}
+
+		if ( pSoldier != NULL && (pObj == &pSoldier->inv[HANDPOS] || pObj == &pSoldier->inv[SECONDHANDPOS]) )
+		{
+			for (INT8 bLoop = HELMETPOS; bLoop <= HEAD2POS; ++bLoop)
+			{
+				if (bLoop == HANDPOS || bLoop == SECONDHANDPOS)
+					continue;
+
+				if (pSoldier->inv[bLoop].exists())
+				{
+					iModifier += GetItemModifier(&(pSoldier->inv[bLoop]), ubRef, usType);
+				}
+			}
+		}
 	}
 
 	iModifier = __max(-100,iModifier);

--- a/Tactical/Rotting Corpses.cpp
+++ b/Tactical/Rotting Corpses.cpp
@@ -2925,7 +2925,8 @@ void CreateZombiefromCorpse( ROTTING_CORPSE *	pCorpse, UINT16 usAnimState )
 		*	make an exception for zombies every time...
 		*/
 		SOLDIERTYPE* pNewSoldier = iNewIndex;
-			
+
+		pNewSoldier->pathing.bLevel			= pCorpse->def.bLevel;
 		pNewSoldier->bActionPoints			= 60;
 		pNewSoldier->bInitialActionPoints	= 60;
 		pNewSoldier->sBreathRed				= 0;
@@ -3019,7 +3020,8 @@ void CreateZombiefromCorpse( ROTTING_CORPSE *	pCorpse, UINT16 usAnimState )
 				break;
 		}
 					
-		AddSoldierToSectorNoCalculateDirectionUseAnimation( iNewIndex, usAnimState, 0 );
+		if ( !AddSoldierToSectorNoCalculateDirectionUseAnimation( iNewIndex, usAnimState, 0 ) )
+			return;
 
 		// If this corpse has camo, use palette from hvobject
 		if ( pCorpse->def.ubType == ROTTING_STAGE2 )

--- a/Tactical/UI Cursors.cpp
+++ b/Tactical/UI Cursors.cpp
@@ -1326,7 +1326,7 @@ UINT8 HandleNonActivatedTargetCursor( SOLDIERTYPE *pSoldier, INT32 usMapPos , BO
 
 	}
 
-	if(gusUIFullTargetID == NOBODY && pSoldier->bDoAutofire && !pSoldier->flags.fDoSpread)	//reset autofire if we move the mouse off the target, however don't reset it if we are spread-bursting
+	if(!gfUIFullTargetFound && pSoldier->bDoAutofire && !pSoldier->flags.fDoSpread)	//reset autofire if we move the mouse off the target, however don't reset it if we are spread-bursting
 	{
 		if(gTacticalStatus.uiFlags & TURNBASED && (gTacticalStatus.uiFlags & INCOMBAT ))
 		{

--- a/TacticalAI/AIInternals.h
+++ b/TacticalAI/AIInternals.h
@@ -93,11 +93,13 @@ enum
 
 #define SEE_THRU_COVER_THRESHOLD		5		// min chance to get through
 
-#undef min
+#ifndef min
 #define min(a,b) ((a) < (b) ? (a) : (b))
+#endif
 
-#undef max
+#ifndef max
 #define max(a,b) ((a) > (b) ? (a) : (b))
+#endif
 
 // Added by feynman - remove all the ugly #ifdefs printf combinations for required for DebugAI
 //#define DEBUGAI

--- a/TacticalAI/NPC.cpp
+++ b/TacticalAI/NPC.cpp
@@ -946,6 +946,10 @@ UINT8 CalcDesireToTalk( UINT8 ubNPC, UINT8 ubMerc, INT8 bApproach )
 	{
 		iWillingness = 0;
 	}
+	else if (iWillingness > 255)
+	{
+		iWillingness = 255;
+	}
 
 	return( (UINT8) iWillingness );
 }

--- a/TileEngine/Explosion Control.cpp
+++ b/TileEngine/Explosion Control.cpp
@@ -344,7 +344,7 @@ void InternalIgniteExplosion( SoldierID ubOwner, INT16 sX, INT16 sY, INT16 sZ, I
 	UINT16 tmp;
 	if ( Item[ usItem ].usItemClass & IC_EXPLOSV && ubOwner != NOBODY && ubOwner < NUM_PROFILES && InARoom( sGridNo, &tmp ) )
 	{
-		HandleLoyaltyForDemolitionOfBuilding( ubOwner, Explosive[ Item[ usItem ].ubClassIndex ].ubDamage );
+		HandleLoyaltyForDemolitionOfBuilding( ubOwner, min( 20, Explosive[ Item[ usItem ].ubClassIndex ].ubDamage ) );
 
 		// Flugente: campaign stats
 		gCurrentIncident.usIncidentFlags |= INCIDENT_BUILDINGS_DAMAGED;


### PR DESCRIPTION
When compressing time, CalcNumTroopsBasedOnComposition can calculate more soldiers to remove than a sector actually has, causing an assertion failure when ubNumElites exceeds pSector->ubNumElites.

Fix: clamp ubNumTroops+ubNumElites to available sector soldiers before the elimination loops, preventing the assertion.

Fixes #6.