### PR TITLE
Delete the code behind three macros nobody defines

### DIFF
--- a/Ja2/Ja25Update.cpp
+++ b/Ja2/Ja25Update.cpp
@@ -1,8 +1,4 @@
 #include <types.h>
-#ifdef NETWORKED
-#include "Networking.h"
-#include "NetworkEvent.h"
-#endif
 
 #ifdef JA2UB
 

--- a/Ja2/gamescreen.cpp
+++ b/Ja2/gamescreen.cpp
@@ -34,9 +34,6 @@
 #include "Game Init.h"
 
 //DEF: Test Code
-#ifdef NETWORKED
-#include "Networking.h"
-#endif
 #include "Interface Control.h"
 #include "physics.h"
 #include "Fade Screen.h"
@@ -824,10 +821,6 @@ UINT32	MainGameScreenHandle(void)
 		//RenderTacticalInterface( );
 	}
 
-	#ifdef NETWORKED
-	// DEF:	Test Code
-	PrintNetworkInfo();
-	#endif
 
 	// Render Interface
 	RenderTopmostTacticalInterface( );

--- a/Ja2/jascreens.cpp
+++ b/Ja2/jascreens.cpp
@@ -37,15 +37,6 @@
 #include <language.hpp>
 
 // Networking Stuff
-#ifdef NETWORKED
-
-#include "Communication.h"
-#include "Application Msg.h"
-#include "Networking.h"
-
-extern ClientReadyType				gMsgClientReady;
-extern BOOLEAN			gfAmINetworked;
-#endif
 
 #define MAX_DEBUG_PAGES 4
 

--- a/Tactical/Interface Dialogue.cpp
+++ b/Tactical/Interface Dialogue.cpp
@@ -5715,11 +5715,7 @@ void DisplayJerryBreakingLaptopTransmitterPopup()
 		swprintf( zString, zNewTacticalMessages[ TCTL_MSG__JERRY_BREAKIN_LAPTOP_ANTENA ], Menptr[ bID ].name );
 	}
 */
-	#ifdef UBMODSHADYJOB
-		swprintf( zString, XMLTacticalMessages[0] ); //Shady Job
-	#else
-		swprintf( zString, zNewTacticalMessages[TCTL_MSG__JERRY_BREAKIN_LAPTOP_ANTENA], Menptr[ bID ].name ); //UB
-	#endif
+	swprintf( zString, zNewTacticalMessages[TCTL_MSG__JERRY_BREAKIN_LAPTOP_ANTENA], Menptr[ bID ].name ); //UB
 	
 
 	//Display it

--- a/Tactical/Overhead.cpp
+++ b/Tactical/Overhead.cpp
@@ -43,10 +43,6 @@
 #include "fov.h"
 #include "Soldier macros.h"
 #include "soldier tile.h"
-#ifdef  NETWORKED
-#include "Networking.h"
-#include "NetworkEvent.h"
-#endif
 #include "Structure Wrap.h"
 #include "Tile Animation.h"
 #include "Strategic Merc Handler.h"
@@ -217,10 +213,6 @@ extern BOOLEAN gfSurrendered;
 
 CHAR8 gDebugStr[128];
 
-#ifdef NETWORKED
-extern  BYTE                    gfAmIHost;
-extern BOOLEAN                  gfAmINetworked;
-#endif
 
 #define NEW_FADE_DELAY                  60
 
@@ -625,10 +617,6 @@ BOOLEAN InitTacticalEngine( )
     if ( !InitOverhead( ) )             // Init Overhead
         return( FALSE );
 
-#ifdef NETWORKED
-    if ( !gfAmINetworked )
-        gfAmIHost = TRUE;
-#endif
     return( TRUE );
 }
 
@@ -1182,17 +1170,8 @@ BOOLEAN ExecuteOverhead( )
 
             // Handle animation update counters
             // ATE: Added additional check here for special value of anispeed that pauses all updates
-#ifndef BOUNDS_CHECKER
             if ( TIMECOUNTERDONE( pSoldier->timeCounters.UpdateCounter, pSoldier->sAniDelay ) && pSoldier->sAniDelay != 10000 )
-#endif
             {
-#ifdef NETWORKED
-                // DEF:
-                // Check for TIMING delay here only if in Realtime
-                if( gTacticalStatus.uiFlags & REALTIME)
-                    if ( pSoldier->flags.fIsSoldierMoving )
-                        CheckForSlowSoldier( pSoldier );
-#endif
 
                 // Check if we need to look for items
                 if ( pSoldier->flags.uiStatusFlags & SOLDIER_LOOKFOR_ITEMS )
@@ -1213,11 +1192,6 @@ BOOLEAN ExecuteOverhead( )
 
                 fNoAPsForPendingAction = FALSE;
 
-#ifdef NETWORKED
-                // Get the path update, if there is 1
-                if (pSoldier->flags.fSoldierUpdatedFromNetwork)
-                    UpdateSoldierFromNetwork(pSoldier);
-#endif
 
                 // Check if we are moving and we deduct points and we have no points
                 if ( !( ( gAnimControl[ pSoldier->usAnimState ].uiFlags & ( ANIM_MOVING | ANIM_SPECIALMOVE ) ) && pSoldier->flags.fNoAPToFinishMove ) && !pSoldier->flags.fPauseAllAnimation    )
@@ -1326,10 +1300,6 @@ BOOLEAN ExecuteOverhead( )
                                 dXPos = pSoldier->pathing.sDestXPos;
                                 dYPos = pSoldier->pathing.sDestYPos;
                                 pSoldier->EVENT_SetSoldierPosition( dXPos, dYPos );
-#ifdef NETWORKED
-                                // DEF: Test Code
-                                StopSoldierMovementTime(pSoldier);
-#endif
                                 // CHECK IF WE HAVE A PENDING ANIMATION
                                 if ( pSoldier->usPendingAnimation != NO_PENDING_ANIMATION )
                                 {
@@ -1835,12 +1805,6 @@ BOOLEAN ExecuteOverhead( )
                     }
                 }
 
-#ifdef NETWORKED
-                if(!pSoldier->flags.fNoAPToFinishMove )
-                    pSoldier->usLastUpdateTime = GetJA2Clock();
-                if (pSoldier->flags.fSoldierUpdatedFromNetwork)
-                    UpdateSoldierFromNetwork(pSoldier);
-#endif
                 //haydens network soldier update ->>
                 if(is_client)
                     UpdateSoldierToNetwork ( pSoldier );

--- a/Tactical/Points.cpp
+++ b/Tactical/Points.cpp
@@ -759,12 +759,6 @@ BOOLEAN EnoughPoints( SOLDIERTYPE *pSoldier, INT16 sAPCost, INT32 iBPCost, BOOLE
 		sAPCost = 0;
 	}
 
-	#ifdef NETWORKED
-	if( !IsTheSolderUnderMyControl( pSoldier->ubID)	)
-	{
-		return( TRUE );
-	}
-	#endif
 
 	if (is_networked)
 	{

--- a/Tactical/Soldier Control.cpp
+++ b/Tactical/Soldier Control.cpp
@@ -35,10 +35,6 @@
 #include "Soldier macros.h"
 #include "english.h"
 #include "Squads.h"
-#ifdef NETWORKED
-#include "Networking.h"
-#include "NetworkEvent.h"
-#endif
 #include "Structure Wrap.h"
 #include "Items.h"
 #include "soundman.h"

--- a/Tactical/Soldier Tile.cpp
+++ b/Tactical/Soldier Tile.cpp
@@ -14,10 +14,6 @@
 	#include "opplist.h"
 	#include "ai.h"
 		
-	#ifdef NETWORKED
-	#include "Networking.h"
-	#include "NetworkEvent.h"
-	#endif
 
 	#include "Items.h"
 	#include "soldier tile.h"

--- a/Tactical/TeamTurns.cpp
+++ b/Tactical/TeamTurns.cpp
@@ -624,11 +624,6 @@ void BeginTeamTurn( UINT8 ubTeam )
 		}
 		else
 		{
-#ifdef NETWORKED
-			// Only the host should do this
-			if(!gfAmIHost)
-				break;
-#endif
 				if( is_client && !is_server ) //hayden //disable independant client AI
 					break;
 

--- a/Tactical/Turn Based Input.cpp
+++ b/Tactical/Turn Based Input.cpp
@@ -26,10 +26,6 @@
 #include "worldman.h"
 #include "Handle UI Plan.h"
 #include "message.h"
-#ifdef NETWORKED
-#include "Networking.h"
-#include "Communication.h"
-#endif
 #include "overhead map.h"
 #include "World Items.h"
 #include "Game Clock.h"
@@ -2337,26 +2333,6 @@ void GetKeyboardInput( UINT32 *puiNewEvent )
 #endif
 
 
-#ifdef NETWORKED
-		// DEF: Test Networking
-		if ((InputEvent.usEvent == KEY_DOWN )&& ( InputEvent.usParam == '0') && ( InputEvent.usKeyState & ALT_DOWN ))
-		{
-			DisplayMultiPlayerInfo();
-		}
-		if ((InputEvent.usEvent == KEY_DOWN )&& ( InputEvent.usParam == '9') && ( InputEvent.usKeyState & ALT_DOWN ))
-		{
-			DisplayDirectPlayInfo();
-		}
-		if ((InputEvent.usEvent == KEY_DOWN )&& ( InputEvent.usParam == '8') && ( InputEvent.usKeyState & ALT_DOWN ))
-		{
-			DisplayDirectPlayPlayerInfo();
-		}
-
-		if ((InputEvent.usEvent == KEY_DOWN )&& ( InputEvent.usParam == '7') && ( InputEvent.usKeyState & ALT_DOWN ))
-		{
-			SetDisplayFlag();
-		}
-#endif
 
 		if( InputEvent.usEvent == KEY_DOWN )
 		{

--- a/TacticalAI/AIMain.cpp
+++ b/TacticalAI/AIMain.cpp
@@ -1012,10 +1012,6 @@ void StartNPCAI(SOLDIERTYPE *pSoldier)
 	BOOLEAN fInValidSoldier = FALSE;
 
 	// Only the host should do this
-#ifdef NETWORKED
-	if(!gfAmIHost)
-		return;
-#endif
 	////pSoldier->flags.uiStatusFlags |= SOLDIER_UNDERAICONTROL;
 	//if (!(pSoldier->flags.uiStatusFlags & SOLDIER_PC))
 

--- a/Utils/Event Pump.cpp
+++ b/Utils/Event Pump.cpp
@@ -13,10 +13,6 @@
 #include <vector>
 #include <queue>
 
-#ifdef NETWORKED
-#include "Networking.h"
-#include "NetworkEvent.h"
-#endif
 #include "MemMan.h"
 #include "Timer Control.h"
 #include "DEBUG.H"
@@ -907,19 +903,11 @@ BOOLEAN AddGameEvent(UINT32 uiEvent, UINT16 usDelay, PTR pEventData)
 	if (usDelay == DEMAND_EVENT_DELAY)
 	{
 		//DebugMsg( TOPIC_JA2, DBG_LEVEL_3, String("AddGameEvent: Sending Local and network #%d", uiEvent));
-#ifdef NETWORKED
-		if (gfAmINetworked)
-			SendEventToNetwork(uiEvent, usDelay, pEventData);
-#endif
 		return(AddGameEventToQueue(uiEvent, 0, pEventData, DEMAND_EVENT_QUEUE));
 	}
 	else if (uiEvent < EVENTS_LOCAL_AND_NETWORK)
 	{
 		//DebugMsg( TOPIC_JA2, DBG_LEVEL_3, String("AddGameEvent: Sending Local and network #%d", uiEvent));
-#ifdef NETWORKED
-		if (gfAmINetworked)
-			SendEventToNetwork(uiEvent, usDelay, pEventData);
-#endif
 		return(AddGameEventToQueue(uiEvent, usDelay, pEventData, PRIMARY_EVENT_QUEUE));
 	}
 	else if (uiEvent < EVENTS_ONLY_USED_LOCALLY)
@@ -930,10 +918,6 @@ BOOLEAN AddGameEvent(UINT32 uiEvent, UINT16 usDelay, PTR pEventData)
 	else if (uiEvent < EVENTS_ONLY_SENT_OVER_NETWORK)
 	{
 		//DebugMsg( TOPIC_JA2, DBG_LEVEL_3, String("AddGameEvent: Sending network #%d", uiEvent));
-#ifdef NETWORKED
-		if (gfAmINetworked)
-			SendEventToNetwork(uiEvent, usDelay, pEventData);
-#endif
 		return(TRUE);
 	}
 	// There is an error with the event

--- a/Utils/Timer Control.cpp
+++ b/Utils/Timer Control.cpp
@@ -235,7 +235,6 @@ void CALLBACK TimeProc( UINT uID,	UINT uMsg, DWORD dwUser, DWORD dw1,	DWORD dw2	
 					timerDone |= UpdateTimeCounter( giTimerCustomizable, iTimeLeft );
 				}
 
-#ifndef BOUNDS_CHECKER
 
 				// If mapscreen...
 				if( guiTacticalInterfaceFlags & INTERFACE_MAPSCREEN )
@@ -274,7 +273,6 @@ void CALLBACK TimeProc( UINT uID,	UINT uMsg, DWORD dwUser, DWORD dw1,	DWORD dw2	
 						}
 					}
 				}
-#endif
 			}
 		}
 

--- a/sgp/mousesystem.cpp
+++ b/sgp/mousesystem.cpp
@@ -114,9 +114,7 @@ BOOLEAN					gfRefreshUpdate = FALSE;
 //that already exists.
 //TO REMOVE ALL DEBUG FUNCTIONALITY:	simply comment out MOUSESYSTEM_DEBUGGING definition
 	#ifdef _DEBUG
-	#ifndef BOUNDS_CHECKER
 	#define MOUSESYSTEM_DEBUGGING
-	#endif
 	#endif
 
 #ifdef MOUSESYSTEM_DEBUGGING


### PR DESCRIPTION
NETWORKED, BOUNDS_CHECKER and UBMODSHADYJOB are not defined in any source file, in CMakeLists.txt, or on any command line, so all 26 guarded sites were dead. NETWORKED is the most thoroughly dead of the three: its blocks include Networking.h, NetworkEvent.h, Communication.h and Application Msg.h, none of which exist in this repository, so that code could not have compiled since long before the CMake build. Multiplayer went through Multiplayer/ and RakNet instead. UBMODSHADYJOB was referenced by a stale comment pointing at builddefines.h, which is how it turned up.

Removed with unifdef, so the surviving branch of each conditional is kept: the #ifndef BOUNDS_CHECKER bodies stay, and so does the #else of UBMODSHADYJOB.

The compiler never saw any of this, so nothing shrinks: no object file's section sizes change, and the only difference in the executables is 24 to 64 assert line numbers shifting by the number of lines removed above them.