### PR TITLE
remove stray 'typename' before non-qualified names

### DIFF
--- a/Tactical/LogicalBodyTypes/Singleton.h
+++ b/Tactical/LogicalBodyTypes/Singleton.h
@@ -42,7 +42,7 @@ private :
 };
 
 
-template<typename T> typename T& Singleton<T>::Instance() {
+template<typename T> T& Singleton<T>::Instance() {
     if (Singleton::instance_ == 0) {
         Singleton::instance_ = CreateInstance();
         ScheduleForDestruction(Singleton::Destroy);
@@ -59,7 +59,7 @@ void Singleton<T>::Destroy() {
 }
 
 template<typename T>
-inline typename T* Singleton<T>::CreateInstance() {
+inline T* Singleton<T>::CreateInstance() {
     return new T();
 }
 
@@ -74,6 +74,6 @@ inline void Singleton<T>::DestroyInstance(T* p) {
 }
 
 template<typename T>
-typename T* Singleton<T>::instance_ = 0;
+T* Singleton<T>::instance_ = 0;
 
 #endif

--- a/Utils/popup_callback.h
+++ b/Utils/popup_callback.h
@@ -62,7 +62,7 @@
 	// three params, no return val
 
 	template<typename P1,typename P2,typename P3>
-	class popupCallbackFunction3<void,typename P1,typename P2,typename P3>: public popupCallback{
+	class popupCallbackFunction3<void,P1,P2,P3>: public popupCallback{
 	protected:
 		void (*fun)(P1,P2,P3);
 		P1 param_1;
@@ -144,7 +144,7 @@
 	// two params, no return val
 
 	template<typename P1,typename P2>
-	class popupCallbackFunction2<void, typename P1,typename P2>: public popupCallback{
+	class popupCallbackFunction2<void, P1,P2>: public popupCallback{
 	protected:
 		void (*fun)(P1,P2);
 		P1 param_1;
@@ -219,7 +219,7 @@
 
 	// no return type, one parameter
 	template <typename P1>
-	class popupCallbackFunction<void, typename P1> : public popupCallback{
+	class popupCallbackFunction<void, P1> : public popupCallback{
 	protected:
 		void (*fun)(P1);
 		P1 param_1;
@@ -260,7 +260,7 @@
 
 	// returns something, no parameter
 	template <typename R>
-	class popupCallbackFunction<typename R, void> : public popupCallback{
+	class popupCallbackFunction<R, void> : public popupCallback{
 	protected:
 		R (*fun)(void);
 	public:

--- a/Utils/popup_class.h
+++ b/Utils/popup_class.h
@@ -44,7 +44,7 @@
 		UINT32	classId;
 	} PopupIndex ;
 
-	extern std::vector<typename PopupIndex>	gPopupRegionIndex;
+	extern std::vector<PopupIndex>	gPopupRegionIndex;
 	extern std::vector<POPUP*>	gPopupIndex;
 
 	extern UINT32			gPopupRegionIndexCounter;


### PR DESCRIPTION
'typename' disambiguates a qualified dependent name, telling the compiler that something like T::iterator names a type rather than a value. Before a plain identifier there is nothing to disambiguate: P1 is already a type, and so is PopupIndex.

The grammar wants a qualified name after the keyword, so clang reports "expected a qualified name after 'typename'", drops the keyword and carries on -- 15175 times, since the offending declarations sit in widely included headers. MSVC accepts them without a word.

Semantics do not change. Both compilers already ignored the keyword, so the partial specialisations matched before this and match after it.

The diagnostic belongs to no -W group and therefore cannot be switched off with -Wno-, which makes deleting the tokens the only way to quiet it.