### PR TITLE
read language from Language.ini file

### DIFF
--- a/Ja2/GameSettings.h
+++ b/Ja2/GameSettings.h
@@ -8,8 +8,10 @@
 #include "Campaign Types.h"
 #include "environment.h"
 
+#include <string_view>
 #define				GAME_INI_FILE					"Ja2.ini"
 
+constexpr std::string_view LANGUAGE_INI_FILE{"Language.ini"};
 //If you add any options, MAKE sure you add the corresponding string to the Options Screen string array.
 //	 look up : zOptionsScreenHelpText , zOptionsToggleText
 //Also, define its initialization and add its load/save to INI lines in : InitGameSettings() , SaveGameSettings() , LoadGameSettings()

--- a/sgp/sgp.cpp
+++ b/sgp/sgp.cpp
@@ -949,12 +949,19 @@ void GetRuntimeSettings( )
 		SGP_THROW_IFFALSE( setlocale(LC_ALL, loc.utf8().c_str()), _BS(L"invalid locale : ") << loc << _BS::wget );
 	}
 
-	vfs::String language = oProps.getStringProperty("Ja2 Settings", L"LANGUAGE");
-	if(!language.empty())
+	vfs::PropertyContainer langProps;
+	langProps.initFromIniFile(std::string{LANGUAGE_INI_FILE});
+	auto langIni = langProps.getStringProperty("Language", L"LANGUAGE");
+	auto langCli = oProps.getStringProperty("Ja2 Settings", L"LANGUAGE");
+	std::string language{};
+	if(!langCli.empty())
 	{
-		std::string languageName = language.utf8();
-		SetLanguageFromName(languageName);
+		language = langCli.utf8();
 	}
+        if (!langIni.empty()) {
+          language = langIni.utf8();
+        }
+        SetLanguageFromName(language);
 
 	// Rebind every language table pointer to the resolved g_lang. Unconditional:
 	// with no LANGUAGE key this binds the build default, matching the static


### PR DESCRIPTION
to avoid having to ship a whole ja2.ini for languages that currently don't

command-line /language:german still works, but INI file is prioritized

format:

```
[Language]
LANGUAGE = ITALIAN
```