### PR TITLE
Remove crt warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<AND:$<CONFIG:Debug>,$<NOT:${_as
 set(CMAKE_MSVC_DEBUG_INFORMATION_FORMAT
   "$<$<CONFIG:Debug,RelWithDebInfo>:Embedded>")
 
-add_compile_definitions(CINTERFACE XML_STATIC VFS_STATIC VFS_WITH_SLF VFS_WITH_7ZIP _CRT_SECURE_NO_DEPRECATE)
+add_compile_definitions(CINTERFACE XML_STATIC VFS_STATIC VFS_WITH_SLF VFS_WITH_7ZIP)
 include_directories(
   "${CMAKE_SOURCE_DIR}/Ja2"
   "${CMAKE_SOURCE_DIR}/ext/VFS/include"
@@ -94,12 +94,6 @@ include(cmake/Warnings.cmake)
 # the build files, and cannot be varied per configuration. Nothing below should
 # ever be reintroduced as a bare #define.
 add_compile_definitions(
-  # 0verhaul: squelch the VC2K5+ warnings about printf and string operations
-  # being unsafe, so real errors stay visible.
-  _CRT_SECURE_NO_WARNINGS
-  _CRT_NON_CONFORMING_SWPRINTFS
-  _SCL_SECURE_NO_WARNINGS
-
   # Laptop briefing room (Jazz). Also needs BRIEFING_ROOM in ja2_options.ini and
   # a briefing-room mod, otherwise the room comes up blank.
   ENABLE_BRIEFINGROOM


### PR DESCRIPTION
_CRT_SECURE_NO_DEPRECATE, _CRT_SECURE_NO_WARNINGS, _SCL_SECURE_NO_WARNINGS and _CRT_NON_CONFORMING_SWPRINTFS all do one thing: hide the deprecation attributes the CRT headers put on strcpy, sprintf, swprintf and friends. That warning is C4996 for cl and -Wdeprecated-declarations for clang-cl, and cmake/Warnings.cmake already suppresses both by name, per compiler, with a count next to it. Two mechanisms for one warning, one of them invisible to anyone reading the warning list.

_CRT_NON_CONFORMING_SWPRINTFS is the only one that could have done more, and it does not: its macro redirect to the argument-count-free swprintf is guarded by !defined __cplusplus (corecrt_wstdio.h), so in C++ the traditional overloads are declared either way and only the deprecation text changes.

No codegen change. Recompiling sgp/video.cpp with and without the four defines gives objects that differ in .debug$T alone, by the 128 bytes of the recorded compiler command line; every other section is byte-identical. All four applications build clean under clang-cl /W3 /WX.

The counts in cmake/Warnings.cmake for /wd4996 and -Wno-deprecated-declarations were harvested with these defines in place, so both now understate the real number. They are stale figures, not wrong suppressions.