### PR TITLE
build on pull requests, drop per-branch push builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,65 +1,39 @@
 name: build
 
 on:
-  push:
-    branches:
-      - master
-    tags:
-      - 'v*'
   pull_request:
-  # allows to manually trigger a build
-  workflow_dispatch:
-    inputs:
-      assemble_release:
-        description: create release
-        required: false
-        default: false
-        type: boolean
-
-permissions:
-  contents: write
+  # release.yml calls this workflow, which is how master, tags and manual runs
+  # build. Keeping the release jobs out of here keeps them off the pull request
+  # check list, where they would only ever show up as skipped.
+  workflow_call:
 
 jobs:
   workflow_setup:
     runs-on: ubuntu-latest
-    outputs:
-      assemble_release: ${{ steps.global_vars.outputs.assemble_release }}
     steps:
-      - id: global_vars
-        name: Set global variables
-        run: |
-          set -eux
-          
-          full_release='${{ ( github.repository == '1dot13/source' && github.ref_name == 'master' ) || startsWith(github.ref, 'refs/tags/v') }}'
-          
-          if [[ '${{ inputs.assemble_release }}' == 'true' || ( '${{ inputs.assemble_release }}' == '' && "$full_release" == 'true' ) ]]
-          then
-            assemble_release='true'
-          else
-            assemble_release='false'
-          fi
-          echo "assemble_release=$assemble_release" >> $GITHUB_OUTPUT
+      - name: Checkout source
+        uses: actions/checkout@v7
+        with:
+          path: source
+          filter: 'tree:0'
+          fetch-depth: 0
 
-      - name: Clone repos metadata
+      - name: Clone gamedir metadata
         run: |
           set -eux
-          
+
           GAMEDIR_REPOSITORY=1dot13/gamedir
           GAMEDIR_LANGUAGES_REPOSITORY=1dot13/gamedir-languages
-          
+
           # filter tree is what makes this fast
-          git clone --config transfer.fsckobjects=false --tags --no-checkout --filter=tree:0 \
-            "https://github.com/$GITHUB_REPOSITORY" \
-            source
-          
           git clone --config transfer.fsckobjects=false --no-checkout --filter=tree:0 \
             https://github.com/$GAMEDIR_REPOSITORY \
             gamedir
-          
+
           git clone --config transfer.fsckobjects=false --no-checkout --filter=tree:0 \
             https://github.com/$GAMEDIR_LANGUAGES_REPOSITORY \
             gamedir-languages
-          
+
           mkdir dist/
           echo -n "
           GAMEDIR_REPOSITORY=$GAMEDIR_REPOSITORY
@@ -217,149 +191,3 @@ jobs:
         with:
           name: ${{ matrix.application }}
           path: build/*.exe
-
-  # only the game data differs per language, every package gets the same executables
-  assemble:
-    needs: [ workflow_setup, compile ]
-    if: needs.workflow_setup.outputs.assemble_release == 'true'
-    runs-on: windows-latest # required for case-insensitive filesystem handling
-    # at least English has to work
-    continue-on-error: ${{ matrix.language != 'English' }}
-    strategy:
-      fail-fast: false
-      matrix:
-        language: [Chinese, German, English, French, Polish, Italian, Dutch, Russian]
-
-    steps:
-      - name: Download versions.env
-        uses: actions/download-artifact@v8
-        with:
-          name: versions.env
-          path: artifacts
-      - name: Restore versions.env
-        shell: bash
-        run: cat artifacts/versions.env >> $GITHUB_ENV
-
-      - name: Checkout gamedir
-        uses: actions/checkout@v7
-        with:
-          repository: ${{ env.GAMEDIR_REPOSITORY }}
-          ref: ${{ env.GAMEDIR_COMMIT_SHA }}
-          path: gamedir
-
-      - name: Checkout gamedir-languages
-        if: matrix.language != 'English'
-        uses: actions/checkout@v7
-        with:
-          repository: ${{ env.GAMEDIR_LANGUAGES_REPOSITORY }}
-          ref: ${{ env.GAMEDIR_LANGUAGES_COMMIT_SHA }}
-          path: gamedir-languages
-
-      - name: Copy gamedir-languages files to gamedir
-        if: matrix.language != 'English'
-        shell: bash
-        run: |
-          set -eux
-          cp -a gamedir-languages/${{ matrix.language }}_Version/* gamedir/
-
-      - name: Download applications
-        uses: actions/download-artifact@v8
-        with:
-          pattern: ja2*
-          path: artifacts
-
-      - name: Copy application files to gamedir
-        shell: bash
-        run: |
-          set -eux
-          for APP in ja2 ja2mapeditor ja2ub ja2ubmapeditor
-          do
-            mv artifacts/${APP}/*.exe gamedir/${APP}.exe
-          done
-
-      - name: Create version information file
-        shell: bash
-        run: |
-          set -eux
-
-          # "-" separates words, "_" combines words, see double-click behavior
-          DIST_PREFIX='JA2_113'
-          DIST_NAME="${DIST_PREFIX}-${GAME_VERSION}-G${GAMEDIR_COMMIT_SHA:0:4}L${GAMEDIR_LANGUAGES_COMMIT_SHA:0:4}-${{ matrix.language }}"
-          echo "DIST_NAME=$DIST_NAME" >> $GITHUB_ENV
-
-          echo "If you encounter problems during gameplay, please provide the following version information:
-          Distribution Name: $DIST_NAME
-          Game Version: $GAME_VERSION
-          Language: ${{ matrix.language }}
-          Build Information: $GAME_BUILD_INFORMATION
-          Source Repository: $GITHUB_REPOSITORY
-          Source Commit SHA: $GITHUB_SHA
-          Source Commit Date: $SOURCE_COMMIT_DATETIME
-          Gamedir Repository: $GAMEDIR_REPOSITORY
-          Gamedir Commit SHA: $GAMEDIR_COMMIT_SHA
-          Gamedir Commit Date: $GAMEDIR_COMMIT_DATETIME
-          Gamedir Languages Repository: $GAMEDIR_LANGUAGES_REPOSITORY
-          Gamedir Languages Commit SHA: $GAMEDIR_LANGUAGES_COMMIT_SHA
-          Gamedir Languages Commit Date: $GAMEDIR_LANGUAGES_COMMIT_DATETIME
-          " > "gamedir/${DIST_PREFIX}-Version.txt"
-          cat "gamedir/${DIST_PREFIX}-Version.txt"
-
-      - name: Create release archive
-        shell: bash
-        run: |
-          set -eux
-          mkdir dist/
-          cd gamedir/
-          7z a -bb -xr'!.*' "../dist/${DIST_NAME}.7z" .
-
-      - name: Upload
-        uses: actions/upload-artifact@v7
-        with:
-          name: ${{ matrix.language }}_release
-          path: dist/
-          compression-level: 0
-
-  release:
-    needs: [ workflow_setup, assemble ]
-    if: needs.workflow_setup.outputs.assemble_release == 'true'
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Download artifacts
-      uses: actions/download-artifact@v8
-      with:
-        path: dist
-        pattern: '*_release'
-        merge-multiple: true
-
-    - name: Checkout Repo
-      uses: actions/checkout@v7
-      with:
-        path: source
-        fetch-depth: 1
-        sparse-checkout: 'README.md'
-    - name: Create latest pre-release
-      if: github.ref == 'refs/heads/master'
-      working-directory: source
-      run: |
-        gh release delete latest --cleanup-tag || true
-        git tag -d latest || true
-        git push --delete origin refs/tags/latest || true
-        git tag latest
-        git push --force origin refs/tags/latest
-        sleep 15 # make sure github can find the tag for gh release
-        gh release create latest ../dist/* \
-          --generate-notes \
-          --title "Latest (unstable)" \
-          --verify-tag \
-          --prerelease
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Upload to tagged release
-      if: startsWith(github.ref, 'refs/tags/v')
-      working-directory: source
-      run: |
-        gh release upload "$GITHUB_REF_NAME" ../dist/* --clobber
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,9 +3,10 @@ name: build
 on:
   push:
     branches:
-      - '**'
+      - master
     tags:
       - 'v*'
+  pull_request:
   # allows to manually trigger a build
   workflow_dispatch:
     inputs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,176 @@
+name: release
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - 'v*'
+  # allows to manually trigger a build
+  workflow_dispatch:
+    inputs:
+      assemble_release:
+        description: create release
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    uses: ./.github/workflows/build.yml
+
+  # only the game data differs per language, every package gets the same executables
+  assemble:
+    needs: build
+    # a manual run only assembles when asked for it. Otherwise every tag does,
+    # and master does in the upstream repository, which is the only one with
+    # somewhere to publish to
+    if: >-
+      ${{ github.event_name == 'workflow_dispatch' && inputs.assemble_release
+          || github.event_name != 'workflow_dispatch'
+             && ( ( github.repository == '1dot13/source' && github.ref_name == 'master' )
+                  || startsWith(github.ref, 'refs/tags/v') ) }}
+    runs-on: windows-latest # required for case-insensitive filesystem handling
+    # at least English has to work
+    continue-on-error: ${{ matrix.language != 'English' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [Chinese, German, English, French, Polish, Italian, Dutch, Russian]
+
+    steps:
+      - name: Download versions.env
+        uses: actions/download-artifact@v8
+        with:
+          name: versions.env
+          path: artifacts
+      - name: Restore versions.env
+        shell: bash
+        run: cat artifacts/versions.env >> $GITHUB_ENV
+
+      - name: Checkout gamedir
+        uses: actions/checkout@v7
+        with:
+          repository: ${{ env.GAMEDIR_REPOSITORY }}
+          ref: ${{ env.GAMEDIR_COMMIT_SHA }}
+          path: gamedir
+
+      - name: Checkout gamedir-languages
+        if: matrix.language != 'English'
+        uses: actions/checkout@v7
+        with:
+          repository: ${{ env.GAMEDIR_LANGUAGES_REPOSITORY }}
+          ref: ${{ env.GAMEDIR_LANGUAGES_COMMIT_SHA }}
+          path: gamedir-languages
+
+      - name: Copy gamedir-languages files to gamedir
+        if: matrix.language != 'English'
+        shell: bash
+        run: |
+          set -eux
+          cp -a gamedir-languages/${{ matrix.language }}_Version/* gamedir/
+
+      - name: Download applications
+        uses: actions/download-artifact@v8
+        with:
+          pattern: ja2*
+          path: artifacts
+
+      - name: Copy application files to gamedir
+        shell: bash
+        run: |
+          set -eux
+          for APP in ja2 ja2mapeditor ja2ub ja2ubmapeditor
+          do
+            mv artifacts/${APP}/*.exe gamedir/${APP}.exe
+          done
+
+      - name: Create version information file
+        shell: bash
+        run: |
+          set -eux
+
+          # "-" separates words, "_" combines words, see double-click behavior
+          DIST_PREFIX='JA2_113'
+          DIST_NAME="${DIST_PREFIX}-${GAME_VERSION}-G${GAMEDIR_COMMIT_SHA:0:4}L${GAMEDIR_LANGUAGES_COMMIT_SHA:0:4}-${{ matrix.language }}"
+          echo "DIST_NAME=$DIST_NAME" >> $GITHUB_ENV
+
+          echo "If you encounter problems during gameplay, please provide the following version information:
+          Distribution Name: $DIST_NAME
+          Game Version: $GAME_VERSION
+          Language: ${{ matrix.language }}
+          Build Information: $GAME_BUILD_INFORMATION
+          Source Repository: $GITHUB_REPOSITORY
+          Source Commit SHA: $GITHUB_SHA
+          Source Commit Date: $SOURCE_COMMIT_DATETIME
+          Gamedir Repository: $GAMEDIR_REPOSITORY
+          Gamedir Commit SHA: $GAMEDIR_COMMIT_SHA
+          Gamedir Commit Date: $GAMEDIR_COMMIT_DATETIME
+          Gamedir Languages Repository: $GAMEDIR_LANGUAGES_REPOSITORY
+          Gamedir Languages Commit SHA: $GAMEDIR_LANGUAGES_COMMIT_SHA
+          Gamedir Languages Commit Date: $GAMEDIR_LANGUAGES_COMMIT_DATETIME
+          " > "gamedir/${DIST_PREFIX}-Version.txt"
+          cat "gamedir/${DIST_PREFIX}-Version.txt"
+
+      - name: Create release archive
+        shell: bash
+        run: |
+          set -eux
+          mkdir dist/
+          cd gamedir/
+          7z a -bb -xr'!.*' "../dist/${DIST_NAME}.7z" .
+
+      - name: Upload
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ matrix.language }}_release
+          path: dist/
+          compression-level: 0
+
+  # a skipped assemble skips this too, so it needs no condition of its own
+  release:
+    needs: assemble
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Download artifacts
+      uses: actions/download-artifact@v8
+      with:
+        path: dist
+        pattern: '*_release'
+        merge-multiple: true
+
+    - name: Checkout Repo
+      uses: actions/checkout@v7
+      with:
+        path: source
+        fetch-depth: 1
+        sparse-checkout: 'README.md'
+    - name: Create latest pre-release
+      if: github.ref == 'refs/heads/master'
+      working-directory: source
+      run: |
+        gh release delete latest --cleanup-tag || true
+        git tag -d latest || true
+        git push --delete origin refs/tags/latest || true
+        git tag latest
+        git push --force origin refs/tags/latest
+        sleep 15 # make sure github can find the tag for gh release
+        gh release create latest ../dist/* \
+          --generate-notes \
+          --title "Latest (unstable)" \
+          --verify-tag \
+          --prerelease
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Upload to tagged release
+      if: startsWith(github.ref, 'refs/tags/v')
+      working-directory: source
+      run: |
+        gh release upload "$GITHUB_REF_NAME" ../dist/* --clobber
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
A push builds in the repository it was pushed to, so a contributor's branch builds in their fork and the base repository sees nothing. Without a run of its own there is no check on the pull request for branch protection to require, so trigger on pull_request as well.

Push builds narrow to master and v* tags: with pull requests covered, building every branch push only duplicated the same commit's build across four Windows matrix jobs. Master still builds so the "latest" pre-release keeps updating. A branch with no pull request open builds via workflow_dispatch.