### PR TITLE
Build adjustments

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,10 @@ if(ADDRESS_SANITIZER)
   add_compile_options($<IF:$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>,-fsanitize=address,>)
 endif()
 
+if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+  add_compile_options(-fno-delete-null-pointer-checks)
+endif()
+
 # whether we are using MSBuild as a generator
 set(usingMsBuild $<STREQUAL:${CMAKE_VS_PLATFORM_NAME},Win32>)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,9 @@ if(ADDRESS_SANITIZER)
   add_compile_options($<IF:$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>,-fsanitize=address,>)
 endif()
 
+# keep frame pointers in both MSVC and clang-cl
+add_compile_options(/Oy-)
+
 if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
   add_compile_options(-fno-delete-null-pointer-checks)
 endif()


### PR DESCRIPTION
keep frame pointers for helpful crash logs and disable clang-cl optimizing nullptr checks since the codebase is practically built around it (MSVC already doesn't)