### PR TITLE
name the application executable when copying to the gamedir

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,7 +85,7 @@ jobs:
           set -eux
           for APP in ja2 ja2mapeditor ja2ub ja2ubmapeditor
           do
-            mv artifacts/${APP}/*.exe gamedir/${APP}.exe
+            mv artifacts/${APP}/${APP}.exe gamedir/${APP}.exe
           done
 
       - name: Create version information file


### PR DESCRIPTION
every build artifact also carries Ja2Export.exe, so the glob handed mv three paths and it failed with "target 'gamedir/ja2.exe' is not a directory". The assemble job runs on Windows, so the lowercase matrix name matches the uppercase target file.