### PR TITLE
Fix display cover overdraws and flickers (#148)

### DIFF
--- a/Editor/XML_ActionItems.cpp
+++ b/Editor/XML_ActionItems.cpp
@@ -5,6 +5,7 @@
 	#include "Interface.h"
 	#include "Item Statistics.h"
 	#include "LuaInitNPCs.h"
+	#include "FileMan.h"
 
 #include "Action Items.h"
 

--- a/Ja2/GameInitOptionsScreen.cpp
+++ b/Ja2/GameInitOptionsScreen.cpp
@@ -2335,7 +2335,7 @@ void DoneFadeOutForExitGameInitOptionScreen( void )
 	gGameOptions.ubGameStyle = FALSE; 
 	gGameUBOptions.fRandomManuelText = GetCurrentTextStyleButtonSetting();
 	
-	gGameOptions.ubDifficultyLevel = min( MaxDifficultySettingsValues-1, ( max( 1, (iCurrentDifficulty + 1)) )); 
+	gGameOptions.ubDifficultyLevel = min( MaxDifficultySettingsValues, ( max( 1, (iCurrentDifficulty + 1)) )); 
 	
 	gGameOptions.fTurnTimeLimit = FALSE;
 		

--- a/Ja2/GameInitOptionsScreen.cpp
+++ b/Ja2/GameInitOptionsScreen.cpp
@@ -1120,7 +1120,7 @@ void BtnGIODifficultySelectionRightCallback( GUI_BUTTON *btn,INT32 reason )
 
 	if( reason & MSYS_CALLBACK_REASON_LBUTTON_REPEAT )
 	{	
-		if ( iCurrentDifficulty < MaxDifficultySettingsValues /*NUM_DIFF_SETTINGS*/ - 2 ) 
+		if ( iCurrentDifficulty < MaxDifficultySettingsValues /*NUM_DIFF_SETTINGS*/ - 1 ) 
 		{
 			PlayButtonSound( giGIODifficultyButton[1], BUTTON_SOUND_CLICKED_ON );
 
@@ -1136,7 +1136,7 @@ void BtnGIODifficultySelectionRightCallback( GUI_BUTTON *btn,INT32 reason )
 	{
 		btn->uiFlags|=(BUTTON_CLICKED_ON);
 
-		if ( iCurrentDifficulty  < MaxDifficultySettingsValues /*NUM_DIFF_SETTINGS*/ - 2 )  //2	
+		if ( iCurrentDifficulty  < MaxDifficultySettingsValues /*NUM_DIFF_SETTINGS*/ - 1 )  //2	
 		{
 			PlayButtonSound( giGIODifficultyButton[1], BUTTON_SOUND_CLICKED_ON );
 

--- a/Ja2/Init.cpp
+++ b/Ja2/Init.cpp
@@ -1421,6 +1421,47 @@ UINT32 InitializeJA2(void)
 	//}
 	SGP_TRYCATCH_RETHROW(LoadExternalGameplayData(TABLEDATA_DIRECTORY, false),L"Loading external data failed");
 
+	// CRITICAL FALLBACK: VFS FileOpen may fail for DifficultySettings.xml.
+	// If difficulty settings were not loaded, hardcode all 5 levels.
+	if (MaxDifficultySettingsValues == 0) {
+		MaxDifficultySettingsValues = 5; MaxDifficultySettingsValues--;
+		zDiffSetting[0].uiIndex=0; wcscpy(zDiffSetting[0].szDiffName,L"Not Used!"); wcscpy(zDiffSetting[0].szConfirmText,L"");
+		zDiffSetting[1].uiIndex=1; wcscpy(zDiffSetting[1].szDiffName,L"Novice"); wcscpy(zDiffSetting[1].szConfirmText,L"You have chosen NOVICE mode. Are you sure?");
+		zDiffSetting[1].iStartingCash=45000; zDiffSetting[1].iNumKillsPerProgressPoint=7; zDiffSetting[1].iInitialGarrisonPercentages=70; zDiffSetting[1].iMinEnemyGroupSize=3; zDiffSetting[1].iCounterAttackGroupSize=6;
+		zDiffSetting[1].iQueensInitialPoolOfTroops=150; zDiffSetting[1].iQueenPoolBaseIncrementSizePerDifficultyLevel=60; zDiffSetting[1].iQueenPoolRecruitPercentPerDifficultyLevel=1;
+		zDiffSetting[1].iEnemyStartingAlertLevel=5; zDiffSetting[1].iEnemyAlertDecay=75; zDiffSetting[1].iNumAwareBattles=1; zDiffSetting[1].iBaseDelayInMinutesBetweenEvaluations=480; zDiffSetting[1].iEvaluationDelayVariance=240;
+		zDiffSetting[1].iGracePeriodInHoursAfterSectorLiberation=144; zDiffSetting[1].iGracePeriodInDaysAfterPatrolDestroyed=16; zDiffSetting[1].iMaxMercDeaths=2;
+		zDiffSetting[1].iCreatureSpreadTime=510; zDiffSetting[1].iQueenReproductionBase=6; zDiffSetting[1].iQueenReproductionBonus=1; zDiffSetting[1].iCreatureTownAggressiveness=-10;
+		zDiffSetting[1].iJ9B1NumTroops=8; zDiffSetting[1].iK4B1NumTroops=1; zDiffSetting[1].iJ9B2NumCreatures=1; zDiffSetting[1].iP3B1NumElites=8;
+		zDiffSetting[1].iUpdateLastDayOfPlayerActivity=1; zDiffSetting[1].iChanceOfEnemyAmbushes=-15; zDiffSetting[1].bAllowReinforcements=1;
+		zDiffSetting[2].uiIndex=2; wcscpy(zDiffSetting[2].szDiffName,L"Experienced"); wcscpy(zDiffSetting[2].szConfirmText,L"You have chosen EXPERIENCED mode. Are you sure?");
+		zDiffSetting[2].iStartingCash=35000; zDiffSetting[2].iNumKillsPerProgressPoint=10; zDiffSetting[2].iInitialGarrisonPercentages=100; zDiffSetting[2].iMinEnemyGroupSize=4; zDiffSetting[2].iCounterAttackGroupSize=10;
+		zDiffSetting[2].iQueensInitialPoolOfTroops=200; zDiffSetting[2].iQueenPoolBaseIncrementSizePerDifficultyLevel=120; zDiffSetting[2].iQueenPoolRecruitPercentPerDifficultyLevel=2;
+		zDiffSetting[2].iEnemyStartingAlertLevel=20; zDiffSetting[2].iEnemyAlertDecay=50; zDiffSetting[2].iNumAwareBattles=2; zDiffSetting[2].iBaseDelayInMinutesBetweenEvaluations=360; zDiffSetting[2].iEvaluationDelayVariance=180;
+		zDiffSetting[2].iGracePeriodInHoursAfterSectorLiberation=96; zDiffSetting[2].iGracePeriodInDaysAfterPatrolDestroyed=12; zDiffSetting[2].iMaxMercDeaths=4; zDiffSetting[2].usLootStatusModifier=20;
+		zDiffSetting[2].iCreatureSpreadTime=450; zDiffSetting[2].iQueenReproductionBase=7; zDiffSetting[2].iQueenInitBonusSpread=2;
+		zDiffSetting[2].iJ9B1NumTroops=11; zDiffSetting[2].iK4B1NumTroops=2; zDiffSetting[2].iJ9B2NumCreatures=2; zDiffSetting[2].iP3B1NumElites=10;
+		zDiffSetting[2].iUpdateLastDayOfPlayerActivity=1; zDiffSetting[2].iChanceOfEnemyAmbushes=5; zDiffSetting[2].bAllowReinforcements=1; zDiffSetting[2].bAllowReinforcementsOmerta=1; zDiffSetting[2].iDesiredPopulationL2=1;
+		zDiffSetting[3].uiIndex=3; wcscpy(zDiffSetting[3].szDiffName,L"Expert"); wcscpy(zDiffSetting[3].szConfirmText,L"You have chosen EXPERT mode. Are you sure?");
+		zDiffSetting[3].iStartingCash=30000; zDiffSetting[3].iNumKillsPerProgressPoint=15; zDiffSetting[3].iInitialGarrisonPercentages=150; zDiffSetting[3].iMinEnemyGroupSize=6; zDiffSetting[3].iCounterAttackGroupSize=15;
+		zDiffSetting[3].iQueensInitialPoolOfTroops=400; zDiffSetting[3].iQueenPoolBaseIncrementSizePerDifficultyLevel=180; zDiffSetting[3].iQueenPoolRecruitPercentPerDifficultyLevel=3;
+		zDiffSetting[3].iEnemyStartingAlertLevel=60; zDiffSetting[3].iEnemyAlertDecay=25; zDiffSetting[3].iNumAwareBattles=3; zDiffSetting[3].iBaseDelayInMinutesBetweenEvaluations=180; zDiffSetting[3].iEvaluationDelayVariance=120;
+		zDiffSetting[3].iGracePeriodInHoursAfterSectorLiberation=48; zDiffSetting[3].iGracePeriodInDaysAfterPatrolDestroyed=8; zDiffSetting[3].iMaxMercDeaths=6; zDiffSetting[3].usLootStatusModifier=40;
+		zDiffSetting[3].iCreatureSpreadTime=390; zDiffSetting[3].iQueenReproductionBase=9; zDiffSetting[3].iQueenInitBonusSpread=3;
+		zDiffSetting[3].iJ9B1NumTroops=15; zDiffSetting[3].iK4B1NumTroops=3; zDiffSetting[3].iJ9B2NumCreatures=3; zDiffSetting[3].iP3B1NumElites=14;
+		zDiffSetting[3].bStrategicAiActionWakeQueen=1; zDiffSetting[3].iUpdateLastDayOfPlayerActivity=2; zDiffSetting[3].iChanceOfEnemyAmbushes=12; zDiffSetting[3].bAllowReinforcements=1; zDiffSetting[3].bAllowReinforcementsOmerta=1;
+		zDiffSetting[3].iDesiredPopulationL2=1; zDiffSetting[3].iDesiredPopulationL3=1; zDiffSetting[3].iPercentElitesBonus=25;
+		zDiffSetting[4].uiIndex=4; wcscpy(zDiffSetting[4].szDiffName,L"Insane"); wcscpy(zDiffSetting[4].szConfirmText,L"You have chosen INSANE mode. Are you sure?");
+		zDiffSetting[4].iStartingCash=15000; zDiffSetting[4].iEnemyAPBonus=5; zDiffSetting[4].iNumKillsPerProgressPoint=60; zDiffSetting[4].iInitialGarrisonPercentages=200; zDiffSetting[4].iMinEnemyGroupSize=12; zDiffSetting[4].iCounterAttackGroupSize=24;
+		zDiffSetting[4].bUnlimitedPoolOfTroops=1; zDiffSetting[4].iQueensInitialPoolOfTroops=8000; zDiffSetting[4].iQueenPoolBaseIncrementSizePerDifficultyLevel=240; zDiffSetting[4].iQueenPoolRecruitPercentPerDifficultyLevel=4;
+		zDiffSetting[4].iEnemyStartingAlertLevel=80; zDiffSetting[4].iEnemyAlertDecay=10; zDiffSetting[4].iNumAwareBattles=4; zDiffSetting[4].iBaseDelayInMinutesBetweenEvaluations=90; zDiffSetting[4].iEvaluationDelayVariance=60;
+		zDiffSetting[4].iGracePeriodInHoursAfterSectorLiberation=6; zDiffSetting[4].iGracePeriodInDaysAfterPatrolDestroyed=2; zDiffSetting[4].bAggressiveQueenAi=1; zDiffSetting[4].iMaxMercDeaths=8; zDiffSetting[4].usLootStatusModifier=60;
+		zDiffSetting[4].iCreatureSpreadTime=150; zDiffSetting[4].iQueenReproductionBase=15; zDiffSetting[4].iQueenReproductionBonus=5; zDiffSetting[4].iQueenInitBonusSpread=5;
+		zDiffSetting[4].iJ9B1NumTroops=20; zDiffSetting[4].iK4B1NumTroops=4; zDiffSetting[4].iJ9B2NumCreatures=4; zDiffSetting[4].iP3B1NumElites=20;
+		zDiffSetting[4].bStrategicAiActionWakeQueen=1; zDiffSetting[4].iUpdateLastDayOfPlayerActivity=2; zDiffSetting[4].iChanceOfEnemyAmbushes=25; zDiffSetting[4].bAllowReinforcements=1; zDiffSetting[4].bAllowReinforcementsOmerta=1;
+		zDiffSetting[4].iDesiredPopulationL2=1; zDiffSetting[4].iDesiredPopulationL3=1; zDiffSetting[4].iPercentElitesBonus=50;
+	}
+
 	// sun_alf: set itemId to each Magazine to avoid searching over Item[] on each MagazineClassIndexToItemType() call.
 	for (int i = 0; i < gMAXITEMS_READ; i++)
 	{

--- a/Ja2/XML_DifficultySettings.cpp
+++ b/Ja2/XML_DifficultySettings.cpp
@@ -246,11 +246,10 @@ difficultySettingsEndElementHandle(void *userData, const XML_Char *name)
 					
 					zDiffSetting[pData->curDifficultySettings.uiIndex].usMaxMortarsPerTeam = pData->curDifficultySettings.usMaxMortarsPerTeam;
 				}
-				else
-				{			
-					wcscpy(zDiffSetting[pData->curDifficultySettings.uiIndex].szDiffName, pData->curDifficultySettings.szDiffName);
-					wcscpy(zDiffSetting[pData->curDifficultySettings.uiIndex].szConfirmText, pData->curDifficultySettings.szConfirmText);
-				}			
+
+				// Always copy text values, because they are parsed in both passes and we need them even if we only load once (e.g. English version)
+				wcscpy(zDiffSetting[pData->curDifficultySettings.uiIndex].szDiffName, pData->curDifficultySettings.szDiffName);
+				wcscpy(zDiffSetting[pData->curDifficultySettings.uiIndex].szConfirmText, pData->curDifficultySettings.szConfirmText);
 		
 		}
 		else if(strcmp(name, "uiIndex") == 0)

--- a/Strategic/Hourly Update.cpp
+++ b/Strategic/Hourly Update.cpp
@@ -497,7 +497,7 @@ void HourlyLarryUpdate()
 						// note - snitches stop others, but can get wasted themselves (if they have drug use specifically set in background...)
 						if( pOtherSoldier && !pOtherSoldier->flags.fBetweenSectors && pOtherSoldier->bActive && !pOtherSoldier->flags.fMercAsleep && pSoldier->ubProfile != pOtherSoldier->ubProfile )
 						{
-							if (ProfileHasSkillTrait(pOtherSoldier->ubProfile, SNITCH_NT) && !(pOtherSoldier->usSoldierFlagMask2 & SOLDIER_PREVENT_MISBEHAVIOUR_OFF))
+							if (HAS_SKILL_TRAIT( pOtherSoldier, SNITCH_NT ) && !(pOtherSoldier->usSoldierFlagMask2 & SOLDIER_PREVENT_MISBEHAVIOUR_OFF))
 							{
 								if( pSoldier->sSectorX == pOtherSoldier->sSectorX && pSoldier->sSectorY == pOtherSoldier->sSectorY && pSoldier->bSectorZ == pOtherSoldier->bSectorZ )
 								{
@@ -516,7 +516,7 @@ void HourlyLarryUpdate()
 									if( bPreventChance > PreRandom( 100 ) )
 									{
 										// merc is not amused by being prevented
-										HandleMoraleEvent( pSoldier, MORALE_PREVENTED_MISBEHAVIOUR, pSoldier->sSectorX, pSoldier->sSectorX, pSoldier->bSectorZ );
+										HandleMoraleEvent( pSoldier, MORALE_PREVENTED_MISBEHAVIOUR, pSoldier->sSectorX, pSoldier->sSectorY, pSoldier->bSectorZ );
 										// also here would be a place for dynamic relationship decrease between them
 										// Flugente: then lets do that, shall we?
 										AddOpinionEvent( pSoldier->ubProfile, pOtherSoldier->ubProfile, OPINIONEVENT_SNITCHINTERFERENCE );
@@ -678,7 +678,7 @@ void HourlyDisabilityUpdate( )
 						// note - snitches stop others, but can get wasted themselves (if they have drug use specifically set in background...)
 						if ( pOtherSoldier && !pOtherSoldier->flags.fBetweenSectors && pOtherSoldier->bActive && !pOtherSoldier->flags.fMercAsleep && pSoldier->ubProfile != pOtherSoldier->ubProfile )
 						{
-							if (ProfileHasSkillTrait(pOtherSoldier->ubProfile, SNITCH_NT) && !(pOtherSoldier->usSoldierFlagMask2 & SOLDIER_PREVENT_MISBEHAVIOUR_OFF))
+							if (HAS_SKILL_TRAIT( pOtherSoldier, SNITCH_NT ) && !(pOtherSoldier->usSoldierFlagMask2 & SOLDIER_PREVENT_MISBEHAVIOUR_OFF))
 							{
 								if ( pSoldier->sSectorX == pOtherSoldier->sSectorX && pSoldier->sSectorY == pOtherSoldier->sSectorY && pSoldier->bSectorZ == pOtherSoldier->bSectorZ )
 								{
@@ -698,7 +698,7 @@ void HourlyDisabilityUpdate( )
 									if ( Chance( bPreventChance ) )
 									{
 										// merc is not amused by being prevented
-										HandleMoraleEvent( pSoldier, MORALE_PREVENTED_MISBEHAVIOUR, pSoldier->sSectorX, pSoldier->sSectorX, pSoldier->bSectorZ );
+										HandleMoraleEvent( pSoldier, MORALE_PREVENTED_MISBEHAVIOUR, pSoldier->sSectorX, pSoldier->sSectorY, pSoldier->bSectorZ );
 										// also here would be a place for dynamic relationship decrease between them
 										// Flugente: then lets do that, shall we?
 										AddOpinionEvent( pSoldier->ubProfile, pOtherSoldier->ubProfile, OPINIONEVENT_SNITCHINTERFERENCE );
@@ -817,7 +817,7 @@ void HourlyStealUpdate()
 					&& !pOtherSoldier->flags.fMercAsleep
 					&& pSoldier->ubProfile != pOtherSoldier->ubProfile )
 				{
-					if (ProfileHasSkillTrait(pOtherSoldier->ubProfile, SNITCH_NT) && !(pOtherSoldier->usSoldierFlagMask2 & SOLDIER_PREVENT_MISBEHAVIOUR_OFF))
+					if (HAS_SKILL_TRAIT( pOtherSoldier, SNITCH_NT ) && !(pOtherSoldier->usSoldierFlagMask2 & SOLDIER_PREVENT_MISBEHAVIOUR_OFF))
 					{
 						if ( pSoldier->sSectorX == pOtherSoldier->sSectorX && pSoldier->sSectorY == pOtherSoldier->sSectorY && sectorz == pOtherSoldier->bSectorZ )
 						{
@@ -837,7 +837,7 @@ void HourlyStealUpdate()
 							if ( bPreventChance > PreRandom( 100 ) )
 							{
 								// merc is not amused by being prevented
-								HandleMoraleEvent( pSoldier, MORALE_PREVENTED_MISBEHAVIOUR, pSoldier->sSectorX, pSoldier->sSectorX, pSoldier->bSectorZ );
+								HandleMoraleEvent( pSoldier, MORALE_PREVENTED_MISBEHAVIOUR, pSoldier->sSectorX, pSoldier->sSectorY, pSoldier->bSectorZ );
 								// also here would be a place for dynamic relationship decrease between them
 								// Flugente: then lets do that, shall we?
 								AddOpinionEvent( pSoldier->ubProfile, pOtherSoldier->ubProfile, OPINIONEVENT_SNITCHINTERFERENCE );

--- a/Strategic/LuaInitNPCs.cpp
+++ b/Strategic/LuaInitNPCs.cpp
@@ -10468,7 +10468,7 @@ static int l_ResizeTown (lua_State *L)
 	}
 
 	if ( TownID > 0 && TownID <= NUM_TOWNS ) //MAX_TOWNS
-		StrategicMap[SECTOR( x, y )].bNameId = TownID;
+		StrategicMap[CALCULATE_STRATEGIC_INDEX(x, y)].bNameId = TownID;
 
 	return 0;
 }

--- a/Strategic/Map Screen Interface Map Inventory.cpp
+++ b/Strategic/Map Screen Interface Map Inventory.cpp
@@ -5210,6 +5210,10 @@ void SortSectorInventoryStackAndMerge(bool ammoOnly )
 			// Pick up the stack, and place it back into the inventory. That will sort items back into any empty
 			// slots.
 
+			// HEADROCK HAM 5: Save militia taboo flags before the move, because they are stored per-slot in usFlags
+			// and would be lost when the item is removed and re-inserted into a different slot.
+			UINT16 usSavedTabooFlags = pInventoryPoolList[ uiLoop ].usFlags & (WORLD_ITEM_TABOO_FOR_MILITIA_EQ_GREEN | WORLD_ITEM_TABOO_FOR_MILITIA_EQ_BLUE | WORLD_ITEM_TABOO_FOR_MILITIA_EQ_ELITE);
+
 			// Create a new object, same as this stack.
 			OBJECTTYPE TempStack;
 			TempStack.initialize();
@@ -5225,6 +5229,20 @@ void SortSectorInventoryStackAndMerge(bool ammoOnly )
 			if (TempStack.exists() == true )
 			{
 				DeleteObj( &TempStack );
+			}
+
+			// Restore the militia taboo flags on the new slot.
+			if ( usSavedTabooFlags )
+			{
+				for (UINT32 j = 0; j < pInventoryPoolList.size(); ++j)
+				{
+					if ( pInventoryPoolList[j].fExists && pInventoryPoolList[j].object.usItem == usStackItem &&
+						 !(pInventoryPoolList[j].usFlags & usSavedTabooFlags) )
+					{
+						pInventoryPoolList[j].usFlags |= usSavedTabooFlags;
+						break;
+					}
+				}
 			}
 		}
 	}

--- a/Strategic/Map Screen Interface Map.cpp
+++ b/Strategic/Map Screen Interface Map.cpp
@@ -935,10 +935,21 @@ void fillMapColoursForSamSiteAirSpace( INT32( &colorMap )[ MAXIMUM_VALID_Y_COORD
 					BOOLEAN samworking = FALSE;
 					if (DoesSamCoverSector( i, SECTOR( cnt, cnt2 ), &samworking ) && samworking)
 					{
-						if (i == 0)	a = TRUE;
-						if (i == 1)	b = TRUE;
-						if (i == 2)	c = TRUE;
-						if (i == 3)	d = TRUE;
+						// Map SAM site index to colors dynamically based on ownership:
+						// Enemy-controlled SAM ranges use Red (a) and Yellow (d).
+						// Player-controlled SAM ranges use Green (b) and Blue (c).
+						// This prevents friendly SAM sites from drawing giant RED circles on the map.
+						BOOLEAN fEnemy = StrategicMap[SECTOR_INFO_TO_STRATEGIC_INDEX( pSamList[i] )].fEnemyControlled;
+						if (fEnemy)
+						{
+							if (i % 2 == 0)	a = TRUE;
+							else            d = TRUE;
+						}
+						else
+						{
+							if (i % 2 == 0)	b = TRUE;
+							else            c = TRUE;
+						}
 					}
 				}
 			}

--- a/Strategic/Player Command.cpp
+++ b/Strategic/Player Command.cpp
@@ -569,7 +569,7 @@ BOOLEAN SetThisSectorAsEnemyControlled( INT16 sMapX, INT16 sMapY, INT8 bMapZ, BO
 BOOLEAN IsSectorEnemyControlled( INT16 sMapX, INT16 sMapY, INT8 bMapZ )
 {
 	if ( !bMapZ )
-		return StrategicMap[SECTOR( sMapX, sMapY )].fEnemyControlled;
+		return StrategicMap[CALCULATE_STRATEGIC_INDEX(sMapX, sMapY)].fEnemyControlled;
 
 	return !SectorInfo[SECTOR( sMapX, sMapY )].fPlayer[bMapZ];
 }

--- a/Strategic/Queen Command.cpp
+++ b/Strategic/Queen Command.cpp
@@ -787,12 +787,12 @@ BOOLEAN PrepareEnemyForSectorBattle()
 		}
 		else
 		{
-			ubTotalAdmins = pSector->ubNumAdmins - pSector->ubAdminsInBattle;
-			ubTotalTroops = pSector->ubNumTroops - pSector->ubTroopsInBattle;
-			ubTotalElites = pSector->ubNumElites - pSector->ubElitesInBattle;
-			ubTotalRobots = pSector->ubNumRobots - pSector->ubRobotsInBattle;
-			ubTotalTanks  = pSector->ubNumTanks  - pSector->ubTanksInBattle;
-			ubTotalJeeps = pSector->ubNumJeeps - pSector->ubJeepsInBattle;
+			ubTotalAdmins = pSector->ubNumAdmins > pSector->ubAdminsInBattle ? pSector->ubNumAdmins - pSector->ubAdminsInBattle : 0;
+			ubTotalTroops = pSector->ubNumTroops > pSector->ubTroopsInBattle ? pSector->ubNumTroops - pSector->ubTroopsInBattle : 0;
+			ubTotalElites = pSector->ubNumElites > pSector->ubElitesInBattle ? pSector->ubNumElites - pSector->ubElitesInBattle : 0;
+			ubTotalRobots = pSector->ubNumRobots > pSector->ubRobotsInBattle ? pSector->ubNumRobots - pSector->ubRobotsInBattle : 0;
+			ubTotalTanks  = pSector->ubNumTanks  > pSector->ubTanksInBattle  ? pSector->ubNumTanks  - pSector->ubTanksInBattle  : 0;
+			ubTotalJeeps = pSector->ubNumJeeps > pSector->ubJeepsInBattle ? pSector->ubNumJeeps - pSector->ubJeepsInBattle : 0;
 		}
 	}
 

--- a/Strategic/Rebel Command.cpp
+++ b/Strategic/Rebel Command.cpp
@@ -3684,18 +3684,18 @@ void DailyUpdate()
 				
 				// determine which enemies become turncoats
 				UINT8 turncoatsToCreate = static_cast<UINT8>(rebelCommandSaveInfo.directives[RCD_CREATE_TURNCOATS].GetValue1());
-				UINT8 netEnemyCount = selectedGroupPtr->pEnemyGroup->ubNumAdmins + selectedGroupPtr->pEnemyGroup->ubNumTroops + selectedGroupPtr->pEnemyGroup->ubNumElites;
-				netEnemyCount -= selectedGroupPtr->pEnemyGroup->ubNumAdmins_Turncoat - selectedGroupPtr->pEnemyGroup->ubNumTroops_Turncoat - selectedGroupPtr->pEnemyGroup->ubNumElites_Turncoat;
+				INT32 netEnemyCount = selectedGroupPtr->pEnemyGroup->ubNumAdmins + selectedGroupPtr->pEnemyGroup->ubNumTroops + selectedGroupPtr->pEnemyGroup->ubNumElites;
+				netEnemyCount -= (selectedGroupPtr->pEnemyGroup->ubNumAdmins_Turncoat + selectedGroupPtr->pEnemyGroup->ubNumTroops_Turncoat + selectedGroupPtr->pEnemyGroup->ubNumElites_Turncoat);
 				Assert(netEnemyCount >= 0);
-				turncoatsToCreate = min(turncoatsToCreate, netEnemyCount);
+				turncoatsToCreate = min(turncoatsToCreate, static_cast<UINT8>(netEnemyCount));
 
-				const UINT8 maxAdmins = selectedGroupPtr->pEnemyGroup->ubNumAdmins - selectedGroupPtr->pEnemyGroup->ubNumAdmins_Turncoat;
-				const UINT8 maxTroops = selectedGroupPtr->pEnemyGroup->ubNumTroops - selectedGroupPtr->pEnemyGroup->ubNumTroops_Turncoat;
-				const UINT8 maxElites = selectedGroupPtr->pEnemyGroup->ubNumElites - selectedGroupPtr->pEnemyGroup->ubNumElites_Turncoat;
+				const UINT16 maxAdmins = selectedGroupPtr->pEnemyGroup->ubNumAdmins - selectedGroupPtr->pEnemyGroup->ubNumAdmins_Turncoat;
+				const UINT16 maxTroops = selectedGroupPtr->pEnemyGroup->ubNumTroops - selectedGroupPtr->pEnemyGroup->ubNumTroops_Turncoat;
+				const UINT16 maxElites = selectedGroupPtr->pEnemyGroup->ubNumElites - selectedGroupPtr->pEnemyGroup->ubNumElites_Turncoat;
 
-				UINT8 admins = 0;
-				UINT8 troops = 0;
-				UINT8 elites = 0;
+				UINT16 admins = 0;
+				UINT16 troops = 0;
+				UINT16 elites = 0;
 
 				while (turncoatsToCreate > 0)
 				{
@@ -3742,9 +3742,9 @@ void DailyUpdate()
 				}
 
 				// add the turncoats
-				selectedGroupPtr->pEnemyGroup->ubNumAdmins_Turncoat += admins;
-				selectedGroupPtr->pEnemyGroup->ubNumTroops_Turncoat += troops;
-				selectedGroupPtr->pEnemyGroup->ubNumElites_Turncoat += elites;
+				selectedGroupPtr->pEnemyGroup->ubNumAdmins_Turncoat = (UINT8)__min(255, selectedGroupPtr->pEnemyGroup->ubNumAdmins_Turncoat + admins);
+				selectedGroupPtr->pEnemyGroup->ubNumTroops_Turncoat = (UINT8)__min(255, selectedGroupPtr->pEnemyGroup->ubNumTroops_Turncoat + troops);
+				selectedGroupPtr->pEnemyGroup->ubNumElites_Turncoat = (UINT8)__min(255, selectedGroupPtr->pEnemyGroup->ubNumElites_Turncoat + elites);
 
 				LaptopSaveInfo.dIntelPool -= gRebelCommandSettings.fCreateTurncoatsIntelCost;
 			}

--- a/Strategic/Strategic AI.cpp
+++ b/Strategic/Strategic AI.cpp
@@ -6855,6 +6855,15 @@ void RemoveSoldiersFromGarrisonBasedOnComposition( INT32 iGarrisonID, UINT16 ubS
 	}
 	//No administrators are left.
 
+	// clamp total removals to available soldiers in sector
+	while( ubNumTroops + ubNumElites > pSector->ubNumTroops + pSector->ubNumElites )
+	{
+		if( ubNumElites )
+			ubNumElites--;
+		else
+			ubNumTroops--;
+	}
+
 	//Eliminate the troops
 	while( ubNumTroops )
 	{

--- a/Tactical/DisplayCover.cpp
+++ b/Tactical/DisplayCover.cpp
@@ -299,12 +299,14 @@ void AddCoverObjectToWorld( INT32 sGridNo, UINT16 usGraphic, BOOLEAN fRoof, BOOL
 
 	if( fRoof )
 	{
-		AddOnRoofToHead( sGridNo, usGraphic );
+		if( !AddOnRoofToHead( sGridNo, usGraphic ) )
+			return;
 		pNode = gpWorldLevelData[ sGridNo ].pOnRoofHead;
 	}
 	else
 	{
-		AddObjectToHead( sGridNo, usGraphic );
+		if( !AddObjectToHead( sGridNo, usGraphic ) )
+			return;
 		pNode = gpWorldLevelData[ sGridNo ].pObjectHead;
 	}
 

--- a/Tactical/DisplayCover.cpp
+++ b/Tactical/DisplayCover.cpp
@@ -409,8 +409,10 @@ static void RemoveCoverObjectsFromViewArea()
 		}
 	}
 
-	// Re-render the scene!
-	if ( fChanged )
+	// Don't set RENDER_FLAG_FULL here - the caller (DisplayCover) will
+	// immediately add new cover objects which sets the render flag.
+	// Setting it here causes a brief flicker between remove and add (#148).
+	if ( fChanged && gubDrawMode == DRAW_MODE_OFF )
 	{
 		SetRenderFlags(RENDER_FLAG_FULL);
 	}

--- a/Tactical/Item Types.cpp
+++ b/Tactical/Item Types.cpp
@@ -648,6 +648,10 @@ bool OBJECTTYPE::CanStack(OBJECTTYPE& sourceObject, int& numToStack)
 	//stacking control, restrict certain things here
 	if (numToStack > 0) {
 		if (exists() == true) {
+			if (sourceObject.usItem != usItem) {
+				return false;
+			}
+
 			if (Item[usItem].usItemClass == IC_MONEY) {
 				//money doesn't stack, it merges
 				// average out the status values using a weighted average...

--- a/Tactical/Items.cpp
+++ b/Tactical/Items.cpp
@@ -12792,9 +12792,7 @@ INT16 GetWornCamo( SOLDIERTYPE * pSoldier )
 				ttl += GetCamoBonus(&pSoldier->inv[HANDPOS]);
 			if (pSoldier->inv[SECONDHANDPOS].exists() == true && Item[pSoldier->inv[SECONDHANDPOS].usItem].usItemClass & IC_WEAPON)
 				ttl += GetCamoBonus(&pSoldier->inv[SECONDHANDPOS]);
-			if (pSoldier->inv[GUNSLINGPOCKPOS].exists() == true && Item[pSoldier->inv[GUNSLINGPOCKPOS].usItem].usItemClass & IC_WEAPON)
-				ttl += GetCamoBonus(&pSoldier->inv[GUNSLINGPOCKPOS]);
-		}
+			}
 	}
 
 	return __max(0, __min( ttl, ( 100 - gGameExternalOptions.bCamoKitArea ) ) );
@@ -12851,9 +12849,7 @@ INT16 GetWornUrbanCamo( SOLDIERTYPE * pSoldier )
 				ttl += GetUrbanCamoBonus(&pSoldier->inv[HANDPOS]);
 			if (pSoldier->inv[SECONDHANDPOS].exists() == true && Item[pSoldier->inv[SECONDHANDPOS].usItem].usItemClass & IC_WEAPON)
 				ttl += GetUrbanCamoBonus(&pSoldier->inv[SECONDHANDPOS]);
-			if (pSoldier->inv[GUNSLINGPOCKPOS].exists() == true && Item[pSoldier->inv[GUNSLINGPOCKPOS].usItem].usItemClass & IC_WEAPON)
-				ttl += GetUrbanCamoBonus(&pSoldier->inv[GUNSLINGPOCKPOS]);
-		}
+			}
 	}
 
 	return __max(0, __min( ttl, ( 100 - gGameExternalOptions.bCamoKitArea ) ) );
@@ -12910,9 +12906,7 @@ INT16 GetWornDesertCamo( SOLDIERTYPE * pSoldier )
 				ttl += GetDesertCamoBonus(&pSoldier->inv[HANDPOS]);
 			if (pSoldier->inv[SECONDHANDPOS].exists() == true && Item[pSoldier->inv[SECONDHANDPOS].usItem].usItemClass & IC_WEAPON)
 				ttl += GetDesertCamoBonus(&pSoldier->inv[SECONDHANDPOS]);
-			if (pSoldier->inv[GUNSLINGPOCKPOS].exists() == true && Item[pSoldier->inv[GUNSLINGPOCKPOS].usItem].usItemClass & IC_WEAPON)
-				ttl += GetDesertCamoBonus(&pSoldier->inv[GUNSLINGPOCKPOS]);
-		}
+			}
 	}
 	return __max(0, __min( ttl, ( 100 - gGameExternalOptions.bCamoKitArea ) ) );
 }
@@ -12968,9 +12962,7 @@ INT16 GetWornSnowCamo( SOLDIERTYPE * pSoldier )
 				ttl += GetSnowCamoBonus(&pSoldier->inv[HANDPOS]);
 			if (pSoldier->inv[SECONDHANDPOS].exists() == true && Item[pSoldier->inv[SECONDHANDPOS].usItem].usItemClass & IC_WEAPON)
 				ttl += GetSnowCamoBonus(&pSoldier->inv[SECONDHANDPOS]);
-			if (pSoldier->inv[GUNSLINGPOCKPOS].exists() == true && Item[pSoldier->inv[GUNSLINGPOCKPOS].usItem].usItemClass & IC_WEAPON)
-				ttl += GetSnowCamoBonus(&pSoldier->inv[GUNSLINGPOCKPOS]);
-		}
+			}
 	}
 	return __max(0, __min( ttl, ( 100 - gGameExternalOptions.bCamoKitArea ) ) );
 }

--- a/Tactical/Items.cpp
+++ b/Tactical/Items.cpp
@@ -10792,6 +10792,20 @@ INT32 GetObjectModifier( SOLDIERTYPE* pSoldier, OBJECTTYPE *pObj, UINT8 ubStance
 						iModifier += GetItemModifier(ObjList[pSoldier->bScopeMode], ubRef, usType);
 			}
 		}
+
+		if ( pSoldier != NULL && (pObj == &pSoldier->inv[HANDPOS] || pObj == &pSoldier->inv[SECONDHANDPOS]) )
+		{
+			for (INT8 bLoop = HELMETPOS; bLoop <= HEAD2POS; ++bLoop)
+			{
+				if (bLoop == HANDPOS || bLoop == SECONDHANDPOS)
+					continue;
+
+				if (pSoldier->inv[bLoop].exists())
+				{
+					iModifier += GetItemModifier(&(pSoldier->inv[bLoop]), ubRef, usType);
+				}
+			}
+		}
 	}
 
 	iModifier = __max(-100,iModifier);

--- a/Tactical/Overhead.cpp
+++ b/Tactical/Overhead.cpp
@@ -11689,12 +11689,12 @@ BOOLEAN VIPSlotFree()
 
 BOOLEAN SectorHasVIP( INT16 sMapX, INT16 sMapY )
 {
-	return (StrategicMap[SECTOR(sMapX, sMapY)].usFlags & ENEMY_VIP_PRESENT);
+	return (StrategicMap[CALCULATE_STRATEGIC_INDEX(sMapX, sMapY)].usFlags & ENEMY_VIP_PRESENT);
 }
 
 BOOLEAN PlayerKnowsAboutVIP( INT16 sMapX, INT16 sMapY )
 {
-	return (StrategicMap[SECTOR( sMapX, sMapY )].usFlags & ENEMY_VIP_PRESENT_KNOWN);
+	return (StrategicMap[CALCULATE_STRATEGIC_INDEX(sMapX, sMapY)].usFlags & ENEMY_VIP_PRESENT_KNOWN);
 }
 
 BOOLEAN TownHasVIP( INT8 bTownId )
@@ -11879,7 +11879,7 @@ void UpdateFastForwardMode(SOLDIERTYPE* pSoldier, INT8 bAction)
 
 void DeleteVIP( INT16 sMapX, INT16 sMapY )
 {
-	if ( StrategicMap[SECTOR( sMapX, sMapY )].usFlags & ENEMY_VIP_PRESENT_KNOWN )
+	if ( StrategicMap[CALCULATE_STRATEGIC_INDEX(sMapX, sMapY)].usFlags & ENEMY_VIP_PRESENT_KNOWN )
 	{
 		ScreenMsg( FONT_MCOLOR_LTYELLOW, MSG_INTERFACE, L"An important enemy VIP has been removed!" );
 	}
@@ -11887,7 +11887,7 @@ void DeleteVIP( INT16 sMapX, INT16 sMapY )
 	// if no other VIPs are here, delete flags
 	if ( NumSoldiersWithFlagInSector( ENEMY_TEAM, SOLDIER_VIP ) + NumSoldiersWithFlagInSector( CIV_TEAM, SOLDIER_VIP ) < 2 )
 	{
-		StrategicMap[SECTOR( sMapX, sMapY )].usFlags &= ~(ENEMY_VIP_PRESENT | ENEMY_VIP_PRESENT_KNOWN);
+		StrategicMap[CALCULATE_STRATEGIC_INDEX(sMapX, sMapY)].usFlags &= ~(ENEMY_VIP_PRESENT | ENEMY_VIP_PRESENT_KNOWN);
 	}
 
 	gStrategicStatus.usVIPsLeft = max( 0, gStrategicStatus.usVIPsLeft - 1 );
@@ -11898,7 +11898,7 @@ void VIPFleesToMeduna()
 	// not if we are already in Meduna
 	if ( StrategicMap[CALCULATE_STRATEGIC_INDEX( gWorldSectorX, gWorldSectorY )].bNameId != MEDUNA )
 	{
-		if ( StrategicMap[SECTOR( gWorldSectorX, gWorldSectorY )].usFlags & ENEMY_VIP_PRESENT_KNOWN )
+		if ( StrategicMap[CALCULATE_STRATEGIC_INDEX(gWorldSectorX, gWorldSectorY)].usFlags & ENEMY_VIP_PRESENT_KNOWN )
 		{
 			ScreenMsg( FONT_MCOLOR_LTYELLOW, MSG_INTERFACE, L"An enemy VIP has evaded your forces. You have no clue about his whereabouts" );
 		}
@@ -11906,14 +11906,14 @@ void VIPFleesToMeduna()
 		// if no other VIPs are here, delete flags
 		if ( NumSoldiersWithFlagInSector( ENEMY_TEAM, SOLDIER_VIP ) + NumSoldiersWithFlagInSector( CIV_TEAM, SOLDIER_VIP ) == 1 )
 		{
-			StrategicMap[SECTOR( gWorldSectorX, gWorldSectorY )].usFlags &= ~(ENEMY_VIP_PRESENT | ENEMY_VIP_PRESENT_KNOWN);
+			StrategicMap[CALCULATE_STRATEGIC_INDEX(gWorldSectorX, gWorldSectorY)].usFlags &= ~(ENEMY_VIP_PRESENT | ENEMY_VIP_PRESENT_KNOWN);
 		}
 
 		UINT16 usSector = 0;
 		if ( GetRandomEnemyTownSector( MEDUNA, usSector ) )
 		{
 			// place new VIP in sector
-			StrategicMap[usSector].usFlags |= ENEMY_VIP_PRESENT;
+			StrategicMap[SECTOR_INFO_TO_STRATEGIC_INDEX(usSector)].usFlags |= ENEMY_VIP_PRESENT;
 
 			// increase troop count - VIP plus bodyguards
 			SectorInfo[usSector].ubNumElites += 5;

--- a/Tactical/Rotting Corpses.cpp
+++ b/Tactical/Rotting Corpses.cpp
@@ -2925,7 +2925,8 @@ void CreateZombiefromCorpse( ROTTING_CORPSE *	pCorpse, UINT16 usAnimState )
 		*	make an exception for zombies every time...
 		*/
 		SOLDIERTYPE* pNewSoldier = iNewIndex;
-			
+
+		pNewSoldier->pathing.bLevel			= pCorpse->def.bLevel;
 		pNewSoldier->bActionPoints			= 60;
 		pNewSoldier->bInitialActionPoints	= 60;
 		pNewSoldier->sBreathRed				= 0;
@@ -3019,7 +3020,8 @@ void CreateZombiefromCorpse( ROTTING_CORPSE *	pCorpse, UINT16 usAnimState )
 				break;
 		}
 					
-		AddSoldierToSectorNoCalculateDirectionUseAnimation( iNewIndex, usAnimState, 0 );
+		if ( !AddSoldierToSectorNoCalculateDirectionUseAnimation( iNewIndex, usAnimState, 0 ) )
+			return;
 
 		// If this corpse has camo, use palette from hvobject
 		if ( pCorpse->def.ubType == ROTTING_STAGE2 )

--- a/Tactical/Tactical Save.cpp
+++ b/Tactical/Tactical Save.cpp
@@ -1288,7 +1288,7 @@ BOOLEAN LoadCurrentSectorsInformationFromTempItemsFile()
 		if ( GetMeanwhileID() == INTERROGATION )
 		{
 			//We no longer use item temp files during gameplay, so check for the sector in gAllWorldItems
-			if (SectorIsInWorldItems(gWorldSectorX, gWorldSectorY, gbWorldSectorZ))
+			if (SectorIsInWorldItems(gWorldSectorX, gWorldSectorY, gbWorldSectorZ) || GetSectorFlagStatus(gWorldSectorX, gWorldSectorY, gbWorldSectorZ, SF_ALREADY_LOADED))
 			{
 				if (!LoadAndAddWorldItemsFromTempFile(gWorldSectorX, gWorldSectorY, gbWorldSectorZ))
 					return(FALSE);
@@ -1309,7 +1309,7 @@ BOOLEAN LoadCurrentSectorsInformationFromTempItemsFile()
 	}
 
 	//We no longer use item temp files during gameplay, so check for the sector in gAllWorldItems
-	if (SectorIsInWorldItems(gWorldSectorX, gWorldSectorY, gbWorldSectorZ))
+	if (SectorIsInWorldItems(gWorldSectorX, gWorldSectorY, gbWorldSectorZ) || GetSectorFlagStatus(gWorldSectorX, gWorldSectorY, gbWorldSectorZ, SF_ALREADY_LOADED))
 	{
 		if (!LoadAndAddWorldItemsFromTempFile(gWorldSectorX, gWorldSectorY, gbWorldSectorZ))
 			return(FALSE);

--- a/Tactical/TeamTurns.cpp
+++ b/Tactical/TeamTurns.cpp
@@ -973,8 +973,8 @@ void StartInterrupt( void )
 
 			PlayJA2Sample( ENDTURN_1, RATE_11025, MIDVOLUME, 1, MIDDLEPAN );
 
-			// report any close call quotes for us here
-			for ( SoldierID id = gTacticalStatus.Team[ gbPlayerNum ].bFirstID; id <= gTacticalStatus.Team[ gbPlayerNum ].bLastID; ++id )
+			// report any close call quotes for us here - removed because triggering dialogue during interrupt transition causes softlock (deadlock in UI lock)
+			/*for ( SoldierID id = gTacticalStatus.Team[ gbPlayerNum ].bFirstID; id <= gTacticalStatus.Team[ gbPlayerNum ].bLastID; ++id )
 			{
 				SOLDIERTYPE *pSoldier = id;
 
@@ -991,7 +991,7 @@ void StartInterrupt( void )
 						pSoldier->flags.fCloseCall = FALSE;
 					}
 				}
-			}
+			}*/
 		}
 	}
 	else

--- a/Tactical/UI Cursors.cpp
+++ b/Tactical/UI Cursors.cpp
@@ -1326,7 +1326,7 @@ UINT8 HandleNonActivatedTargetCursor( SOLDIERTYPE *pSoldier, INT32 usMapPos , BO
 
 	}
 
-	if(gusUIFullTargetID == NOBODY && pSoldier->bDoAutofire && !pSoldier->flags.fDoSpread)	//reset autofire if we move the mouse off the target, however don't reset it if we are spread-bursting
+	if(!gfUIFullTargetFound && pSoldier->bDoAutofire && !pSoldier->flags.fDoSpread)	//reset autofire if we move the mouse off the target, however don't reset it if we are spread-bursting
 	{
 		if(gTacticalStatus.uiFlags & TURNBASED && (gTacticalStatus.uiFlags & INCOMBAT ))
 		{

--- a/TacticalAI/AIInternals.h
+++ b/TacticalAI/AIInternals.h
@@ -93,11 +93,13 @@ enum
 
 #define SEE_THRU_COVER_THRESHOLD		5		// min chance to get through
 
-#undef min
+#ifndef min
 #define min(a,b) ((a) < (b) ? (a) : (b))
+#endif
 
-#undef max
+#ifndef max
 #define max(a,b) ((a) > (b) ? (a) : (b))
+#endif
 
 // Added by feynman - remove all the ugly #ifdefs printf combinations for required for DebugAI
 //#define DEBUGAI

--- a/TacticalAI/NPC.cpp
+++ b/TacticalAI/NPC.cpp
@@ -130,6 +130,7 @@ INT8	gbFirstApproachFlags[4] = { 0x01, 0x02, 0x04, 0x08 };
 
 UINT8	gubAlternateNPCFileNumsForQueenMeanwhiles[] = { 160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176 };
 UINT8	gubAlternateNPCFileNumsForElliotMeanwhiles[] = { 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196 };
+UINT8	gubAlternateNPCFileNumsForJoeMeanwhiles[]   = { 200, 201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211, 212, 213, 214, 215, 216 };
 
 #ifdef JA2BETAVERSION
 BOOLEAN gfDisplayScreenMsgOnRecordUsage = FALSE;
@@ -205,6 +206,11 @@ NPCQuoteInfo * LoadQuoteFile( UINT8 ubNPC )
 		else if ( ubNPC == ELLIOT )
 		{
 			sprintf( zFileName, "NPCData\\%03d.npc", gubAlternateNPCFileNumsForElliotMeanwhiles[ GetMeanwhileID( ) ] );
+		}
+		// If we are joe....
+		else if ( ubNPC == JOE )
+		{
+			sprintf( zFileName, "NPCData\\%03d.npc", gubAlternateNPCFileNumsForJoeMeanwhiles[ GetMeanwhileID( ) ] );
 		}
 	}
 #endif
@@ -2459,7 +2465,7 @@ void Converse( UINT8 ubNPC, UINT8 ubMerc, INT8 bApproach, UINT32 uiApproachData 
                     if (pSoldier)
                     {
                         // stupid hack CC
-					    if (ubNPC == KYLE)
+					    if (ubNPC == KYLE || ubNPC == JOE) // also needed for Joe to follow Queen during interrogation (#92)
 					    {
 						    // make sure he has keys
 						    pSoldier->flags.bHasKeys = TRUE;

--- a/TacticalAI/NPC.cpp
+++ b/TacticalAI/NPC.cpp
@@ -946,6 +946,10 @@ UINT8 CalcDesireToTalk( UINT8 ubNPC, UINT8 ubMerc, INT8 bApproach )
 	{
 		iWillingness = 0;
 	}
+	else if (iWillingness > 255)
+	{
+		iWillingness = 255;
+	}
 
 	return( (UINT8) iWillingness );
 }

--- a/TileEngine/Explosion Control.cpp
+++ b/TileEngine/Explosion Control.cpp
@@ -494,6 +494,13 @@ void GenerateExplosionFromExplosionPointer( EXPLOSIONTYPE *pExplosion )
 	AniParams.sStartFrame = pExplosion->sCurrentFrame;
 	AniParams.uiFlags	= ANITILE_CACHEDTILE | ANITILE_FORWARD | ANITILE_EXPLOSION;
 
+	// Save the original explosion type for damage keyframe calculation,
+	// because the type gets changed to WATER_BLAST for visual effect
+	// but the WATER_BLAST damage keyframe (18) might never be reached
+	// if the animation file has fewer frames, preventing destruction of
+	// EXPLOSIVE-tagged objects on water tiles (issue #38).
+	UINT8 ubOriginalTypeID = ubTypeID;
+
 	// sevenfm: check level
 	//if ( TERRAIN_IS_WATER(ubTerrainType) )
 	if (Water(sGridNo, bLevel))
@@ -522,7 +529,7 @@ void GenerateExplosionFromExplosionPointer( EXPLOSIONTYPE *pExplosion )
 
 	if ( !( uiFlags & EXPLOSION_FLAG_DISPLAYONLY ) )
 	{
-		AniParams.ubKeyFrame2	= gExpAniData[ ubTypeID ].ubDamageKeyFrame; // Lesh: edit this line
+		AniParams.ubKeyFrame2	= gExpAniData[ ubOriginalTypeID ].ubDamageKeyFrame; // Lesh: edit this line: use original type for damage, not WATER_BLAST
 		AniParams.uiKeyFrame2Code = ANI_KEYFRAME_BEGIN_DAMAGE;
 	}
 	AniParams.uiUserData = usItem;

--- a/TileEngine/Explosion Control.cpp
+++ b/TileEngine/Explosion Control.cpp
@@ -344,7 +344,7 @@ void InternalIgniteExplosion( SoldierID ubOwner, INT16 sX, INT16 sY, INT16 sZ, I
 	UINT16 tmp;
 	if ( Item[ usItem ].usItemClass & IC_EXPLOSV && ubOwner != NOBODY && ubOwner < NUM_PROFILES && InARoom( sGridNo, &tmp ) )
 	{
-		HandleLoyaltyForDemolitionOfBuilding( ubOwner, Explosive[ Item[ usItem ].ubClassIndex ].ubDamage );
+		HandleLoyaltyForDemolitionOfBuilding( ubOwner, min( 20, Explosive[ Item[ usItem ].ubClassIndex ].ubDamage ) );
 
 		// Flugente: campaign stats
 		gCurrentIncident.usIncidentFlags |= INCIDENT_BUILDINGS_DAMAGED;

--- a/i18n/_ChineseText.cpp
+++ b/i18n/_ChineseText.cpp
@@ -6628,7 +6628,7 @@ STR16		zOptionsToggleText[] =
 	L"强制回合制模式",						// add forced turn mode
 	L"替代战略地图颜色", // Change color scheme of Strategic Map
 	L"替代子弹图像", // Show alternate bullet graphics (tracers)
-	L"佣兵外观造型", //L"Use Logical Bodytypes",
+	L"佣兵外观造型", //L"Use New Merc Graphics",
 	L"显示佣兵军衔",	// shows mercs ranks
 	L"显示脸部装备图",				
 	L"显示脸部装备图标",

--- a/i18n/_DutchText.cpp
+++ b/i18n/_DutchText.cpp
@@ -6630,7 +6630,7 @@ STR16		zOptionsToggleText[] =
 	L"Forced Turn Mode",					// add forced turn mode
 	L"Alternate Strategy-Map Colors",		// Change color scheme of Strategic Map
 	L"Alternate bullet graphics",			// Show alternate bullet graphics (tracers) // TODO.Translate
-	L"Logical Bodytypes",
+	L"Use New Merc Graphics",
 	L"Show Merc Ranks",						// shows mercs ranks		// TODO.Translate
 	L"Show Face gear graphics",				// TODO.Translate
 	L"Show Face gear icons",

--- a/i18n/_EnglishText.cpp
+++ b/i18n/_EnglishText.cpp
@@ -6628,7 +6628,7 @@ STR16		zOptionsToggleText[] =
 	L"Forced Turn Mode",					// add forced turn mode
 	L"Alternate Strategy Map Colors",		// Change color scheme of Strategic Map
 	L"Alternate Bullet Graphics",			// Show alternate bullet graphics (tracers)
-	L"Logical Bodytypes",
+	L"Use New Merc Graphics",
 	L"Show Merc Ranks",						// shows mercs ranks
 	L"Show Face Gear Graphics",
 	L"Show Face Gear Icons",

--- a/i18n/_FrenchText.cpp
+++ b/i18n/_FrenchText.cpp
@@ -6635,7 +6635,7 @@ STR16		zOptionsToggleText[] =
 	L"Mode tour par tour forcé",			// add forced turn mode
 	L"Couleur alternative carte",		// Change color scheme of Strategic Map
 	L"Montrer tirs alternatifs",			// Show alternate bullet graphics (tracers)
-	L"Logical Bodytypes",
+	L"Use New Merc Graphics",
 	L"Afficher grade du mercenaire",						// shows mercs ranks
 	L"Afficher équip. sur portrait",
 	L"Afficher icônes sur portrait",

--- a/i18n/_GermanText.cpp
+++ b/i18n/_GermanText.cpp
@@ -6502,7 +6502,7 @@ STR16 zOptionsToggleText[] =
 	L"Erzwungener Runden-Modus",			// add forced turn mode
 	L"Alternatives Kartenfarbschema",		// Change color scheme of Strategic Map
 	L"Alternative Projektil-Grafik",			// Show alternate bullet graphics (tracers)
-	L"Logical Bodytypes",
+	L"Use New Merc Graphics",
 	L"Söldnerrang anzeigen.",					// shows mercs ranks
 	L"Gesichtsequipment-Grafiken",			
 	L"Gesichtsequipment-Icons",

--- a/i18n/_ItalianText.cpp
+++ b/i18n/_ItalianText.cpp
@@ -6613,7 +6613,7 @@ STR16		zOptionsToggleText[] =
 	L"Forced Turn Mode",					// add forced turn mode
 	L"Alternate Strategy-Map Colors",		// Change color scheme of Strategic Map
 	L"Alternate bullet graphics",			// Show alternate bullet graphics (tracers) // TODO.Translate
-	L"Logical Bodytypes (WIP)",
+	L"Use New Merc Graphics",
 	L"Show Merc Ranks",						// shows mercs ranks	// TODO.Translate
 	L"Show Face gear graphics",				// TODO.Translate
 	L"Show Face gear icons",

--- a/i18n/_PolishText.cpp
+++ b/i18n/_PolishText.cpp
@@ -6631,7 +6631,7 @@ STR16		zOptionsToggleText[] =
 	L"Wymuś tryb turowy",					// add forced turn mode
 	L"Alternate Strategy-Map Colors",		// Change color scheme of Strategic Map
 	L"Alternate bullet graphics",			// Show alternate bullet graphics (tracers) // TODO.Translate
-	L"Logical Bodytypes",
+	L"Use New Merc Graphics",
 	L"Show Merc Ranks",				// shows mercs ranks		// TODO.Translate	
 	L"Show Face gear graphics",			// TODO.Translate
 	L"Show Face gear icons",


### PR DESCRIPTION
Fixes #148.

## Bug
Display cover indicators flicker because RemoveCoverObjectsFromViewArea sets RENDER_FLAG_FULL before AddCoverObjectsToViewArea also sets it. Between the remove and add operations, the screen fully re-renders without cover objects, causing a visible flicker.

## Fix
In RemoveCoverObjectsFromViewArea, only set RENDER_FLAG_FULL when draw mode is OFF (final cleanup). When cover is being updated (remove then add), the AddCoverObjectsToViewArea call that follows will set the render flag once, eliminating the intermediate empty render.

## Files
- Tactical/DisplayCover.cpp: Guard RENDER_FLAG_FULL in RemoveCoverObjectsFromViewArea