### PR TITLE
Apply MSVC library paths to shared and module linkers too

### DIFF
--- a/cmake/toolchains/clang-cl.cmake
+++ b/cmake/toolchains/clang-cl.cmake
@@ -74,5 +74,8 @@ foreach(directory ${_includes})
 endforeach()
 set(CMAKE_RC_FLAGS_INIT "${_rc_flags}")
 
-set(CMAKE_EXE_LINKER_FLAGS_INIT
+set(_linker_libpaths
     "/libpath:${_msvc}/lib/x86 /libpath:${_sdk_lib}/ucrt/x86 /libpath:${_sdk_lib}/um/x86")
+set(CMAKE_EXE_LINKER_FLAGS_INIT    "${_linker_libpaths}")
+set(CMAKE_SHARED_LINKER_FLAGS_INIT "${_linker_libpaths}")
+set(CMAKE_MODULE_LINKER_FLAGS_INIT "${_linker_libpaths}")


### PR DESCRIPTION
The /libpath flags for the MSVC, UCRT, and Windows SDK x86 libraries were only injected into CMAKE_EXE_LINKER_FLAGS_INIT, so linking a shared library or module produced unresolved externals. Hoist the paths into a local variable and feed it to the EXE, SHARED, and MODULE init flags.

Never bit because nothing in the tree builds a shared lib yet.