### PR TITLE
Fix exception handling, crash dumping and add telemetry

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,9 @@ jobs:
           SOURCE_COMMIT_DATETIME=$(TZ=UTC0 git log -1 --date=iso-strict-local --format=%cd $GITHUB_SHA)
           SOURCE_COMMIT_DATE=$(TZ=UTC0 git log -1 --date=short-local --format=%cd $GITHUB_SHA)
           
-          # GAME_VERSION is used to detect outdated save games and is the main version used for tracking
+          # GAME_VERSION is the release's name: it labels the dist archives and leads
+          # the in-game version line. Outdated save games are detected with GIT_SHA
+          # below, which is what czVersionString holds.
           if [[ "$GITHUB_REF_TYPE" == 'tag' ]]
           then
             # if we build for a specific tag, use that as the game version
@@ -62,10 +64,13 @@ jobs:
             # - v1.13-5-7g7ffa
             GAME_VERSION="$(git describe --tags --match='v[0-9]*' $GITHUB_SHA || echo v0-$(git rev-list --skip 1 --count $GITHUB_SHA)-g${GITHUB_SHA:0:8})"
           fi
-          # max 15 CHAR8
+          # keeps archive names bounded; nothing binary depends on this any more
           GAME_VERSION="${GAME_VERSION:0:15}"
           
-          GAME_BUILD_INFORMATION="$SOURCE_COMMIT_DATE GitHub $GITHUB_REPOSITORY"
+          # the version line shown in game. It leads with GAME_VERSION because
+          # czVersionString is no longer displayed beside it: this is the only
+          # place a player can read which release they are running.
+          GAME_BUILD_INFORMATION="$GAME_VERSION $SOURCE_COMMIT_DATE GitHub $GITHUB_REPOSITORY"
           # in case of a branch or if the tag is truncated
           if [[ "$GAME_VERSION" != *"$GITHUB_REF_NAME"* ]]
           then
@@ -73,11 +78,19 @@ jobs:
           fi
           # max 255 CHAR16
           GAME_BUILD_INFORMATION="${GAME_BUILD_INFORMATION:0:255}"
-          
+
+          # the machine-readable build identity stamped into czVersionString, which
+          # is both the savegame compatibility key and the crash-report key. Pinned
+          # here rather than derived per job, so the parallel builds cannot disagree,
+          # and left unsuffixed: this names a commit whose tree we really built.
+          # See Ja2/CMakeLists.txt for why it is 9 hex and nothing else.
+          GIT_SHA="${GITHUB_SHA:0:9}"
+
           echo -n "
           SOURCE_COMMIT_DATETIME=$SOURCE_COMMIT_DATETIME
           GAME_VERSION=$GAME_VERSION
           GAME_BUILD_INFORMATION=$GAME_BUILD_INFORMATION
+          GIT_SHA=$GIT_SHA
           " >> ../dist/versions.env
 
       # due to building everything in parallel, versions should be pinned at the start so everything builds based on the same versions
@@ -144,17 +157,6 @@ jobs:
         shell: bash
         run: cat artifacts/versions.env >> $GITHUB_ENV
 
-      # TODO: Move this into CMake, just taking the GitHub Actions parameters as -D variables
-      - name: Update GameVersion.cpp
-        shell: bash
-        run: |
-          set -eux
-          GAME_VERSION=$(echo "$GAME_VERSION" | tr -cd '[:print:]' | tr -d '"\\')
-          GAME_BUILD=$(echo "$GAME_BUILD_INFORMATION" | tr -cd '[:print:]' | tr -d '"\\')
-          sed -i "s|@Version@|${GAME_VERSION:0:15}|" Ja2/GameVersion.cpp
-          sed -i "s|@Build@|${GAME_BUILD:0:255}|" Ja2/GameVersion.cpp
-          cat Ja2/GameVersion.cpp
-
       - name: Prepare build properties
         shell: bash
         run: |
@@ -176,7 +178,11 @@ jobs:
         run: |
           # sccache can only cache MSVC objects when the debug information is embedded
           # in them (/Z7) instead of collected in a shared PDB (/Zi, the CMake default)
-          cmake -S . -B build -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DApplications="$Env:JA2Application"
+          #
+          # The build identity comes from versions.env, pinned once for the whole
+          # workflow. Handing it over is what makes this a packaged build rather
+          # than a local one; CMake never asks git who we are.
+          cmake -S . -B build -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DApplications="$Env:JA2Application" -DGAME_BUILD_INFORMATION="$Env:GAME_BUILD_INFORMATION" -DGIT_SHA="$Env:GIT_SHA"
       - name: Build
         run: |
           cmake --build build/ -- -v

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,6 +130,7 @@ set(Ja2_Libraries
 "dbghelp.lib"
 "winmm.lib"
 "ws2_32.lib"
+"winhttp.lib"
 bfVFS
 Lua
 Multiplayer

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,9 @@ include(cmake/Warnings.cmake)
 # ja2export utility
 add_subdirectory("export/src")
 
+# developer tools, built alongside the game
+add_subdirectory(tools)
+
 # static libraries whose translation units don't rely on Application preprocessor definitions.
 add_subdirectory(lua)
 add_subdirectory(Multiplayer)

--- a/Ja2/CMakeLists.txt
+++ b/Ja2/CMakeLists.txt
@@ -1,3 +1,47 @@
+# Stamp the build's identity into GameVersion.cpp. Both strings come from the
+# caller with -D, and CI passes them: it pins them once, where it decides what the
+# release is, so the parallel build jobs cannot stamp identities that disagree.
+#
+# A build nobody identified is a local build, and says so rather than guessing
+# from HEAD. Keeping such a guess honest would mean re-running configure on every
+# commit, and it would buy nothing: only what we package is archived with its PDB,
+# and a local crash report is symbolized against the PDB next to the exe.
+#
+# GIT_SHA lands in czVersionString, which is both the savegame compatibility key
+# and the crash-report key. It is the bare short SHA and nothing else — a `git
+# describe` string cannot serve here, because czVersionString is only 16 bytes and
+# describe puts the SHA last, so it is exactly the discriminating part that would
+# get clipped off. The budget is 15 chars + NUL: the string is stored in the
+# savegame header as SAVED_GAME_HEADER::zGameVersionNumber (GAME_VERSION_LENGTH),
+# so its size is a binary format constant and cannot grow. CI passes 9 hex, well
+# past what uniqueness needs (git's own auto-abbrev picks 8 for this repo).
+# Overshooting it is an error rather than a truncation, because a clipped SHA is
+# how two different builds end up claiming to be the same one.
+if(NOT GIT_SHA)
+	set(GIT_SHA "local")
+endif()
+string(LENGTH "${GIT_SHA}" _length)
+if(_length GREATER 15)
+	message(FATAL_ERROR "GIT_SHA is ${_length} characters; czVersionString holds 15")
+endif()
+
+# zBuildInformation is the version line shown on screen, CHAR16[256]. Nothing
+# parses it, so it carries the version in full and truncation costs only
+# readability.
+if(NOT GAME_BUILD_INFORMATION)
+	string(TIMESTAMP _buildDate "%Y-%m-%d" UTC)
+	set(GAME_BUILD_INFORMATION "local build ${_buildDate}")
+endif()
+string(LENGTH "${GAME_BUILD_INFORMATION}" _length)
+if(_length GREATER 255)
+	string(SUBSTRING "${GAME_BUILD_INFORMATION}" 0 255 GAME_BUILD_INFORMATION)
+endif()
+
+configure_file(
+	"${CMAKE_CURRENT_SOURCE_DIR}/GameVersion.cpp.in"
+	"${CMAKE_CURRENT_BINARY_DIR}/GameVersion.cpp"
+	@ONLY)
+
 set(Ja2Src
 "${CMAKE_CURRENT_SOURCE_DIR}/aniviewscreen.cpp"
 "${CMAKE_CURRENT_SOURCE_DIR}/Credits.cpp"
@@ -7,7 +51,7 @@ set(Ja2Src
 "${CMAKE_CURRENT_SOURCE_DIR}/gameloop.cpp"
 "${CMAKE_CURRENT_SOURCE_DIR}/gamescreen.cpp"
 "${CMAKE_CURRENT_SOURCE_DIR}/GameSettings.cpp"
-"${CMAKE_CURRENT_SOURCE_DIR}/GameVersion.cpp"
+"${CMAKE_CURRENT_BINARY_DIR}/GameVersion.cpp"
 "${CMAKE_CURRENT_SOURCE_DIR}/HelpScreen.cpp"
 "${CMAKE_CURRENT_SOURCE_DIR}/Init.cpp"
 "${CMAKE_CURRENT_SOURCE_DIR}/Intro.cpp"

--- a/Ja2/GameSettings.cpp
+++ b/Ja2/GameSettings.cpp
@@ -4299,7 +4299,7 @@ void FreeGameExternalOptions()
 void DisplayGameSettings( )
 {
 	//Display the version number
-	ScreenMsg( FONT_MCOLOR_LTYELLOW, MSG_INTERFACE, L"%s: %s %S %s", pMessageStrings[ MSG_VERSION ], zProductLabel, czVersionString, zBuildInformation );
+	ScreenMsg( FONT_MCOLOR_LTYELLOW, MSG_INTERFACE, L"%s: %s %s", pMessageStrings[ MSG_VERSION ], zProductLabel, zBuildInformation );
 
 	//Display the difficulty level
 	ScreenMsg( FONT_MCOLOR_LTYELLOW, MSG_INTERFACE, L"%s: %s", gzGIOScreenText[ GIO_DIF_LEVEL_TEXT ], zDiffSetting[gGameOptions.ubDifficultyLevel].szDiffName );

--- a/Ja2/GameVersion.cpp.in
+++ b/Ja2/GameVersion.cpp.in
@@ -39,7 +39,7 @@
 
 #endif
 
-CHAR8		czVersionString[16]	= { "@Version@" };
-CHAR16		zBuildInformation[256]	= { L"@Build@" };
+CHAR8          czVersionString[16]     = { "@GIT_SHA@" };
+CHAR16         zBuildInformation[256]  = { L"@GAME_BUILD_INFORMATION@" };
 
 // SAVE_GAME_VERSION is defined in header, change it there

--- a/Ja2/GameVersion.h
+++ b/Ja2/GameVersion.h
@@ -13,9 +13,15 @@ extern "C" {
 
 // name of the product, Unfinished Business, Map Editor etc..
 extern	CHAR16		zProductLabel[64];
-// used for save game comparison
+// this build's identity, stamped in by CMake from -DGIT_SHA. A packaged build sets
+// it to the bare short commit SHA and nothing else, so it names that build exactly;
+// a build nobody identified reads "local". Used for save game comparison, and
+// stamped into crash reports so a packaged build's report can be matched to the PDB
+// archived beside it for offline symbolization.
 extern	CHAR8		czVersionString[16];
-// can contain information regarding the build: what git ref was the base (tag, branch), by whom, commit date, build date, etc..
+// human-readable build description, stamped in from -DGAME_BUILD_INFORMATION: the
+// release name, its date and where it was built, or "local build <date>". For
+// display only — never compared against, so it is free to change shape.
 extern	CHAR16		zBuildInformation[256];
 
 //ADB:	I needed these here so I moved them, and why put them in *.cpp anyways?

--- a/Ja2/jascreens.cpp
+++ b/Ja2/jascreens.cpp
@@ -354,9 +354,9 @@ UINT32 InitScreenHandle(void)
 		SetFontForeground( FONT_MCOLOR_WHITE );
 
 #ifdef _DEBUG
-		mprintf( 10, 10, L"%s: %s Debug %S %s", pMessageStrings[ MSG_VERSION ], zProductLabel, czVersionString, zBuildInformation );
+		mprintf( 10, 10, L"%s: %s Debug %s", pMessageStrings[ MSG_VERSION ], zProductLabel, zBuildInformation );
 #else
-		mprintf( 10, 10, L"%s: %s %S %s", pMessageStrings[ MSG_VERSION ], zProductLabel, czVersionString, zBuildInformation );
+		mprintf( 10, 10, L"%s: %s %s", pMessageStrings[ MSG_VERSION ], zProductLabel, zBuildInformation );
 #endif
 
 #if defined JA2BETAVERSION

--- a/crash-telemetry/.dev.vars.example
+++ b/crash-telemetry/.dev.vars.example
@@ -1,0 +1,8 @@
+# Copy to .dev.vars for `wrangler dev`. The deployed Worker does NOT read this
+# file — set that one with `wrangler secret put DISCORD_WEBHOOK`.
+#
+# There is no stub value that works: a webhook URL you do not own answers 401 or
+# 404, which the Worker correctly turns into a 503. Use a real webhook, pointed at
+# a throwaway channel rather than the live one. .dev.vars therefore holds a live
+# credential and is gitignored — keep it that way.
+DISCORD_WEBHOOK="https://discord.com/api/webhooks/<id>/<token>"

--- a/crash-telemetry/.gitignore
+++ b/crash-telemetry/.gitignore
@@ -1,0 +1,7 @@
+# Holds a live Discord webhook URL. Never commit it.
+.dev.vars
+
+# Regenerable local state: build cache, miniflare storage, account cache.
+.wrangler/
+
+node_modules/

--- a/crash-telemetry/README.md
+++ b/crash-telemetry/README.md
@@ -96,6 +96,10 @@ a millisecond of CPU — the time spent waiting on Discord is not metered.
 
 No authentication. The endpoint is public and its URL ships in every player's
 `Ja2.ini`, so assume it will eventually be found; the size and `*** CRASH` checks
-only keep out drive-by scanners. Report contents are attacker-controlled text, which
-is why the summary line strips markdown from the handle and sends
+only keep out drive-by scanners. Every field the summary line quotes is therefore
+attacker-chosen, not just the handle: all of them go through `clean()`, which keeps
+printable ASCII minus Discord's markup and link characters, and the post sends
 `allowed_mentions: {parse: []}`. Blast radius of abuse is a message we delete.
+
+The per-IP limiter does nothing against a distributed flood — that would cost
+channel noise and the 100k/day request budget, not money.

--- a/crash-telemetry/README.md
+++ b/crash-telemetry/README.md
@@ -1,0 +1,101 @@
+# Crash telemetry sink
+
+Receives the crash reports `sgp::processCrashTelemetry` uploads and posts them to a
+Discord channel. Stores nothing — a report is only useful next to the matching PDB,
+which lives on a developer's machine.
+
+## Deploy
+
+```sh
+npm i -g wrangler                     # once
+wrangler login                        # once
+wrangler deploy                       # creates the Worker
+wrangler secret put DISCORD_WEBHOOK   # paste the channel's webhook URL
+```
+
+Deploy first: `secret put` needs the Worker to already exist. To point it at a
+different channel later, run `secret put` again — it overwrites in place and
+redeploys, no other step needed. Secrets are write-only; `wrangler secret list`
+shows names, never values.
+
+Then put the printed `https://ja2-crash-telemetry.<subdomain>.workers.dev` into
+`gamedir/Ja2.ini`:
+
+```ini
+[Ja2 Settings]
+CRASH_TELEMETRY_URL = https://ja2-crash-telemetry.<subdomain>.workers.dev
+```
+
+Empty or missing key = telemetry off, reports just accumulate locally.
+
+## Test without the game
+
+```sh
+node test.mjs             # status-code contract, Discord payload shape. No network.
+```
+
+Against a real local instance:
+
+```sh
+cp .dev.vars.example .dev.vars   # put a webhook URL in it, see below
+wrangler dev                     # local, http://localhost:8787
+
+printf '*** CRASH  code=C0000005 ***\r\n  build test\r\n' \
+  | curl -X POST --data-binary @- localhost:8787
+```
+
+Expect `204` for that, `400` for junk (`curl -X POST -d hello localhost:8787`). Any
+real `crash_report_*.txt` out of a gamedir works as a body too.
+
+**`wrangler dev` does not see `wrangler secret put`.** Secrets set that way go to the
+deployed Worker; local dev reads `.dev.vars` and nothing else. Without it every
+request answers `503 not configured`. Each 503 names its own cause in the response
+body and in wrangler's console.
+
+There is no stub webhook value that returns 2xx — a Discord webhook URL you do not
+own answers 401 or 404, which the Worker correctly turns into a 503. So `.dev.vars`
+needs a real webhook; point it at a throwaway channel rather than the live one.
+`node test.mjs` is the path that needs no webhook at all.
+
+## Status codes are a contract
+
+The client (`reportIsSettled()` in `sgp/crash_telemetry.cpp`) deletes its copy of a
+report on 2xx and on 400/413/415, and keeps it on everything else. So:
+
+| Status | Meaning | Client does |
+| --- | --- | --- |
+| 2xx | delivered | deletes its copy |
+| 400 | not a crash report, or too big | deletes its copy |
+| 429 | throttled | keeps it, retries next launch |
+| 5xx | our fault (Discord down, rate-limited, secret unset) | keeps it, retries next launch |
+
+**Never answer a settling 4xx for a failure on our side** — that silently destroys
+the report. 429 is the one 4xx that is safe here, precisely because the client does
+not settle it.
+
+## Rate limiting
+
+A per-IP cap, via the `UPLOAD_LIMITER` binding in `wrangler.toml`, checked before
+the body is read. The ceiling (50/minute) has to clear `kMaxUploadsPerRun` (20) in
+the client, or a player draining a backlog throttles themselves.
+
+This has to be a binding with a `.limit()` call in `worker.js`, not a dashboard
+rule: WAF rate limiting rules need a zone, and a `workers.dev` subdomain is not
+one. The counter is per-colo and best-effort, so treat the number as a rough
+ceiling — it is there to keep scanners out of the channel, not to be exact.
+
+Adding the binding from the Cloudflare dashboard instead would leave `wrangler.toml`
+out of sync, and the next `wrangler deploy` would drop it. Edit the file.
+
+## Free tier
+
+100k requests/day and 10 ms CPU per invocation. Forwarding a few KB costs well under
+a millisecond of CPU — the time spent waiting on Discord is not metered.
+
+## Not done
+
+No authentication. The endpoint is public and its URL ships in every player's
+`Ja2.ini`, so assume it will eventually be found; the size and `*** CRASH` checks
+only keep out drive-by scanners. Report contents are attacker-controlled text, which
+is why the summary line strips markdown from the handle and sends
+`allowed_mentions: {parse: []}`. Blast radius of abuse is a message we delete.

--- a/crash-telemetry/package.json
+++ b/crash-telemetry/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "ja2-crash-telemetry",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node test.mjs",
+    "deploy": "wrangler deploy"
+  }
+}

--- a/crash-telemetry/test.mjs
+++ b/crash-telemetry/test.mjs
@@ -43,7 +43,7 @@ assert.equal(await sent.body.get("files[0]").text(), REPORT);
 
 // junk: client should delete these, so they must be 400
 assert.equal((await post("hello")).status, 400);
-assert.equal((await post("x".repeat(64 * 1024 + 1))).status, 400);
+assert.equal((await post("x".repeat(32 * 1024 + 1))).status, 400);
 
 // throttled: 429, and nothing reaches Discord. reportIsSettled() leaves 429
 // unsettled, so the client keeps the report for next launch.

--- a/crash-telemetry/test.mjs
+++ b/crash-telemetry/test.mjs
@@ -1,0 +1,62 @@
+// node test.mjs — exercises the status-code contract the client depends on.
+import assert from "node:assert";
+import worker from "./worker.js";
+
+const REPORT = `
+*** CRASH  code=C0000005  eip=0071D5A0  esp=202BF99C  ebp=202BFA18 ***
+  time 2026-07-26 10:41:02 UTC
+  build 6a941c06
+  handle @marco*evil
+  access violation: read from 00000002
+  [0] 0071D5A0
+  [1] 006BE7DE
+`;
+
+let sent = null;               // what we handed Discord on the last call
+let upstream = () => new Response(null, { status: 204 });
+globalThis.fetch = async (url, init) => { sent = init; return upstream(); };
+
+let throttled = false;
+const ENV = {
+  DISCORD_WEBHOOK: "https://discord.test/hook",
+  UPLOAD_LIMITER: { limit: async () => ({ success: !throttled }) },
+};
+
+const post = (body, env = ENV) =>
+  worker.fetch(new Request("https://x/", { method: "POST", body }), env);
+
+// happy path
+let r = await post(REPORT);
+assert.equal(r.status, 204);
+const content = JSON.parse(sent.body.get("payload_json")).content;
+assert.match(content, /C0000005/);
+assert.match(content, /read from 00000002/);
+assert.match(content, /build `6a941c06`/);
+assert.match(content, /marcoevil/);            // markdown and @ stripped from the handle
+assert.deepEqual(JSON.parse(sent.body.get("payload_json")).allowed_mentions, { parse: [] });
+assert.equal(await sent.body.get("files[0]").text(), REPORT);
+
+// junk: client should delete these, so they must be 400
+assert.equal((await post("hello")).status, 400);
+assert.equal((await post("x".repeat(64 * 1024 + 1))).status, 400);
+
+// throttled: 429, and nothing reaches Discord. reportIsSettled() leaves 429
+// unsettled, so the client keeps the report for next launch.
+throttled = true;
+sent = null;
+assert.equal((await post(REPORT)).status, 429);
+assert.equal(sent, null);
+throttled = false;
+
+// our failures: client must keep the report, so these must be 5xx
+upstream = () => new Response(null, { status: 429 });          // Discord rate limit
+assert.equal((await post(REPORT)).status, 503);
+upstream = () => { throw new Error("network"); };
+assert.equal((await post(REPORT)).status, 503);
+upstream = () => new Response(null, { status: 204 });
+assert.equal((await post(REPORT, {})).status, 503);            // secret not set
+
+// wrong method
+assert.equal((await worker.fetch(new Request("https://x/"), {})).status, 405);
+
+console.log("ok");

--- a/crash-telemetry/test.mjs
+++ b/crash-telemetry/test.mjs
@@ -7,7 +7,7 @@ const REPORT = `
   time 2026-07-26 10:41:02 UTC
   build 6a941c06
   handle @marco*evil
-  access violation: read from 00000002
+  access violation: read from 00000002 [x](https://evil.test) \`
   [0] 0071D5A0
   [1] 006BE7DE
 `;
@@ -33,6 +33,11 @@ assert.match(content, /C0000005/);
 assert.match(content, /read from 00000002/);
 assert.match(content, /build `6a941c06`/);
 assert.match(content, /marcoevil/);            // markdown and @ stripped from the handle
+// every field is attacker-chosen: no field may carry markup or a link into the
+// channel, and none may close the backticks or bold the summary wraps it in.
+assert.ok(!content.includes("]("), content);   // no link syntax out of the report
+assert.ok(!content.includes("://"), content);  // and no bare URL either
+assert.equal(content.match(/`/g).length, 4);   // only the two pairs summarize() opens
 assert.deepEqual(JSON.parse(sent.body.get("payload_json")).allowed_mentions, { parse: [] });
 assert.equal(await sent.body.get("files[0]").text(), REPORT);
 

--- a/crash-telemetry/worker.js
+++ b/crash-telemetry/worker.js
@@ -15,17 +15,23 @@
 
 const MAX_BYTES = 64 * 1024; // reports run 2-8 KB; anything near this is not ours
 
+// Every field below is lifted out of the uploaded file, and the endpoint is public
+// and unauthenticated: treat all of it as attacker-chosen, not just the handle.
+// Keep printable ASCII minus everything Discord reads as markup or a link, and cap
+// the length, so nothing in a report can shape the message around it.
+const clean = (s) => (s || "").replace(/[^A-Za-z0-9 .,+-]/g, "").slice(0, 64).trim();
+
 // Pull the header fields the client writes, for a one-line channel summary.
 // See writeExceptionBacktrace(): "*** CRASH code=... ***", then "  <key> <value>".
 function summarize(text) {
-  const field = (name) => (text.match(new RegExp(`^\\s+${name} (.+)$`, "m")) || [])[1]?.trim();
-  const code = (text.match(/code=(\w+)/) || [])[1] || "????????";
-  const av = (text.match(/access violation: (.+)/) || [])[1]?.trim();
+  const field = (name) => (text.match(new RegExp(`^\\s+${name} (.+)$`, "m")) || [])[1];
+  const code = clean((text.match(/code=(\w+)/) || [])[1]) || "????????";
+  const av = clean((text.match(/access violation: (.+)/) || [])[1]);
   const parts = [`\`${code}\`${av ? ` (${av})` : ""}`];
-  const build = field("build");
-  const handle = field("handle");
+  const build = clean(field("build"));
+  const handle = clean(field("handle"));
   if (build) parts.push(`build \`${build}\``);
-  if (handle) parts.push(`from **${handle.replace(/[`*_~|@]/g, "")}**`); // no pings, no markdown
+  if (handle) parts.push(`from **${handle}**`);
   return parts.join("  ·  ");
 }
 

--- a/crash-telemetry/worker.js
+++ b/crash-telemetry/worker.js
@@ -13,7 +13,11 @@
 // So never answer a settling 4xx for a failure on our side: that throws the report
 // away. 429 is the one 4xx that is safe, because the client does not settle it.
 
-const MAX_BYTES = 64 * 1024; // reports run 2-8 KB; anything near this is not ours
+// Reports run 2-8 KB, and the fixed bounds in writeExceptionBacktrace (128
+// modules, 64 frames) cap them near 10 KB. Kept equal to kMaxReportBytes in the
+// client: anything the client is willing to send must not meet a settling 400
+// here, or the upload is what destroys the report.
+const MAX_BYTES = 32 * 1024;
 
 // Every field below is lifted out of the uploaded file, and the endpoint is public
 // and unauthenticated: treat all of it as attacker-chosen, not just the handle.

--- a/crash-telemetry/worker.js
+++ b/crash-telemetry/worker.js
@@ -1,0 +1,84 @@
+// Crash-telemetry sink for JA2 1.13. Takes the POST that sgp::processCrashTelemetry
+// makes, and forwards the report to a Discord webhook as a file attachment.
+//
+// It stores nothing. Reports are only useful next to a PDB, and the PDB lives on a
+// developer's machine, so there is nothing for a bucket to do here that the channel
+// we already read bug reports in does not do better.
+//
+// The status codes matter — the client acts on them (reportIsSettled()):
+//   2xx  accepted; the client deletes its copy
+//   400  junk, never going to be accepted; the client deletes its copy
+//   429  throttled; the client keeps the file and retries next launch
+//   5xx  our problem; the client keeps the file and retries next launch
+// So never answer a settling 4xx for a failure on our side: that throws the report
+// away. 429 is the one 4xx that is safe, because the client does not settle it.
+
+const MAX_BYTES = 64 * 1024; // reports run 2-8 KB; anything near this is not ours
+
+// Pull the header fields the client writes, for a one-line channel summary.
+// See writeExceptionBacktrace(): "*** CRASH code=... ***", then "  <key> <value>".
+function summarize(text) {
+  const field = (name) => (text.match(new RegExp(`^\\s+${name} (.+)$`, "m")) || [])[1]?.trim();
+  const code = (text.match(/code=(\w+)/) || [])[1] || "????????";
+  const av = (text.match(/access violation: (.+)/) || [])[1]?.trim();
+  const parts = [`\`${code}\`${av ? ` (${av})` : ""}`];
+  const build = field("build");
+  const handle = field("handle");
+  if (build) parts.push(`build \`${build}\``);
+  if (handle) parts.push(`from **${handle.replace(/[`*_~|@]/g, "")}**`); // no pings, no markdown
+  return parts.join("  ·  ");
+}
+
+export default {
+  async fetch(request, env) {
+    if (request.method !== "POST") return new Response("POST only\n", { status: 405 });
+    if (!env.DISCORD_WEBHOOK) {
+      // `wrangler secret put` targets the deployed Worker; `wrangler dev` reads
+      // .dev.vars instead. Missing one of the two is the usual cause of a 503.
+      console.error("DISCORD_WEBHOOK unset (deploy: wrangler secret put, dev: .dev.vars)");
+      return new Response("not configured\n", { status: 503 });
+    }
+
+    // Per-IP cap, checked before the body is read so a flood costs nothing. 429 is
+    // deliberate: reportIsSettled() does not settle it, so a throttled player keeps
+    // the report and it goes out next launch. Answering 400 here would delete it.
+    const ip = request.headers.get("cf-connecting-ip") || "unknown";
+    const { success } = await env.UPLOAD_LIMITER.limit({ key: ip });
+    if (!success) return new Response("slow down\n", { status: 429 });
+
+    // Trust the declared length only as a cheap early out; the real cap is on the
+    // bytes actually read, since Content-Length can lie or be absent.
+    const declared = Number(request.headers.get("content-length") || 0);
+    if (declared > MAX_BYTES) return new Response("too large\n", { status: 400 });
+
+    const text = await request.text();
+    if (text.length > MAX_BYTES) return new Response("too large\n", { status: 400 });
+    // The endpoint is public and unauthenticated — the URL ships in every player's
+    // Ja2.ini. This is not security, just a filter that keeps drive-by POSTs and
+    // scanners out of the channel. Anything determined gets through; that is fine,
+    // the blast radius is a message we delete.
+    if (!text.includes("*** CRASH")) return new Response("not a crash report\n", { status: 400 });
+
+    const stamp = new Date().toISOString().replace(/[-:]/g, "").slice(0, 15);
+    const form = new FormData();
+    form.append("payload_json", JSON.stringify({
+      content: summarize(text),
+      allowed_mentions: { parse: [] }, // a report is attacker-controlled text; never ping
+    }));
+    form.append("files[0]", new Blob([text], { type: "text/plain" }), `crash_${stamp}.txt`);
+
+    let res;
+    try {
+      res = await fetch(env.DISCORD_WEBHOOK, { method: "POST", body: form });
+    } catch (e) {
+      console.error("discord unreachable:", e.message);
+      return new Response("upstream unreachable\n", { status: 503 });
+    }
+    // Discord's own 429 included: not the player's fault, so keep the report alive.
+    if (!res.ok) {
+      console.error("discord rejected:", res.status, (await res.text()).slice(0, 200));
+      return new Response("upstream rejected\n", { status: 503 });
+    }
+    return new Response(null, { status: 204 });
+  },
+};

--- a/crash-telemetry/wrangler.toml
+++ b/crash-telemetry/wrangler.toml
@@ -1,0 +1,27 @@
+name = "ja2-crash-telemetry"
+main = "worker.js"
+compatibility_date = "2025-07-01"
+
+# The workers.dev subdomain is the endpoint players POST to — there is no custom
+# domain. Stated explicitly so the default can't move; wrangler warns otherwise.
+workers_dev = true
+
+# No per-version preview URLs. Each one is another live, public endpoint that
+# forwards to the Discord webhook, and testing happens against `wrangler dev`
+# with the local sink, so they would be surface area for nothing.
+preview_urls = false
+
+# Per-IP upload cap. The ceiling has to clear kMaxUploadsPerRun (20) in the client,
+# or a player draining a backlog throttles themselves; 50/minute leaves headroom
+# without letting a scanner flood the channel. period accepts only 10 or 60.
+[[ratelimits]]
+name = "UPLOAD_LIMITER"
+namespace_id = "1001"
+
+  [ratelimits.simple]
+  limit = 50
+  period = 60
+
+# DISCORD_WEBHOOK is a secret, not a var — it never belongs in this file:
+#   wrangler secret put DISCORD_WEBHOOK        (deployed Worker)
+#   .dev.vars                                  (wrangler dev)

--- a/sgp/CMakeLists.txt
+++ b/sgp/CMakeLists.txt
@@ -2,6 +2,7 @@ set(sgpSrc
 "${CMAKE_CURRENT_SOURCE_DIR}/Button Sound Control.cpp"
 "${CMAKE_CURRENT_SOURCE_DIR}/Button System.cpp"
 "${CMAKE_CURRENT_SOURCE_DIR}/Compression.cpp"
+"${CMAKE_CURRENT_SOURCE_DIR}/crash_telemetry.cpp"
 "${CMAKE_CURRENT_SOURCE_DIR}/Cursor Control.cpp"
 "${CMAKE_CURRENT_SOURCE_DIR}/DEBUG.cpp"
 "${CMAKE_CURRENT_SOURCE_DIR}/debug_util.cpp"

--- a/sgp/DEBUG.cpp
+++ b/sgp/DEBUG.cpp
@@ -395,7 +395,7 @@ void _FailMessage(const char* message, unsigned lineNum, const char * functionNa
 
 	sgp::dumpStackTrace(message);
 
-	mprintf( 10, 10, L"%s: %s %S %s", pMessageStrings[ MSG_VERSION ], zProductLabel, czVersionString, zBuildInformation );
+	mprintf( 10, 10, L"%s: %s %s", pMessageStrings[ MSG_VERSION ], zProductLabel, zBuildInformation );
 
 	std::stringstream basicInformation;
 	basicInformation << "Assertion Failure [Line " << lineNum;

--- a/sgp/crash_telemetry.cpp
+++ b/sgp/crash_telemetry.cpp
@@ -37,8 +37,10 @@ void writeConsent(bool yes) {
 	CloseHandle(h);
 }
 
-// A report bigger than this is not one of ours; never put it on the wire.
-const DWORD kMaxReportBytes = 256 * 1024;
+// A report bigger than this is not one of ours; never put it on the wire. Kept
+// equal to MAX_BYTES in the sink, which answers a settling 400 above it: sending
+// what the sink will not take is how an upload destroys the report it carries.
+const DWORD kMaxReportBytes = 32 * 1024;
 
 // POST one report file to url. Returns the HTTP status, or 0 if the request never
 // completed (no connection, DNS failure, timeout) — see reportIsSettled().

--- a/sgp/crash_telemetry.cpp
+++ b/sgp/crash_telemetry.cpp
@@ -1,0 +1,174 @@
+// Crash telemetry: upload the crash_report_*.txt files the crash handler left
+// behind, on the next launch.
+//
+// Deliberately a separate translation unit from debug_win_util.cpp. Everything in
+// there runs inside a faulting thread and may not allocate; everything here runs at
+// startup with a healthy heap and is ordinary code. Keeping the two apart keeps the
+// no-heap rule easy to see and easy to hold.
+
+#if defined(_MSC_VER)
+
+#include "debug_util.h"
+
+#include <windows.h>
+#include <winhttp.h>
+#include <process.h> // _beginthreadex for the detached upload thread
+
+#include <vector>
+
+namespace {
+
+// Persisted consent: 1 = yes, 0 = no, -1 = not asked yet.
+int readConsent() {
+	HANDLE h = CreateFileA("telemetry.consent", GENERIC_READ, FILE_SHARE_READ, NULL,
+		OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+	if (h == INVALID_HANDLE_VALUE) return -1;
+	char c = 0; DWORD got = 0;
+	ReadFile(h, &c, 1, &got, NULL);
+	CloseHandle(h);
+	return (got == 1 && c == '1') ? 1 : 0;
+}
+
+void writeConsent(bool yes) {
+	HANDLE h = CreateFileA("telemetry.consent", GENERIC_WRITE, 0, NULL,
+		CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
+	if (h == INVALID_HANDLE_VALUE) return;
+	DWORD w; WriteFile(h, yes ? "1" : "0", 1, &w, NULL);
+	CloseHandle(h);
+}
+
+// A report bigger than this is not one of ours; never put it on the wire.
+const DWORD kMaxReportBytes = 256 * 1024;
+
+// POST one report file to url. Returns the HTTP status, or 0 if the request never
+// completed (no connection, DNS failure, timeout) — see reportIsSettled().
+DWORD postReport(const wchar_t* url, const char* path) {
+	HANDLE fh = CreateFileA(path, GENERIC_READ, FILE_SHARE_READ, NULL,
+		OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+	if (fh == INVALID_HANDLE_VALUE) return 0;
+	DWORD size = GetFileSize(fh, NULL);
+	if (size > kMaxReportBytes) { CloseHandle(fh); return 413; }
+	std::vector<char> body(size ? size : 1);
+	DWORD got = 0;
+	BOOL read_ok = ReadFile(fh, body.data(), size, &got, NULL);
+	CloseHandle(fh);
+	if (!read_ok || got != size) return 0;
+
+	URL_COMPONENTS uc = {}; uc.dwStructSize = sizeof(uc);
+	wchar_t host[256] = {}, urlpath[1024] = {};
+	uc.lpszHostName = host;    uc.dwHostNameLength = _countof(host);
+	uc.lpszUrlPath = urlpath;  uc.dwUrlPathLength  = _countof(urlpath);
+	if (!WinHttpCrackUrl(url, 0, 0, &uc)) return 400;
+
+	HINTERNET hSession = WinHttpOpen(L"JA2-1.13-crash-telemetry",
+		WINHTTP_ACCESS_TYPE_DEFAULT_PROXY, WINHTTP_NO_PROXY_NAME, WINHTTP_NO_PROXY_BYPASS, 0);
+	if (!hSession) return 0;
+	// Bound every phase. Even off the main thread these must not hang forever: the
+	// thread holds the report files open-ish and we want the queue drained or given
+	// up on within seconds, not to leave a socket parked for the whole session.
+	WinHttpSetTimeouts(hSession, 5000, 5000, 10000, 15000);
+
+	DWORD status = 0;
+	if (HINTERNET hConnect = WinHttpConnect(hSession, host, uc.nPort, 0)) {
+		DWORD flags = (uc.nScheme == INTERNET_SCHEME_HTTPS) ? WINHTTP_FLAG_SECURE : 0;
+		if (HINTERNET hReq = WinHttpOpenRequest(hConnect, L"POST", urlpath, NULL,
+				WINHTTP_NO_REFERER, WINHTTP_DEFAULT_ACCEPT_TYPES, flags)) {
+			if (WinHttpSendRequest(hReq, L"Content-Type: text/plain\r\n", (DWORD)-1,
+					body.data(), size, size, 0) &&
+				WinHttpReceiveResponse(hReq, NULL)) {
+				DWORD len = sizeof(status);
+				WinHttpQueryHeaders(hReq,
+					WINHTTP_QUERY_STATUS_CODE | WINHTTP_QUERY_FLAG_NUMBER,
+					WINHTTP_HEADER_NAME_BY_INDEX, &status, &len, WINHTTP_NO_HEADER_INDEX);
+			}
+			WinHttpCloseHandle(hReq);
+		}
+		WinHttpCloseHandle(hConnect);
+	}
+	WinHttpCloseHandle(hSession);
+	return status;
+}
+
+// Whether a report is done with, i.e. safe to delete. Uploaded (2xx), or rejected
+// as content the server will never take (a malformed or oversized body). Anything
+// else — no connection, 5xx, and notably 404/403 from a mistyped or misconfigured
+// CRASH_TELEMETRY_URL — keeps the file, so a bad setting loses nobody's report.
+bool reportIsSettled(DWORD status) {
+	return (status >= 200 && status < 300) ||
+		status == 400 || status == 413 || status == 415;
+}
+
+// Reports older than this are stale: the crash they describe is long since shipped
+// past, and a player who was offline for a season should not upload a season of them.
+const DWORD kMaxReportAgeDays = 30;
+
+bool olderThan(const FILETIME& ft, DWORD days) {
+	FILETIME now;
+	GetSystemTimeAsFileTime(&now);
+	ULARGE_INTEGER t = { ft.dwLowDateTime, ft.dwHighDateTime };
+	ULARGE_INTEGER n = { now.dwLowDateTime, now.dwHighDateTime };
+	if (n.QuadPart <= t.QuadPart) return false; // clock skew: treat as fresh
+	return (n.QuadPart - t.QuadPart) > days * 24ULL * 60 * 60 * 10000000ULL;
+}
+
+// One launch drains at most this many, so a crash-looping build cannot turn startup
+// into a long upload session. The rest wait for the next launch.
+const int kMaxUploadsPerRun = 20;
+
+wchar_t s_telemetryUrl[512];
+
+// Drains the pending reports. Runs detached: if the player quits first the process
+// exits from under it, which costs nothing — an interrupted upload leaves the file
+// on disk and it goes out next launch.
+unsigned __stdcall telemetryThread(void*) {
+	WIN32_FIND_DATAA fd;
+	HANDLE hFind = FindFirstFileA("crash_report_*.txt", &fd);
+	if (hFind == INVALID_HANDLE_VALUE) return 0;
+	int sent = 0;
+	do {
+		if (olderThan(fd.ftLastWriteTime, kMaxReportAgeDays)) {
+			DeleteFileA(fd.cFileName);
+			continue;
+		}
+		if (sent++ >= kMaxUploadsPerRun) break;
+		if (reportIsSettled(postReport(s_telemetryUrl, fd.cFileName)))
+			DeleteFileA(fd.cFileName);
+	} while (FindNextFileA(hFind, &fd));
+	FindClose(hFind);
+	return 0;
+}
+
+} // anonymous namespace
+
+namespace sgp {
+void processCrashTelemetry(const wchar_t* url) {
+	if (url == NULL || url[0] == L'\0') return; // no endpoint configured: feature off
+
+	int consent = readConsent();
+	if (consent < 0) { // first run: ask once, remember the answer
+		int r = MessageBoxW(NULL,
+			L"This build can send crash reports to the developers to help fix bugs.\n"
+			L"A report contains only technical crash data \x2014 no personal information.\n\n"
+			L"Send crash reports automatically?",
+			L"Jagged Alliance 2 v1.13 \x2014 Crash Reporting",
+			MB_YESNO | MB_ICONQUESTION);
+		writeConsent(r == IDYES);
+		consent = (r == IDYES) ? 1 : 0;
+	}
+	if (consent != 1) return; // declined: leave reports on disk, accumulating
+
+	// Hand the draining to a detached thread. The uploads are synchronous WinHttp
+	// calls with seconds-long timeouts, and this runs on the startup path: on the
+	// main thread a slow or unreachable endpoint is a stall the player sees before
+	// the splash screen. Nothing waits on the result, so it can take as long as it
+	// takes. The consent prompt above stays here, on purpose — that one is a
+	// question, and a question has to be asked before anything is sent.
+	lstrcpynW(s_telemetryUrl, url, ARRAYSIZE(s_telemetryUrl));
+	// _beginthreadex, not CreateThread: the upload path uses the CRT (std::vector),
+	// which wants its per-thread state set up and torn down.
+	uintptr_t t = _beginthreadex(NULL, 0, telemetryThread, NULL, 0, NULL);
+	if (t) CloseHandle((HANDLE)t);
+}
+} // namespace sgp
+
+#endif // _MSC_VER

--- a/sgp/crash_telemetry.cpp
+++ b/sgp/crash_telemetry.cpp
@@ -148,7 +148,9 @@ void processCrashTelemetry(const wchar_t* url) {
 	if (consent < 0) { // first run: ask once, remember the answer
 		int r = MessageBoxW(NULL,
 			L"This build can send crash reports to the developers to help fix bugs.\n"
-			L"A report contains only technical crash data \x2014 no personal information.\n\n"
+			L"A report contains where the game crashed, the names of the loaded\n"
+			L"modules, and the HANDLE from your Ja2.ini if you set one. No file\n"
+			L"paths, no save games, nothing else about your machine.\n\n"
 			L"Send crash reports automatically?",
 			L"Jagged Alliance 2 v1.13 \x2014 Crash Reporting",
 			MB_YESNO | MB_ICONQUESTION);

--- a/sgp/debug_util.cpp
+++ b/sgp/debug_util.cpp
@@ -24,14 +24,3 @@ void sgp::dumpStackTrace(vfs::String const& msg)
 		already_dumping = false;
 	}
 }
-
-#ifdef __MINGW32__
-StackTrace::StackTrace()
-{
-}
-
-void StackTrace::PrintBacktrace(const char* msg)
-{
-}
-
-#endif

--- a/sgp/debug_util.h
+++ b/sgp/debug_util.h
@@ -69,6 +69,12 @@ namespace sgp
 	// stamp into crash reports, so a report can be tied to whoever raises it with
 	// us on Discord. Empty or unset simply omits the field. Call once at startup.
 	void setCrashUserHandle(const wchar_t* handle);
+
+	// Startup crash-telemetry pass (heap is healthy here — never call from a
+	// crash handler). If url is empty the feature is off. On first run, asks the
+	// player for consent (native dialog) and remembers it; if granted, POSTs each
+	// pending crash_report_*.txt to url and deletes the ones that upload cleanly.
+	void processCrashTelemetry(const wchar_t* url);
 }
 
 #endif  // BASE_DEBUG_UTIL_H_

--- a/sgp/debug_util.h
+++ b/sgp/debug_util.h
@@ -46,9 +46,29 @@ private:
 	DISALLOW_EVIL_CONSTRUCTORS(StackTrace);
 };
 
+struct _EXCEPTION_POINTERS;
+
 namespace sgp
 {
 	void dumpStackTrace(vfs::String const& msg);
+
+	// Write a heap-free crash report (registers + a raw return-address backtrace)
+	// for the faulting context to a numbered crash_report file; symbolize it
+	// offline against the build's PDB. Call first-chance from a vectored handler.
+	void writeExceptionBacktrace(_EXCEPTION_POINTERS* ep);
+
+	// Record the build-id (game version string) to stamp into crash reports, so
+	// a report can be matched to the exact build's PDB. Call once at startup.
+	void setCrashBuildId(const char* id);
+
+	// What to tell the player: why we died and where the report landed. NULL if
+	// no crash was recorded. Built by the handler, shown from the exit path.
+	const wchar_t* crashReportMessage();
+
+	// Record the player's optional self-chosen handle (HANDLE in Ja2 Settings) to
+	// stamp into crash reports, so a report can be tied to whoever raises it with
+	// us on Discord. Empty or unset simply omits the field. Call once at startup.
+	void setCrashUserHandle(const wchar_t* handle);
 }
 
 #endif  // BASE_DEBUG_UTIL_H_

--- a/sgp/debug_win_util.cpp
+++ b/sgp/debug_win_util.cpp
@@ -12,6 +12,7 @@
 
 
 #include <dbghelp.h>
+#include <winternl.h> // PEB loader list, so the module table costs no allocation
 
 #include <vfs/Tools/vfs_log.h>
 
@@ -207,6 +208,166 @@ void StackTrace::PrintBacktrace(const char* msg) {
 	sgp::Logger::LogInstance log = SGP_LOG(s_log.id);
 	OutputToStream(msg, &log);
 }
+
+// Called first-chance from the vectored crash handler, so it runs *inside* the
+// faulting thread with a possibly-wrecked heap: the very crash we want to report
+// is often heap corruption (a trashed std::map, a wild pointer). Anything that
+// allocates — the game Logger, std::vector, DbgHelp's Sym* — would fault again
+// and take the report down with it. So this path is deliberately heap-free: only
+// stack buffers and raw Win32. It emits runtime addresses plus the module table
+// needed to make sense of them; symbolize offline against the build's PDB:
+//   llvm-symbolizer --obj=JA2.exe --adjust-vma=$((<JA2.exe base> - 0x400000)) <addr>
+namespace sgp {
+
+// Stamped into every crash report so a report maps to the exact build's PDB.
+// Copied into a fixed buffer (no heap) — safe to read from a crash handler.
+static char s_buildId[64] = { 0 };
+void setCrashBuildId(const char* id) {
+	if (id) lstrcpynA(s_buildId, id, sizeof(s_buildId));
+}
+
+// Filled in once a report has been written; see crashReportMessage().
+static WCHAR s_crashMessage[512] = { 0 };
+const wchar_t* crashReportMessage() {
+	return s_crashMessage[0] ? s_crashMessage : NULL;
+}
+
+// The player's optional handle, for tying a report to whoever raises it with us.
+// Sanitized here rather than at crash time: it is user input that lands in a text
+// report the telemetry server parses line by line, so drop anything that could
+// forge a line (CR/LF, control and non-ASCII characters) and cap the length.
+static char s_userHandle[33] = { 0 };
+void setCrashUserHandle(const wchar_t* handle) {
+	size_t out = 0;
+	for (size_t i = 0; handle && handle[i] && out < sizeof(s_userHandle) - 1; ++i) {
+		if (handle[i] >= L' ' && handle[i] <= L'~')
+			s_userHandle[out++] = (char)handle[i];
+	}
+	s_userHandle[out] = 0;
+}
+
+void writeExceptionBacktrace(_EXCEPTION_POINTERS* ep) {
+	if (ep == NULL || ep->ContextRecord == NULL || ep->ExceptionRecord == NULL)
+		return;
+
+	// The same fault storms (Wine re-dispatches the crashing window message) and
+	// walking a wrecked stack can fault us in turn. Dump each distinct faulting
+	// address once, never re-enter. ponytail: single globals, fine in a crash.
+	static void* s_lastFault = NULL;
+	static bool  s_inDump    = false;
+	void* fault = ep->ExceptionRecord->ExceptionAddress;
+	if (s_inDump || fault == s_lastFault)
+		return;
+	s_lastFault = fault;
+	s_inDump = true;
+
+	// One fresh, numbered file per crash. CREATE_NEW claims the first free number,
+	// so reports never overwrite each other and pile up while a player is offline;
+	// the telemetry uploader drains and deletes them when it can reach the server.
+	char name[32];
+	HANDLE h = INVALID_HANDLE_VALUE;
+	for (int n = 1; n <= 999; ++n) {
+		wsprintfA(name, "crash_report_%03d.txt", n);
+		h = CreateFileA(name, GENERIC_WRITE, FILE_SHARE_READ, NULL,
+			CREATE_NEW, FILE_ATTRIBUTE_NORMAL, NULL);
+		if (h != INVALID_HANDLE_VALUE) break;
+		if (GetLastError() != ERROR_FILE_EXISTS) break; // real error, stop trying
+	}
+	if (h == INVALID_HANDLE_VALUE) { s_inDump = false; return; }
+
+	char line[192];
+	auto emit = [&](int n) { DWORD w; WriteFile(h, line, n, &w, NULL); };
+
+	const CONTEXT&          c = *ep->ContextRecord;
+	const EXCEPTION_RECORD& r = *ep->ExceptionRecord;
+
+	emit(wsprintfA(line,
+		"\r\n*** CRASH  code=%08lX  eip=%08lX  esp=%08lX  ebp=%08lX ***\r\n",
+		r.ExceptionCode, c.Eip, c.Esp, c.Ebp));
+	// UTC, so a report stays unambiguous once it leaves the machine that wrote it.
+	SYSTEMTIME t;
+	GetSystemTime(&t);
+	emit(wsprintfA(line, "  time %04d-%02d-%02d %02d:%02d:%02d UTC\r\n",
+		t.wYear, t.wMonth, t.wDay, t.wHour, t.wMinute, t.wSecond));
+	if (s_buildId[0])
+		emit(wsprintfA(line, "  build %s\r\n", s_buildId));
+	if (s_userHandle[0])
+		emit(wsprintfA(line, "  handle %s\r\n", s_userHandle));
+	if (r.ExceptionCode == EXCEPTION_ACCESS_VIOLATION && r.NumberParameters >= 2)
+		emit(wsprintfA(line, "  access violation: %s %08lX\r\n",
+			r.ExceptionInformation[0] == 1 ? "write to " :
+			r.ExceptionInformation[0] == 8 ? "execute at" : "read from",
+			(DWORD)r.ExceptionInformation[1]));
+
+	// Where the loader actually put each image. Our executables are /DYNAMICBASE,
+	// so a runtime address matches neither the preferred base recorded in the PDB
+	// nor anything identifiable in a sibling module: without this table none of
+	// the addresses below can be symbolized. Walked off the PEB loader list, which
+	// costs no allocation, unlike EnumProcessModules or DbgHelp's module APIs.
+	emit(wsprintfA(line, "  modules (base size path):\r\n"));
+	PEB_LDR_DATA* ldr = NtCurrentTeb()->ProcessEnvironmentBlock->Ldr;
+	LIST_ENTRY* head = &ldr->InMemoryOrderModuleList;
+	int seen = 0;
+	for (LIST_ENTRY* e = head->Flink; e != head && ++seen <= 128; e = e->Flink) {
+		LDR_DATA_TABLE_ENTRY* m =
+			CONTAINING_RECORD(e, LDR_DATA_TABLE_ENTRY, InMemoryOrderLinks);
+		DWORD base = (DWORD)(DWORD_PTR)m->DllBase;
+		IMAGE_DOS_HEADER* dos = (IMAGE_DOS_HEADER*)base;
+		if (!base || dos->e_magic != IMAGE_DOS_SIGNATURE)
+			continue;
+		IMAGE_NT_HEADERS* nt = (IMAGE_NT_HEADERS*)(base + dos->e_lfanew);
+		if (nt->Signature != IMAGE_NT_SIGNATURE)
+			continue;
+		// Truncate the path into a terminated buffer: FullDllName is counted, not
+		// terminated, and wsprintf supports neither "*" precision nor a way to
+		// bound %S, so a long path would run off the end of both.
+		WCHAR path[140];
+		int pathChars = (int)(m->FullDllName.Length / sizeof(WCHAR)) + 1;
+		lstrcpynW(path, m->FullDllName.Buffer,
+			pathChars < ARRAYSIZE(path) ? pathChars : ARRAYSIZE(path));
+		emit(wsprintfA(line, "    %08lX %08lX %S\r\n", base,
+			nt->OptionalHeader.SizeOfImage, path));
+	}
+
+	// Committed stack bounds from the TEB, so a bad ebp can't fault our reads.
+	NT_TIB* tib = (NT_TIB*)NtCurrentTeb();
+	DWORD stkLo = (DWORD)(DWORD_PTR)tib->StackLimit;
+	DWORD stkHi = (DWORD)(DWORD_PTR)tib->StackBase;
+
+	emit(wsprintfA(line, "  [0] %08lX\r\n", c.Eip)); // exact crash site
+	DWORD ebp = c.Ebp;
+	for (int i = 1; i < 64; ++i) {
+		if (ebp < stkLo || ebp + 8 > stkHi || (ebp & 3)) break;
+		DWORD ret  = *(DWORD*)(ebp + 4);
+		DWORD next = *(DWORD*)ebp;
+		// Print every return address, not just our own module's: a fault inside
+		// ddraw/fmod/bink is exactly the case worth seeing, and the module table
+		// above already tells the reader which addresses land in real code.
+		emit(wsprintfA(line, "  [%d] %08lX\r\n", i, ret));
+		if (next <= ebp) break; // frames must climb the stack
+		ebp = next;
+	}
+	FlushFileBuffers(h);
+	CloseHandle(h);
+
+	// Compose what the player gets told, while the fault details and the report's
+	// name are still in hand — but do not show it here. First-chance means the
+	// exception may yet be handled downstream, and a message box pumps messages,
+	// which on the wrecked heap that just faulted is a second crash. SGPExit puts
+	// it on screen once the game is actually going down.
+	WCHAR dir[MAX_PATH];
+	DWORD dirLen = GetCurrentDirectoryW(ARRAYSIZE(dir), dir);
+	if (dirLen == 0 || dirLen >= ARRAYSIZE(dir))
+		dir[0] = 0;
+	wsprintfW(s_crashMessage,
+		L"Jagged Alliance 2 1.13 crashed: exception %08lX at %08lX.\r\n\r\n"
+		L"A crash report was written to\r\n\r\n    %s\\%S\r\n\r\n"
+		L"Please attach that file to your bug report.",
+		r.ExceptionCode, (DWORD)(DWORD_PTR)fault, dir, name);
+
+	s_inDump = false;
+}
+} // namespace sgp
 
 void StackTrace::OutputToStream(const char* msg, sgp::Logger::LogInstance* os) {
 	SymbolContext* context = SymbolContext::Get();

--- a/sgp/debug_win_util.cpp
+++ b/sgp/debug_win_util.cpp
@@ -216,7 +216,7 @@ void StackTrace::PrintBacktrace(const char* msg) {
 // and take the report down with it. So this path is deliberately heap-free: only
 // stack buffers and raw Win32. It emits runtime addresses plus the module table
 // needed to make sense of them; symbolize offline against the build's PDB:
-//   llvm-symbolizer --obj=JA2.exe --adjust-vma=$((<JA2.exe base> - 0x400000)) <addr>
+//   symbolize_crash crash_report_001.txt JA2.exe
 namespace sgp {
 
 // Stamped into every crash report so a report maps to the exact build's PDB.

--- a/sgp/debug_win_util.cpp
+++ b/sgp/debug_win_util.cpp
@@ -304,7 +304,7 @@ void writeExceptionBacktrace(_EXCEPTION_POINTERS* ep) {
 	// nor anything identifiable in a sibling module: without this table none of
 	// the addresses below can be symbolized. Walked off the PEB loader list, which
 	// costs no allocation, unlike EnumProcessModules or DbgHelp's module APIs.
-	emit(wsprintfA(line, "  modules (base size path):\r\n"));
+	emit(wsprintfA(line, "  modules (base size name):\r\n"));
 	PEB_LDR_DATA* ldr = NtCurrentTeb()->ProcessEnvironmentBlock->Ldr;
 	LIST_ENTRY* head = &ldr->InMemoryOrderModuleList;
 	int seen = 0;
@@ -318,15 +318,28 @@ void writeExceptionBacktrace(_EXCEPTION_POINTERS* ep) {
 		IMAGE_NT_HEADERS* nt = (IMAGE_NT_HEADERS*)(base + dos->e_lfanew);
 		if (nt->Signature != IMAGE_NT_SIGNATURE)
 			continue;
-		// Truncate the path into a terminated buffer: FullDllName is counted, not
-		// terminated, and wsprintf supports neither "*" precision nor a way to
-		// bound %S, so a long path would run off the end of both.
-		WCHAR path[140];
-		int pathChars = (int)(m->FullDllName.Length / sizeof(WCHAR)) + 1;
-		lstrcpynW(path, m->FullDllName.Buffer,
-			pathChars < ARRAYSIZE(path) ? pathChars : ARRAYSIZE(path));
+		// File name only, never the directory: a full path carries the player's
+		// Windows account name and whatever else their install path says about
+		// them, and the report leaves the machine. Symbolizing matches on module
+		// name and base, so the directory was never read by anything.
+		//
+		// Copied into a terminated buffer: FullDllName is counted, not terminated,
+		// and wsprintf supports neither "*" precision nor a way to bound %S, so a
+		// long name would run off the end of both.
+		const WCHAR* full = m->FullDllName.Buffer;
+		int fullChars = (int)(m->FullDllName.Length / sizeof(WCHAR));
+		if (!full || fullChars <= 0)
+			continue;
+		int start = 0;
+		for (int i = 0; i < fullChars; ++i)
+			if (full[i] == L'\\' || full[i] == L'/')
+				start = i + 1;
+		WCHAR modname[64];
+		int nameChars = fullChars - start + 1;
+		lstrcpynW(modname, full + start,
+			nameChars < ARRAYSIZE(modname) ? nameChars : ARRAYSIZE(modname));
 		emit(wsprintfA(line, "    %08lX %08lX %S\r\n", base,
-			nt->OptionalHeader.SizeOfImage, path));
+			nt->OptionalHeader.SizeOfImage, modname));
 	}
 
 	// Committed stack bounds from the TEB, so a bad ebp can't fault our reads.

--- a/sgp/sgp.cpp
+++ b/sgp/sgp.cpp
@@ -698,35 +698,6 @@ int PASCAL WinMain(HINSTANCE hInstance,	HINSTANCE hPrevInstance, LPSTR pCommandL
 	/****************************************************************************************************/
 #endif
 
-//If we are to use exception handling
-#ifdef ENABLE_EXCEPTION_HANDLING
-	int Result = -1;
-
-	__try
-	{
-		Result = HandledWinMain(hInstance, hPrevInstance, pCommandLine, sCommandShow);
-	}
-	__except( RecordExceptionInfo( GetExceptionInformation() ))
-	{
-		// Do nothing here - RecordExceptionInfo() has already done
-		// everything that is needed. Actually this code won't even
-		// get called unless you return EXCEPTION_EXECUTE_HANDLER from
-		// the __except clause.
-
-
-	}
-	return Result;
-
-}
-
-//Do not place code in between WinMain and Handled WinMain
-
-
-
-int PASCAL HandledWinMain(HINSTANCE hInstance,	HINSTANCE hPrevInstance, LPSTR pCommandLine, int sCommandShow)
-{
-//DO NOT REMOVE, used for exception handing list above in WinMain
-#endif
 	MSG				Message;
 	HWND			hPrevInstanceWindow;
 	UINT32			uiTimer = 0;
@@ -1334,30 +1305,6 @@ static void PopulateSectionFromCommandLine(vfs::PropertyContainer &oProps, vfs::
 
 static LONG __stdcall SGPExceptionFilter(int exceptionCount, EXCEPTION_POINTERS* pExceptInfo)
 {
-#ifdef ENABLE_EXCEPTION_HANDLING
-	extern BOOL ERGetFirstModuleException(EXCEPTION_POINTERS*, HMODULE, LPSTR, INT, LPSTR, INT, INT *);
-	extern STR GetExceptionString( DWORD uiExceptionCode );
-	CHAR funcName[64], sourceName[MAX_PATH];
-	INT lineNum = 0;
-	if (exceptionCount >= 1)
-	{
-		bool showAssert = true;
-		__try{
-			// the exception handler writer can fail with exceptions too
-			RecordExceptionInfo(pExceptInfo);
-
-			LPCSTR exceptMsg = GetExceptionString(pExceptInfo->ExceptionRecord->ExceptionCode);
-			if ( ERGetFirstModuleException(pExceptInfo, NULL, funcName, _countof(funcName), sourceName, _countof(sourceName), &lineNum ) )
-			{
-				_FailMessage(exceptMsg, lineNum, funcName, sourceName);
-				showAssert = false;
-			}
-		} __except (EXCEPTION_EXECUTE_HANDLER) {}
-		if (showAssert) AssertMsg(FALSE, "Unhanded exception processing GameLoop unable to recover.");
-	}
-
-#endif
-
 	return EXCEPTION_EXECUTE_HANDLER;
 }
 

--- a/sgp/sgp.cpp
+++ b/sgp/sgp.cpp
@@ -948,6 +948,11 @@ void GetRuntimeSettings( )
 	oProps.initFromIniFile(GAME_INI_FILE);
 	PopulateSectionFromCommandLine(oProps, "Ja2 Settings");
 
+	// Upload crash reports from previous runs (first launch asks the player).
+	// Empty CRASH_TELEMETRY_URL = off. Runs here, at startup, never in a crash.
+	sgp::processCrashTelemetry(
+		oProps.getStringProperty("Ja2 Settings", L"CRASH_TELEMETRY_URL").c_str());
+
 	// Optional player handle stamped into crash reports written from here on, so a
 	// report can be tied to whoever raises it with us. Unset = field omitted.
 	sgp::setCrashUserHandle(

--- a/sgp/sgp.cpp
+++ b/sgp/sgp.cpp
@@ -630,6 +630,7 @@ static vfs::String getGameID()
 }
 
 #include "debug_util.h"
+#include "GameVersion.h" // czVersionString, stamped into crash reports
 #include <vfs/Aspects/vfs_logging.h>
 
 class VfsLogAdapter : public vfs::Aspects::ILogger
@@ -681,8 +682,35 @@ private:
 //	}
 //};
 
+// Catch crashes on any thread/path. A last-chance UnhandledExceptionFilter is no
+// good: faults on the message-pump/WindowProcedure path have no game __except on
+// their stack, and under Wine the WndProc dispatch swallows them before they ever
+// reach "unhandled". A vectored handler runs first-chance, ahead of every frame
+// handler; it only records the fault and continues the search.
+static LONG CALLBACK VectoredCrashHandler(EXCEPTION_POINTERS* pExceptInfo)
+{
+	switch (pExceptInfo->ExceptionRecord->ExceptionCode)
+	{
+		case EXCEPTION_ACCESS_VIOLATION:
+		case EXCEPTION_ILLEGAL_INSTRUCTION:
+		case EXCEPTION_IN_PAGE_ERROR:
+		case EXCEPTION_STACK_OVERFLOW:
+		case EXCEPTION_ARRAY_BOUNDS_EXCEEDED:
+		case EXCEPTION_INT_DIVIDE_BY_ZERO:
+		case EXCEPTION_PRIV_INSTRUCTION:
+			sgp::writeExceptionBacktrace(pExceptInfo);
+			break;
+		default:
+			break; // C++ EH (0xE06D7363) and other first-chance noise: ignore
+	}
+	return EXCEPTION_CONTINUE_SEARCH; // never handle; let normal SEH run
+}
+
 int PASCAL WinMain(HINSTANCE hInstance,	HINSTANCE hPrevInstance, LPSTR pCommandLine, int sCommandShow)
 {
+	AddVectoredExceptionHandler(1, VectoredCrashHandler); // 1 = call first
+	sgp::setCrashBuildId(czVersionString); // packaged: the commit SHA whose PDB we kept
+
 #ifdef _DEBUG
 	// Use this one ONLY if you're having memory corruption issues that can be repeated in a short time
 	// Otherwise it will just run out of memory.
@@ -895,7 +923,13 @@ void SGPExit(void)
 
 	ShutdownStandardGamingPlatform();
 //	ShowCursor(TRUE);
-	if(strlen(gzErrorMsg))
+	// A recorded crash says more than "unable to recover", and names the report the
+	// player has to send us, so it replaces the generic box rather than adding to it.
+	if (const wchar_t* crashMsg = sgp::crashReportMessage())
+	{
+		MessageBoxW(NULL, crashMsg, L"Jagged Alliance 2 1.13 - Crash", MB_OK | MB_ICONERROR);
+	}
+	else if(strlen(gzErrorMsg))
 	{
 		MessageBox(NULL, gzErrorMsg, "Error", MB_OK | MB_ICONERROR	);
 	}
@@ -913,6 +947,11 @@ void GetRuntimeSettings( )
 	vfs::PropertyContainer oProps;
 	oProps.initFromIniFile(GAME_INI_FILE);
 	PopulateSectionFromCommandLine(oProps, "Ja2 Settings");
+
+	// Optional player handle stamped into crash reports written from here on, so a
+	// report can be tied to whoever raises it with us. Unset = field omitted.
+	sgp::setCrashUserHandle(
+		oProps.getStringProperty("Ja2 Settings", L"HANDLE").c_str());
 	
 	vfs::String loc = oProps.getStringProperty("Ja2 Settings", L"LOCALE");
 	if(!loc.empty())

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,0 +1,12 @@
+# Developer tools. Console programs, no game code and no Application preprocessor
+# definitions, so each is built once no matter which applications are configured.
+
+# Reads a crash report written by sgp::writeExceptionBacktrace and resolves its
+# addresses against a build's PDB. Wants C++23 (std::print, std::format); the game
+# itself is C++17, hence the per-target standard.
+add_executable(symbolize_crash symbolize_crash.cpp)
+target_link_libraries(symbolize_crash PRIVATE "dbghelp.lib")
+set_target_properties(symbolize_crash PROPERTIES
+  CXX_STANDARD 23
+  CXX_STANDARD_REQUIRED ON
+)

--- a/tools/symbolize_crash.cpp
+++ b/tools/symbolize_crash.cpp
@@ -1,0 +1,306 @@
+// Symbolize a JA2 1.13 crash report: turn the runtime addresses the crash handler
+// dumped into function names and source lines, against the matching build.
+//
+//   symbolize_crash <report.txt> [path\to\JA2.exe]
+//
+// The exe and the PDB beside it must be the exact build the report's `build <sha>`
+// line names, or the addresses resolve to the wrong lines, silently. The default
+// object is JA2.exe in the current directory.
+//
+// Frames print in call order: outermost caller first, descending to the fault.
+//
+// Addresses in a report are runtime VAs, and our executables are /DYNAMICBASE: the
+// loader may put the image anywhere -- Wine keeps it at the preferred base,
+// Windows ASLR does not. The report's module table records where it actually
+// landed, and that is the base we hand DbgHelp, so the relocation arithmetic is
+// its problem rather than ours. Reports predating the module table are assumed
+// unrelocated, which is what they were.
+
+#include <windows.h>
+#include <dbghelp.h>
+
+#include <algorithm>
+#include <cstdio>
+#include <cstdlib>
+#include <format>
+#include <fstream>
+#include <iterator>
+#include <optional>
+#include <print>
+#include <regex>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace {
+
+template <typename... Args>
+[[noreturn]] void fatal(std::format_string<Args...> format, Args&&... args) {
+	std::print(stderr, "symbolize_crash: ");
+	std::println(stderr, format, std::forward<Args>(args)...);
+	std::exit(1);
+}
+
+// --- colour ----------------------------------------------------------------
+
+// Every field is empty when colour is off, so the format strings below never have
+// to know which mode they are in.
+struct Ink {
+	std::string_view heading, label, code, function, location, address, fault,
+		inlined, faded, off;
+};
+
+constexpr Ink kPlain{};
+constexpr Ink kAnsi{
+	.heading  = "\x1b[1;91m", // bright red
+	.label    = "\x1b[90m",   // grey
+	.code     = "\x1b[1;93m", // bright yellow
+	.function = "\x1b[1;96m", // bright cyan
+	.location = "\x1b[32m",   // green
+	.address  = "\x1b[90m",
+	.fault    = "\x1b[1;91m",
+	.inlined  = "\x1b[35m",   // magenta
+	.faded    = "\x1b[90m",
+	.off      = "\x1b[0m",
+};
+
+Ink ink = kPlain;
+
+// Colour only when standard output is a console we can put in ANSI mode: a report
+// piped to a file or a pager should not collect escape sequences.
+void enableColour() {
+	if (std::getenv("NO_COLOR"))
+		return;
+	HANDLE out = GetStdHandle(STD_OUTPUT_HANDLE);
+	DWORD mode = 0;
+	if (!GetConsoleMode(out, &mode))
+		return;
+	if (mode & ENABLE_VIRTUAL_TERMINAL_PROCESSING ||
+		SetConsoleMode(out, mode | ENABLE_VIRTUAL_TERMINAL_PROCESSING))
+		ink = kAnsi;
+}
+
+// --- the report ------------------------------------------------------------
+
+struct Module {
+	DWORD64 base = 0;
+	DWORD64 size = 0;
+	std::string path;
+};
+
+struct Frame {
+	int index = 0;
+	DWORD64 address = 0;
+};
+
+struct Report {
+	std::string code = "????????";
+	std::string accessViolation, time, build, handle;
+	std::vector<Module> modules; // the loader lists the main image first
+	std::vector<Frame> frames;
+};
+
+std::string slurp(const char* path) {
+	std::ifstream file(path, std::ios::binary);
+	if (!file)
+		fatal("cannot read {}", path);
+	return { std::istreambuf_iterator<char>(file), std::istreambuf_iterator<char>() };
+}
+
+// Reports are CRLF and ECMAScript treats CR as a line terminator, so neither "."
+// nor "$" ever crosses one -- captures come back without the carriage return.
+std::string capture(const std::string& text, const char* pattern) {
+	std::smatch match;
+	std::regex expression(pattern, std::regex::ECMAScript | std::regex::multiline);
+	return std::regex_search(text, match, expression) ? match[1].str() : std::string();
+}
+
+std::vector<std::smatch> captureAll(const std::string& text, const char* pattern) {
+	std::regex expression(pattern, std::regex::ECMAScript | std::regex::multiline);
+	return { std::sregex_iterator(text.begin(), text.end(), expression),
+	         std::sregex_iterator() };
+}
+
+DWORD64 fromHex(const std::string& digits) {
+	return std::strtoull(digits.c_str(), nullptr, 16);
+}
+
+Report parse(const std::string& text) {
+	Report report;
+	if (auto code = capture(text, R"(code=(\w+))"); !code.empty())
+		report.code = code;
+	report.accessViolation = capture(text, R"(access violation: (.+))");
+	report.time            = capture(text, R"(^\s+time (.+))");
+	report.build           = capture(text, R"(^\s+build (.+))");
+	report.handle          = capture(text, R"(^\s+handle (.+))");
+
+	for (const auto& match : captureAll(text, R"(^ {4}([0-9A-Fa-f]{8}) ([0-9A-Fa-f]{8}) (.+)$)"))
+		report.modules.push_back({ fromHex(match[1]), fromHex(match[2]), match[3] });
+	for (const auto& match : captureAll(text, R"(^\s+\[(\d+)\] ([0-9A-Fa-f]{8}))"))
+		report.frames.push_back({ std::stoi(match[1]), fromHex(match[2]) });
+	return report;
+}
+
+// --- symbols ---------------------------------------------------------------
+
+struct Location {
+	std::string function = "<no symbol>";
+	std::string file;
+	DWORD line = 0;
+};
+
+// DbgHelp writes the name into the tail of the structure, hence the raw buffer.
+struct SymbolBuffer {
+	SYMBOL_INFO* get() {
+		auto* symbol = reinterpret_cast<SYMBOL_INFO*>(storage);
+		symbol->SizeOfStruct = sizeof(SYMBOL_INFO);
+		symbol->MaxNameLen = MAX_SYM_NAME;
+		return symbol;
+	}
+	alignas(SYMBOL_INFO) char storage[sizeof(SYMBOL_INFO) + MAX_SYM_NAME] = {};
+};
+
+// Outermost first: the function that owns the address, then everything the
+// optimizer inlined into it, down to the code the address really belongs to.
+std::vector<Location> resolve(HANDLE process, DWORD64 address) {
+	std::vector<Location> locations;
+
+	SymbolBuffer buffer;
+	DWORD64 offset = 0;
+	DWORD displacement = 0;
+	IMAGEHLP_LINE64 line{ sizeof(IMAGEHLP_LINE64) };
+
+	Location outer;
+	if (SymFromAddr(process, address, &offset, buffer.get()))
+		outer.function = buffer.get()->Name;
+	if (SymGetLineFromAddr64(process, address, &displacement, &line)) {
+		outer.file = line.FileName;
+		outer.line = line.LineNumber;
+	}
+	locations.push_back(std::move(outer));
+
+	// Inline contexts run innermost first, so walk them backwards to keep the
+	// caller-to-callee order the rest of the listing uses.
+	DWORD inlined = SymAddrIncludeInlineTrace(process, address);
+	DWORD context = 0, frameIndex = 0;
+	if (inlined == 0 || !SymQueryInlineTrace(process, address, 0, address, address,
+			&context, &frameIndex))
+		return locations;
+
+	for (DWORD i = inlined; i-- > 0;) {
+		Location location;
+		if (SymFromInlineContext(process, address, context + i, &offset, buffer.get()))
+			location.function = buffer.get()->Name;
+		line = { sizeof(IMAGEHLP_LINE64) };
+		if (SymGetLineFromInlineContext(process, address, context + i, 0,
+				&displacement, &line)) {
+			location.file = line.FileName;
+			location.line = line.LineNumber;
+		}
+		locations.push_back(std::move(location));
+	}
+	return locations;
+}
+
+std::string_view baseName(std::string_view path) {
+	size_t separator = path.find_last_of("\\/");
+	return separator == std::string_view::npos ? path : path.substr(separator + 1);
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+	if (argc < 2) {
+		std::println(stderr, "usage: {} <report.txt> [JA2.exe]", baseName(argv[0]));
+		return 2;
+	}
+	const char* objectPath = argc > 2 ? argv[2] : "JA2.exe";
+	enableColour();
+
+	const Report report = parse(slurp(argv[1]));
+	if (report.frames.empty())
+		fatal("no [n] ADDR frames in {}", argv[1]);
+
+	// Only the main image can be symbolized against this exe's PDB. Sibling
+	// modules are named with an offset, and addresses inside no module at all are
+	// stack debris the frame-pointer walk picked up, so they are dropped.
+	const Module* image = report.modules.empty() ? nullptr : &report.modules.front();
+	const auto owner = [&](DWORD64 address) -> const Module* {
+		auto found = std::ranges::find_if(report.modules, [&](const Module& module) {
+			return module.base <= address && address < module.base + module.size;
+		});
+		return found == report.modules.end() ? nullptr : &*found;
+	};
+
+	HANDLE process = GetCurrentProcess();
+	SymSetOptions(SYMOPT_LOAD_LINES | SYMOPT_UNDNAME | SYMOPT_NO_PROMPTS);
+	// The PDB sits next to the exe, which is not necessarily the current directory.
+	const std::string_view object(objectPath);
+	const std::string_view directory =
+		object.substr(0, object.size() - baseName(object).size());
+	const std::string searchPath(directory.empty() ? "." : directory);
+	if (!SymInitialize(process, searchPath.c_str(), FALSE))
+		fatal("SymInitialize failed ({})", GetLastError());
+
+	// A base of zero tells DbgHelp to use the image's own preferred base, which is
+	// exactly right for a report from before the module table existed.
+	const DWORD64 loadedAt = SymLoadModuleEx(process, nullptr, objectPath, nullptr,
+		image ? image->base : 0, image ? static_cast<DWORD>(image->size) : 0, nullptr, 0);
+	if (loadedAt == 0)
+		fatal("cannot load {} ({})", objectPath, GetLastError());
+
+	IMAGEHLP_MODULE64 moduleInfo{ sizeof(IMAGEHLP_MODULE64) };
+	if (SymGetModuleInfo64(process, loadedAt, &moduleInfo) && moduleInfo.SymType != SymPdb)
+		std::println("  {}no PDB beside {} -- expect export names and no source lines{}",
+			ink.fault, objectPath, ink.off);
+
+	std::println("\n  {}CRASH  {}{}{}{}{}", ink.heading, ink.code, report.code, ink.off,
+		report.accessViolation.empty() ? "" : "   ",
+		report.accessViolation.empty() ? std::string()
+			: std::format("{}({}){}", ink.faded, report.accessViolation, ink.off));
+	for (auto [label, value] : { std::pair{ "time", &report.time },
+			std::pair{ "build", &report.build }, std::pair{ "handle", &report.handle } })
+		if (!value->empty())
+			std::println("  {}{:<6}{} {}", ink.label, label, ink.off, *value);
+	std::println("  {}{:<6}{} {:08X}", ink.label, "base", ink.off, loadedAt);
+	std::println("");
+
+	// Call order: the outermost caller ([n]) first, the fault ([0]) last.
+	auto frames = report.frames;
+	std::ranges::sort(frames, std::ranges::greater{}, &Frame::index);
+
+	int depth = 0;
+	for (const Frame& frame : frames) {
+		const Module* module = owner(frame.address);
+		if (!report.modules.empty() && module == nullptr)
+			continue;
+		const std::string indent(2 * depth++, ' ');
+		const std::string tag = frame.index == 0
+			? std::format("   {}<-- fault{}", ink.fault, ink.off) : "";
+		const std::string address =
+			std::format("{}[{:08X}]{}", ink.address, frame.address, ink.off);
+
+		if (module != nullptr && module != image) {
+			std::println("  {}{}{}+0x{:X}{}{}   {}", indent, ink.function,
+				baseName(module->path), frame.address - module->base, ink.off, tag, address);
+			continue;
+		}
+
+		bool first = true;
+		for (const Location& location : resolve(process, frame.address)) {
+			std::println("  {}{}{}{}{}{}", indent, first ? "" : "  ",
+				first ? ink.function : ink.inlined,
+				first ? location.function : std::format("(inlined) {}", location.function),
+				ink.off, first ? tag : "");
+			if (!location.file.empty())
+				std::println("  {}{}    {}{}:{}{}{}", indent, first ? "" : "  ",
+					ink.location, location.file, location.line, ink.off,
+					first ? std::format("   {}", address) : "");
+			first = false;
+		}
+	}
+	std::println("");
+
+	SymCleanup(process);
+	return 0;
+}


### PR DESCRIPTION
cut out the old exception handling system (that wasn't working) and replace it with something that survives heap corruption that's common when we crash

additionally add a simple thread when the game starts to flush crash_report_xxx.txt files to a Cloudflare worker that forwards it to a discord channel, all gated by a user consent dialog that gets stored as a 1/0 in `telemetry.consent` file

to test, start the game and set `CRASH_TELEMETRY_URL=https://ja2-crash-telemetry.1dot13.workers.dev` and, optionally, `HANDLE=NameYouWantToIdentifyAs` to `[Ja2 Settings]` of your Ja2.ini (which means it also works as CLI arguments, /CRASH_TELEMETRY_URL:xxx and /HANDLE:xxx)

crash reports aren't symbolized since shipping the .pdb's with the build is another 100MB, the reports have the git SHA of the build stamped on them by our CI, so the workflow is to check out that version, build the .pdb and use tools/symbolize_crash (added here) to pretty-print the translated addresses